### PR TITLE
Clarify Docker steps for non-technical users

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,7 +39,7 @@ For a more detailed guide on how to get started with OLDP have a look at:
 ### Docker
 
 To skip the whole installation procedure you can simply run OLDP as Docker container.
-Just `git clone` the repository first and then start everything with a `docker compose up` from within the repository directory.
+Just `git clone` the repository first and then start everything with a `docker compose up` from within the repository directory.After running `docker compose up`, navigate to http://localhost:8000 to view the site.
 A small tutorial on how to use OLDP with Docker can be found [here](https://oldp.readthedocs.io/en/latest/docker.html).
 
 ### Dependencies


### PR DESCRIPTION
I updated the Docker section in the README.md to clarify that users should visit http://localhost:8000 after running docker-compose up. This should help new contributors understand how to access the running project.

Let me know if there’s anything else I can improve. Happy to help with other beginner-related clarifications too!