### PR TITLE
fix: drop orphaned cases_case_nlp_entities table before migration

### DIFF
--- a/oldp/apps/cases/migrations/0023_alter_case_following_cases_alter_case_id_and_more.py
+++ b/oldp/apps/cases/migrations/0023_alter_case_following_cases_alter_case_id_and_more.py
@@ -9,6 +9,10 @@ class Migration(migrations.Migration):
     ]
 
     operations = [
+        migrations.RunSQL(
+            sql="DROP TABLE IF EXISTS cases_case_nlp_entities;",
+            reverse_sql=migrations.RunSQL.noop,
+        ),
         migrations.AlterField(
             model_name="case",
             name="following_cases",


### PR DESCRIPTION
## Summary

- Drops the orphaned `cases_case_nlp_entities` table (left behind when the `nlp` app was removed in 2019) at the start of migration `cases.0023`
- Fixes MySQL error caused by a stale foreign key constraint blocking the `AutoField` → `BigAutoField` change on `cases_case.id`
- Uses `DROP TABLE IF EXISTS` for idempotency (safe on fresh databases that never had the table)

## Test plan

- [ ] Run `make migrate` — should complete without errors
- [ ] Confirm `cases_case_nlp_entities` table no longer exists in the database

🤖 Generated with [Claude Code](https://claude.com/claude-code)