### PR TITLE
Switch from recommonmark to myst-parser to improve Markdown rendering in the documentation

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -15,7 +15,7 @@
 # import os
 # import sys
 # sys.path.insert(0, os.path.abspath('.'))
-from recommonmark.parser import CommonMarkParser
+# from recommonmark.parser import CommonMarkParser
 
 # -- Project information -----------------------------------------------------
 
@@ -38,7 +38,7 @@ release = "0.1"
 # Add any Sphinx extension module names here, as strings. They can be
 # extensions coming with Sphinx (named 'sphinx.ext.*') or your custom
 # ones.
-extensions = []
+extensions = ['myst_parser']
 
 # Add any paths that contain templates here, relative to this directory.
 templates_path = ["_templates"]
@@ -47,10 +47,6 @@ templates_path = ["_templates"]
 # You can specify multiple suffix as a list of string:
 #
 # source_suffix = ['.rst', '.md']
-
-source_parsers = {
-    ".md": CommonMarkParser,
-}
 
 source_suffix = [".rst", ".md"]
 

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -83,3 +83,19 @@ An admin account can be created using:
 ```
 ./manage.py createsuperuser
 ```
+
+## Build documentation
+
+To build the documentation locally, install the docs dependencies and generate the HTML:
+
+```
+# Install documentation dependencies
+pip install -e ".[docs]"
+
+# Build the documentation
+cd docs
+make html
+
+# Open in browser
+open _build/html/index.html
+```

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -106,6 +106,11 @@ search = [
   "elasticsearch==7.17.12",
   "elasticsearch-dsl==7.4.1",
 ]
+docs = [
+  "sphinx>=8.0.0",
+  "sphinx-rtd-theme>=3.0.0",
+  "myst-parser>=4.0.0",
+]
 all = [
   "oldp[dev,theme-de,prod,processing,mysql,search]"
 ]


### PR DESCRIPTION
When I read through the project, I noticed a minor issue in the documentation. 
Code blocks, lists, and inline code were not rendering correctly in the generated docs HTML and the documentation was using `recommonmark`, which is deprecated. I replaced `recommonmark` with `myst-parser` in the Sphinx configuration.
I also added the dependencies sphinx, sphinx-rtd-theme, myst-parser.