### PR TITLE
fix: remove dead static tag that breaks manifest storage

### DIFF
--- a/oldp/assets/templates/layout.html
+++ b/oldp/assets/templates/layout.html
@@ -61,10 +61,7 @@
 
     {# Javascript: inside of bundling we load all depdencies from CDN #}
 
-    <!-- <script src="{% static 'dist/main.js' %}"></script> -->
-    <!-- <script src="https://cdn.jsdelivr.net/npm/jquery@3.5.1/dist/jquery.slim.min.js" integrity="sha384-DfXdz2htPH0lsSSs5nCTpuj/zy4C+OGpamoFVy38MVBnE+IbbVYUew+OrCXaRkfj" crossorigin="anonymous"></script>
-    <script src="https://cdn.jsdelivr.net/npm/popper.js@1.16.1/dist/umd/popper.min.js" integrity="sha384-9/reFTGAW83EW2RDu2S0VKaIzap3H66lZH81PoYlFhbGU+6BZp6G7niu735Sk7lN" crossorigin="anonymous"></script>
-    <script src="https://cdn.jsdelivr.net/npm/bootstrap@4.6.2/dist/js/bootstrap.min.js" integrity="sha384-+sLIOodYLS7CIrQpBjl+C7nPvqq+FbNUBDunl/OZv93DB7Ln/533i8e/mZXLi/P+" crossorigin="anonymous"></script> -->
+    {# CDN dependencies and bundled main.js removed — loaded via js/main.js below #}
     <script src="{% static 'js/main.js' %}"></script>
 
     {% block footer_js %}


### PR DESCRIPTION
## Summary
- Remove HTML-commented `{% static 'dist/main.js' %}` tag from `layout.html` that causes `ValueError: Missing staticfiles manifest entry for 'dist/main.js'` on the stage deployment
- HTML comments (`<!-- -->`) don't prevent Django template tags from being evaluated — after PR #150 switched to `CompressedManifestStaticFilesStorage`, every `{% static %}` lookup is validated against the manifest, causing this crash
- Replaced with a Django template comment (`{# #}`) so the tag is never processed

## Test plan
- [ ] Stage deployment starts without `ValueError`
- [ ] Static assets (js/main.js, CSS) load correctly
- [ ] `make test` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)