### PR TITLE
fix(laws,cases): hide pending/rejected from non-admin views; dedupe § title

### DIFF
--- a/README.md
+++ b/README.md
@@ -118,6 +118,7 @@ You can as well override specific settings from `src/oldp/settings.py` with envi
 | `DJANGO_DEBUG` | `True` | Enable to show debugging messages and errors |
 | `DJANGO_ADMINS` | `Admin,admin@openlegaldata.io` | Format: `Foo,foo@site.com;Bar,bar@site.com` |
 | `DJANGO_ALLOWED_HOSTS` | `None` | Format: `foo.com,bar.net` |
+| `DJANGO_TOP_LAW_BOOKS` | (empty) | Comma-separated `LawBook` slugs surfaced as "top books" on `/law/`, in the order listed. Empty hides the top block. Example: `gg,bgb,stgb,hgb,estg` |
 | `DJANGO_LANGUAGES_DOMAINS` | | Format: `{'de.foo.com':'de','fr.foo.com':'fr'}` |
 | `DJANGO_DEFAULT_FROM_EMAIL` | `no-reply@openlegaldata.io` | Emails are sent from this address |
 | `DJANGO_EMAIL_HOST` | `localhost` | SMTP server |

--- a/oldp/api/mixins.py
+++ b/oldp/api/mixins.py
@@ -6,31 +6,43 @@ Provides review_status-based filtering and field visibility control.
 from django.db.models import Q
 
 
+def filter_by_review_status(qs, request):
+    """Restrict ``qs`` by ``review_status`` according to the request's user.
+
+    - Staff: full queryset
+    - Authenticated non-staff: accepted items plus items they created
+      (matched via ``created_by_token__user``)
+    - Anonymous, no request, or request without a user: accepted only
+
+    Used by :class:`ReviewStatusFilterMixin` for DRF viewsets and by the
+    ``Case.get_queryset`` / ``Law.get_queryset`` / ``LawBook.get_queryset``
+    static methods so all entry points share one rule.
+    """
+    if request is None or not hasattr(request, "user"):
+        return qs.filter(review_status="accepted")
+
+    user = request.user
+
+    if user.is_authenticated and user.is_staff:
+        return qs
+
+    if user.is_authenticated:
+        return qs.filter(Q(review_status="accepted") | Q(created_by_token__user=user))
+
+    return qs.filter(review_status="accepted")
+
+
 class ReviewStatusFilterMixin:
     """Filters queryset by review_status based on the authenticated user.
 
-    - Staff: see all items
-    - Authenticated non-staff: see accepted + items created by their token
-    - Unauthenticated: see only accepted items
+    Thin wrapper around :func:`filter_by_review_status` so DRF viewsets can
+    drop it into their MRO without duplicating the rule.
     """
 
     def get_queryset(self):
         qs = super().get_queryset()
-
-        if not hasattr(self, "request") or self.request is None:
-            return qs.filter(review_status="accepted")
-
-        user = self.request.user
-
-        if user.is_authenticated and user.is_staff:
-            return qs
-
-        if user.is_authenticated:
-            return qs.filter(
-                Q(review_status="accepted") | Q(created_by_token__user=user)
-            )
-
-        return qs.filter(review_status="accepted")
+        request = getattr(self, "request", None)
+        return filter_by_review_status(qs, request)
 
 
 class ReviewStatusFieldMixin:

--- a/oldp/api/tests/test_mixins.py
+++ b/oldp/api/tests/test_mixins.py
@@ -1,0 +1,118 @@
+"""Unit tests for filter_by_review_status — the shared visibility rule."""
+
+from datetime import date
+
+from django.contrib.auth import get_user_model
+from django.test import RequestFactory, TestCase, override_settings
+
+from oldp.api.mixins import filter_by_review_status
+from oldp.apps.accounts.models import (
+    APIToken,
+    APITokenPermission,
+    APITokenPermissionGroup,
+)
+from oldp.apps.cases.models import Case
+from oldp.apps.courts.models import Court
+
+User = get_user_model()
+
+
+@override_settings(
+    CACHES={"default": {"BACKEND": "django.core.cache.backends.dummy.DummyCache"}}
+)
+class FilterByReviewStatusTestCase(TestCase):
+    """Direct tests for the helper function.
+
+    Uses Case as the concrete model since it has both review_status and
+    created_by_token (the helper relies on both fields).
+    """
+
+    fixtures = [
+        "locations/countries.json",
+        "locations/states.json",
+        "locations/cities.json",
+        "courts/courts.json",
+    ]
+
+    @classmethod
+    def setUpTestData(cls):
+        cls.factory = RequestFactory()
+        cls.staff = User.objects.create_user(
+            username="staff", password="x", is_staff=True
+        )
+        cls.user_a = User.objects.create_user(username="alice", password="x")
+        cls.user_b = User.objects.create_user(username="bob", password="x")
+
+        read_perm, _ = APITokenPermission.objects.get_or_create(
+            resource="cases", action="read"
+        )
+        group = APITokenPermissionGroup.objects.create(name="cases_read")
+        group.permissions.add(read_perm)
+        cls.token_a = APIToken.objects.create(
+            user=cls.user_a, name="A", permission_group=group
+        )
+
+        court = Court.objects.exclude(pk=Court.DEFAULT_ID).first()
+
+        cls.accepted = Case.objects.create(
+            court=court,
+            file_number="ACC",
+            date=date(2026, 1, 1),
+            content="<p>a</p>",
+            review_status="accepted",
+        )
+        cls.pending_a = Case.objects.create(
+            court=court,
+            file_number="PEND-A",
+            date=date(2026, 1, 2),
+            content="<p>b</p>",
+            review_status="pending",
+            created_by_token=cls.token_a,
+        )
+        cls.rejected = Case.objects.create(
+            court=court,
+            file_number="REJ",
+            date=date(2026, 1, 3),
+            content="<p>c</p>",
+            review_status="rejected",
+        )
+
+    def _request(self, user):
+        req = self.factory.get("/")
+        if user is None:
+            from django.contrib.auth.models import AnonymousUser
+
+            req.user = AnonymousUser()
+        else:
+            req.user = user
+        return req
+
+    def _slugs(self, qs):
+        return set(qs.values_list("file_number", flat=True))
+
+    def test_no_request_returns_accepted_only(self):
+        qs = filter_by_review_status(Case.objects.all(), None)
+        self.assertEqual(self._slugs(qs), {"ACC"})
+
+    def test_request_without_user_returns_accepted_only(self):
+        req = self.factory.get("/")  # no user attribute
+        if hasattr(req, "user"):
+            del req.user  # simulate missing user
+        qs = filter_by_review_status(Case.objects.all(), req)
+        self.assertEqual(self._slugs(qs), {"ACC"})
+
+    def test_anonymous_returns_accepted_only(self):
+        qs = filter_by_review_status(Case.objects.all(), self._request(None))
+        self.assertEqual(self._slugs(qs), {"ACC"})
+
+    def test_staff_returns_all(self):
+        qs = filter_by_review_status(Case.objects.all(), self._request(self.staff))
+        self.assertEqual(self._slugs(qs), {"ACC", "PEND-A", "REJ"})
+
+    def test_owner_sees_accepted_plus_own(self):
+        qs = filter_by_review_status(Case.objects.all(), self._request(self.user_a))
+        self.assertEqual(self._slugs(qs), {"ACC", "PEND-A"})
+
+    def test_other_user_sees_only_accepted(self):
+        qs = filter_by_review_status(Case.objects.all(), self._request(self.user_b))
+        self.assertEqual(self._slugs(qs), {"ACC"})

--- a/oldp/apps/cases/models.py
+++ b/oldp/apps/cases/models.py
@@ -397,13 +397,9 @@ class Case(
 
     @staticmethod
     def get_queryset(request=None):
-        # TODO superuser?
-        if settings.DEBUG:
-            return Case.objects.all()
-        else:
-            # production
-            # hide non-accepted content
-            return Case.objects.filter(review_status="accepted")
+        from oldp.api.mixins import filter_by_review_status
+
+        return filter_by_review_status(Case.objects.all(), request)
 
 
 class RelatedCase(RelatedContent):

--- a/oldp/apps/cases/tests/test_view_review_status.py
+++ b/oldp/apps/cases/tests/test_view_review_status.py
@@ -1,0 +1,166 @@
+"""HTML view visibility checks: Case.get_queryset() and the cases views.
+
+Complements oldp/api/tests/test_mixins.py (helper-level) and
+test_api_review_status.py (DRF level) — focused on the model static + the
+list/detail Django views.
+"""
+
+from datetime import date
+
+from django.contrib.auth import get_user_model
+from django.test import RequestFactory, TestCase, override_settings
+from django.urls import reverse
+
+from oldp.apps.accounts.models import (
+    APIToken,
+    APITokenPermission,
+    APITokenPermissionGroup,
+)
+from oldp.apps.cases.models import Case
+from oldp.apps.courts.models import Court
+
+User = get_user_model()
+
+
+@override_settings(
+    CACHES={"default": {"BACKEND": "django.core.cache.backends.dummy.DummyCache"}}
+)
+class CaseGetQuerysetTestCase(TestCase):
+    """Direct tests for Case.get_queryset(request) — uses the shared helper."""
+
+    fixtures = [
+        "locations/countries.json",
+        "locations/states.json",
+        "locations/cities.json",
+        "courts/courts.json",
+    ]
+
+    @classmethod
+    def setUpTestData(cls):
+        cls.factory = RequestFactory()
+        cls.staff = User.objects.create_user(
+            username="staff", password="x", is_staff=True
+        )
+        cls.regular = User.objects.create_user(username="reg", password="x")
+
+        read_perm, _ = APITokenPermission.objects.get_or_create(
+            resource="cases", action="read"
+        )
+        group = APITokenPermissionGroup.objects.create(name="cases_read")
+        group.permissions.add(read_perm)
+        cls.token_reg = APIToken.objects.create(
+            user=cls.regular, name="reg-token", permission_group=group
+        )
+
+        court = Court.objects.exclude(pk=Court.DEFAULT_ID).first()
+        cls.accepted = Case.objects.create(
+            court=court,
+            file_number="ACC",
+            date=date(2026, 1, 1),
+            content="<p>a</p>",
+            review_status="accepted",
+        )
+        cls.pending_own = Case.objects.create(
+            court=court,
+            file_number="PEND-OWN",
+            date=date(2026, 1, 2),
+            content="<p>b</p>",
+            review_status="pending",
+            created_by_token=cls.token_reg,
+        )
+        cls.pending_other = Case.objects.create(
+            court=court,
+            file_number="PEND-OTHER",
+            date=date(2026, 1, 3),
+            content="<p>c</p>",
+            review_status="pending",
+        )
+
+    def _request(self, user):
+        req = self.factory.get("/")
+        if user is None:
+            from django.contrib.auth.models import AnonymousUser
+
+            req.user = AnonymousUser()
+        else:
+            req.user = user
+        return req
+
+    def _fns(self, qs):
+        return set(qs.values_list("file_number", flat=True))
+
+    def test_no_request_returns_accepted_only(self):
+        self.assertEqual(self._fns(Case.get_queryset()), {"ACC"})
+
+    def test_anon_returns_accepted_only(self):
+        self.assertEqual(self._fns(Case.get_queryset(self._request(None))), {"ACC"})
+
+    def test_staff_returns_all(self):
+        self.assertEqual(
+            self._fns(Case.get_queryset(self._request(self.staff))),
+            {"ACC", "PEND-OWN", "PEND-OTHER"},
+        )
+
+    def test_owner_sees_accepted_plus_own(self):
+        self.assertEqual(
+            self._fns(Case.get_queryset(self._request(self.regular))),
+            {"ACC", "PEND-OWN"},
+        )
+
+
+@override_settings(
+    CACHES={"default": {"BACKEND": "django.core.cache.backends.dummy.DummyCache"}}
+)
+class CaseViewVisibilityTestCase(TestCase):
+    """List + detail HTML views must respect Case.get_queryset()."""
+
+    fixtures = [
+        "locations/countries.json",
+        "locations/states.json",
+        "locations/cities.json",
+        "courts/courts.json",
+    ]
+
+    @classmethod
+    def setUpTestData(cls):
+        cls.staff = User.objects.create_user(
+            username="staff", password="pass", is_staff=True
+        )
+
+        court = Court.objects.exclude(pk=Court.DEFAULT_ID).first()
+        cls.accepted = Case.objects.create(
+            court=court,
+            file_number="ACC-12345",
+            slug="acc-12345",
+            date=date(2026, 1, 1),
+            content="<p>accepted body</p>",
+            review_status="accepted",
+        )
+        cls.pending = Case.objects.create(
+            court=court,
+            file_number="PEND-99999",
+            slug="pend-99999",
+            date=date(2026, 1, 2),
+            content="<p>pending body</p>",
+            review_status="pending",
+        )
+
+    def test_list_anon_hides_pending(self):
+        res = self.client.get(reverse("cases:index"))
+        self.assertContains(res, "ACC-12345")
+        self.assertNotContains(res, "PEND-99999")
+
+    def test_list_staff_shows_pending(self):
+        self.client.force_login(self.staff)
+        res = self.client.get(reverse("cases:index"))
+        self.assertContains(res, "ACC-12345")
+        self.assertContains(res, "PEND-99999")
+
+    def test_detail_anon_404s_on_pending(self):
+        res = self.client.get(reverse("cases:case", args=("pend-99999",)))
+        self.assertEqual(res.status_code, 404)
+
+    def test_detail_staff_renders_pending(self):
+        self.client.force_login(self.staff)
+        res = self.client.get(reverse("cases:case", args=("pend-99999",)))
+        self.assertEqual(res.status_code, 200)

--- a/oldp/apps/cases/tests/test_views.py
+++ b/oldp/apps/cases/tests/test_views.py
@@ -67,15 +67,24 @@ class CasesViewsTestCase(ExtendedLiveServerTestCase):
 
     def test_private_detail(self):
         private_item = Case.objects.get(pk=2)
-        res = self.client.get(private_item.get_absolute_url())
 
+        # Anonymous + non-staff users get 404 for non-accepted content.
+        res = self.client.get(private_item.get_absolute_url())
         self.assertEqual(404, res.status_code, "Private content should not be found")
 
-        res = self.staff_client.get(private_item.get_absolute_url())
+        res = self.user_client.get(private_item.get_absolute_url())
         self.assertEqual(
             404,
             res.status_code,
-            "Private content should return not found also for staff users",
+            "Private content should not be found by regular users either",
+        )
+
+        # Staff/admins must be able to review pending and rejected content.
+        res = self.staff_client.get(private_item.get_absolute_url())
+        self.assertEqual(
+            200,
+            res.status_code,
+            "Private content should be visible to staff/admins for review",
         )
 
     def test_detail_as_user(self):

--- a/oldp/apps/laws/models.py
+++ b/oldp/apps/laws/models.py
@@ -203,6 +203,17 @@ class LawBook(TopicContent):
     def __str__(self):
         return "%s (%s)" % (self.title, self.revision_date)
 
+    @staticmethod
+    def get_queryset(request=None):
+        """Visibility-filtered LawBook queryset (staff/owner/anon rules).
+
+        Mirrors :meth:`Case.get_queryset`. Callers should still chain the
+        ``latest=True`` filter where needed.
+        """
+        from oldp.api.mixins import filter_by_review_status
+
+        return filter_by_review_status(LawBook.objects.all(), request)
+
 
 class Law(SearchableContent, models.Model):
     """Law model contains actual law text and belongs to a law book"""
@@ -364,6 +375,13 @@ class Law(SearchableContent, models.Model):
         return self.id
 
     def get_title(self):
+        # Some laws have no descriptive title and the scraper stores the
+        # bare section marker ("§ 13") in both fields, or leaves title
+        # empty/whitespace. Avoid rendering "BGB § 13 § 13" or trailing
+        # whitespace by collapsing those cases to just code + section.
+        stripped_title = self.title.strip() if self.title else ""
+        if not stripped_title or stripped_title == self.section.strip():
+            return "%s %s" % (self.book.code, self.section)
         return "%s %s %s" % (self.book.code, self.section, self.title)
 
     def get_short_title(self, length=40):
@@ -371,6 +389,17 @@ class Law(SearchableContent, models.Model):
             return self.get_title()
         else:
             return self.get_title()[:length] + " ..."
+
+    @staticmethod
+    def get_queryset(request=None):
+        """Visibility-filtered Law queryset (staff/owner/anon rules).
+
+        Mirrors :meth:`Case.get_queryset`. Callers should still chain
+        ``book__latest=True`` / ``book=...`` filters as needed.
+        """
+        from oldp.api.mixins import filter_by_review_status
+
+        return filter_by_review_status(Law.objects.all(), request)
 
     def get_book_title(self):
         raise ValueError("Call book directly")

--- a/oldp/apps/laws/sitemaps.py
+++ b/oldp/apps/laws/sitemaps.py
@@ -5,9 +5,12 @@ from oldp.apps.laws.models import Law
 
 class LawSitemap(GenericSitemap):
     def __init__(self):
+        # Sitemaps run anonymously: get_queryset(request=None) returns
+        # accepted-only, hiding pending/rejected laws from public crawlers.
         super().__init__(
             {
-                "queryset": Law.objects.select_related("book")
+                "queryset": Law.get_queryset()
+                .select_related("book")
                 .filter(book__latest=True)
                 .defer("content", "footnotes")
                 .order_by("-updated_date"),

--- a/oldp/apps/laws/tests/test_review_visibility.py
+++ b/oldp/apps/laws/tests/test_review_visibility.py
@@ -162,3 +162,68 @@ class LawGetTitleDedupTestCase(TestCase):
     def test_title_with_padding_still_dedupes(self):
         law = self._make("p9", "§ 9", " § 9 ")
         self.assertEqual(law.get_title(), "BGB § 9")
+
+
+@override_settings(
+    CACHES={"default": {"BACKEND": "django.core.cache.backends.dummy.DummyCache"}}
+)
+class LawIndexDigitFilterTestCase(TestCase):
+    """The /law/0-9/ quick link aggregates books whose slug starts with a digit."""
+
+    @classmethod
+    def setUpTestData(cls):
+        cls.alpha_book = LawBook.objects.create(
+            slug="alpha-book",
+            code="ALPHA",
+            title="Alpha book",
+            order=1,
+            latest=True,
+            revision_date=date(2026, 1, 1),
+            review_status="accepted",
+        )
+        cls.numeric_book = LawBook.objects.create(
+            slug="3astg",
+            code="3ASTG",
+            title="Drittes Amtshilfegesetz",
+            order=2,
+            latest=True,
+            revision_date=date(2026, 1, 1),
+            review_status="accepted",
+        )
+        cls.numeric_book_2 = LawBook.objects.create(
+            slug="9volkszg",
+            code="9VOLKSZG",
+            title="Neuntes Volkszählungsgesetz",
+            order=3,
+            latest=True,
+            revision_date=date(2026, 1, 1),
+            review_status="accepted",
+        )
+
+    def test_index_offers_digit_quicklink(self):
+        res = self.client.get(reverse("laws:index"))
+        # Button label and URL both present
+        self.assertContains(res, ">\n            0-9\n        </a>", count=1)
+        self.assertContains(res, reverse("laws:index_char", args=("0-9",)))
+
+    def test_digit_filter_includes_all_numeric_books(self):
+        res = self.client.get(reverse("laws:index_char", args=("0-9",)))
+        self.assertEqual(res.status_code, 200)
+        self.assertContains(res, "Drittes Amtshilfegesetz")
+        self.assertContains(res, "Neuntes Volkszählungsgesetz")
+
+    def test_digit_filter_excludes_alpha_books(self):
+        res = self.client.get(reverse("laws:index_char", args=("0-9",)))
+        self.assertNotContains(res, "Alpha book")
+
+    def test_alpha_filter_excludes_numeric_books(self):
+        res = self.client.get(reverse("laws:index_char", args=("a",)))
+        self.assertContains(res, "Alpha book")
+        self.assertNotContains(res, "Drittes Amtshilfegesetz")
+
+    def test_single_digit_filter_still_works(self):
+        # Backwards compat: /law/3/ filters books starting with "3"
+        res = self.client.get(reverse("laws:index_char", args=("3",)))
+        self.assertEqual(res.status_code, 200)
+        self.assertContains(res, "Drittes Amtshilfegesetz")
+        self.assertNotContains(res, "Neuntes Volkszählungsgesetz")

--- a/oldp/apps/laws/tests/test_review_visibility.py
+++ b/oldp/apps/laws/tests/test_review_visibility.py
@@ -1,0 +1,164 @@
+"""Tests for review_status visibility on laws HTML views and Law.get_title()."""
+
+from datetime import date
+
+from django.contrib.auth import get_user_model
+from django.test import RequestFactory, TestCase, override_settings
+from django.urls import reverse
+
+from oldp.apps.laws.models import Law, LawBook
+
+User = get_user_model()
+
+
+@override_settings(
+    CACHES={"default": {"BACKEND": "django.core.cache.backends.dummy.DummyCache"}}
+)
+class LawsReviewVisibilityTestCase(TestCase):
+    """End-to-end visibility checks for /law/, /law/<book>/, /law/<book>/<sec>."""
+
+    @classmethod
+    def setUpTestData(cls):
+        cls.factory = RequestFactory()
+        cls.staff = User.objects.create_user(
+            username="staff", password="pass", is_staff=True
+        )
+        cls.regular = User.objects.create_user(username="reg", password="pass")
+
+        cls.book_acc = LawBook.objects.create(
+            slug="acc-book",
+            code="ACC",
+            title="Accepted book",
+            order=1,
+            latest=True,
+            revision_date=date(2026, 1, 1),
+            review_status="accepted",
+        )
+        cls.book_pending = LawBook.objects.create(
+            slug="pend-book",
+            code="PEND",
+            title="Pending book",
+            order=2,
+            latest=True,
+            revision_date=date(2026, 1, 1),
+            review_status="pending",
+        )
+
+        cls.law_acc = Law.objects.create(
+            book=cls.book_acc,
+            slug="art-1",
+            section="Art 1",
+            title="Würde des Menschen",
+            order=10,
+            review_status="accepted",
+        )
+        cls.law_pending = Law.objects.create(
+            book=cls.book_acc,
+            slug="art-2",
+            section="Art 2",
+            title="Persönliche Freiheit",
+            order=20,
+            review_status="pending",
+        )
+
+    # --- Static method behaviour --------------------------------------
+
+    def test_lawbook_get_queryset_anon_hides_pending(self):
+        qs = LawBook.get_queryset()
+        self.assertIn(self.book_acc, qs)
+        self.assertNotIn(self.book_pending, qs)
+
+    def test_lawbook_get_queryset_staff_shows_all(self):
+        req = self.factory.get("/")
+        req.user = self.staff
+        qs = LawBook.get_queryset(req)
+        self.assertIn(self.book_acc, qs)
+        self.assertIn(self.book_pending, qs)
+
+    def test_law_get_queryset_anon_hides_pending(self):
+        qs = Law.get_queryset()
+        self.assertIn(self.law_acc, qs)
+        self.assertNotIn(self.law_pending, qs)
+
+    def test_law_get_queryset_staff_shows_all(self):
+        req = self.factory.get("/")
+        req.user = self.staff
+        qs = Law.get_queryset(req)
+        self.assertIn(self.law_acc, qs)
+        self.assertIn(self.law_pending, qs)
+
+    # --- View-level integration ---------------------------------------
+
+    def test_index_anon_excludes_pending_book(self):
+        res = self.client.get(reverse("laws:index"))
+        self.assertContains(res, "Accepted book")
+        self.assertNotContains(res, "Pending book")
+
+    def test_index_staff_includes_pending_book(self):
+        self.client.force_login(self.staff)
+        res = self.client.get(reverse("laws:index"))
+        self.assertContains(res, "Accepted book")
+        self.assertContains(res, "Pending book")
+
+    def test_book_detail_anon_404s_on_pending_book(self):
+        res = self.client.get(reverse("laws:book", args=("pend-book",)))
+        self.assertEqual(res.status_code, 404)
+
+    def test_book_detail_staff_renders_pending_book(self):
+        self.client.force_login(self.staff)
+        res = self.client.get(reverse("laws:book", args=("pend-book",)))
+        self.assertEqual(res.status_code, 200)
+
+    def test_law_detail_anon_omits_pending_section(self):
+        # Section list within the accepted book should hide the pending law
+        res = self.client.get(reverse("laws:book", args=("acc-book",)))
+        self.assertContains(res, "Würde des Menschen")
+        self.assertNotContains(res, "Persönliche Freiheit")
+
+    def test_law_detail_anon_404s_on_pending_law(self):
+        res = self.client.get(reverse("laws:law", args=("acc-book", "art-2")))
+        self.assertEqual(res.status_code, 404)
+
+    def test_law_detail_staff_renders_pending_law(self):
+        self.client.force_login(self.staff)
+        res = self.client.get(reverse("laws:law", args=("acc-book", "art-2")))
+        self.assertEqual(res.status_code, 200)
+
+
+class LawGetTitleDedupTestCase(TestCase):
+    """Bug 2: get_title must not render '§ 13 § 13' when title == section."""
+
+    @classmethod
+    def setUpTestData(cls):
+        cls.book = LawBook.objects.create(
+            slug="bgb",
+            code="BGB",
+            title="Bürgerliches Gesetzbuch",
+            order=1,
+            latest=True,
+            revision_date=date(2026, 1, 1),
+            review_status="accepted",
+        )
+
+    def _make(self, slug, section, title):
+        return Law(book=self.book, slug=slug, section=section, title=title, order=1)
+
+    def test_distinct_title_is_kept(self):
+        law = self._make("p1", "§ 1", "Beginn der Rechtsfähigkeit")
+        self.assertEqual(law.get_title(), "BGB § 1 Beginn der Rechtsfähigkeit")
+
+    def test_title_equals_section_is_deduped(self):
+        law = self._make("p13", "§ 13", "§ 13")
+        self.assertEqual(law.get_title(), "BGB § 13")
+
+    def test_empty_title_renders_section_only(self):
+        law = self._make("p7", "§ 7", "")
+        self.assertEqual(law.get_title(), "BGB § 7")
+
+    def test_whitespace_only_title_renders_section_only(self):
+        law = self._make("p8", "§ 8", "   ")
+        self.assertEqual(law.get_title(), "BGB § 8")
+
+    def test_title_with_padding_still_dedupes(self):
+        law = self._make("p9", "§ 9", " § 9 ")
+        self.assertEqual(law.get_title(), "BGB § 9")

--- a/oldp/apps/laws/tests/test_top_books.py
+++ b/oldp/apps/laws/tests/test_top_books.py
@@ -1,0 +1,251 @@
+"""Tests for the /law/ index ordering rules.
+
+Covers:
+  * top books driven by settings.TOP_LAW_BOOKS (slug allowlist, ordered)
+  * empty allowlist → top block hidden
+  * unknown / whitespace-padded slugs tolerated
+  * unfiltered list ordered by -updated_date
+  * char-filtered (/law/<a>/, /law/0-9/) lists ordered by slug
+  * pending top-listed book hidden from anon, visible to staff
+  * top block suppressed on char-filtered views even if allowlist is set
+"""
+
+from datetime import date, timedelta
+
+from django.contrib.auth import get_user_model
+from django.core.cache import cache
+from django.test import TestCase, override_settings
+from django.urls import reverse
+from django.utils import timezone
+
+from oldp.apps.laws.models import LawBook
+
+User = get_user_model()
+
+
+def assert_order(test, body: bytes, first: bytes, second: bytes, msg: str = "") -> None:
+    """Assert ``first`` appears before ``second`` in ``body``."""
+    p1 = body.find(first)
+    p2 = body.find(second)
+    test.assertNotEqual(p1, -1, f"{first!r} not in body — {msg}")
+    test.assertNotEqual(p2, -1, f"{second!r} not in body — {msg}")
+    test.assertLess(p1, p2, f"{first!r} should appear before {second!r} — {msg}")
+
+
+@override_settings(
+    CACHES={"default": {"BACKEND": "django.core.cache.backends.dummy.DummyCache"}}
+)
+class LawIndexOrderingTestCase(TestCase):
+    """Comprehensive coverage of the /law/ index ordering rules."""
+
+    @classmethod
+    def setUpTestData(cls):
+        cls.staff = User.objects.create_user(
+            username="staff", password="pass", is_staff=True
+        )
+
+        # Numeric-prefix books — used to verify /law/0-9/ slug ordering
+        cls.book_1 = LawBook.objects.create(
+            slug="1book",
+            code="1B",
+            title="One",
+            order=0,
+            latest=True,
+            revision_date=date(2020, 1, 1),
+            review_status="accepted",
+        )
+        cls.book_2 = LawBook.objects.create(
+            slug="2book",
+            code="2B",
+            title="Two",
+            order=0,
+            latest=True,
+            revision_date=date(2020, 1, 1),
+            review_status="accepted",
+        )
+        cls.book_9 = LawBook.objects.create(
+            slug="9book",
+            code="9B",
+            title="Nine",
+            order=0,
+            latest=True,
+            revision_date=date(2020, 1, 1),
+            review_status="accepted",
+        )
+
+        # Alpha books with deliberately *non-alphabetical* titles to make
+        # sure ordering is by slug, not by the legacy title sort.
+        cls.alpha_a = LawBook.objects.create(
+            slug="alpha-a",
+            code="ALPHA-A",
+            title="Zzz title",
+            order=0,
+            latest=True,
+            revision_date=date(2020, 1, 1),
+            review_status="accepted",
+        )
+        cls.alpha_z = LawBook.objects.create(
+            slug="alpha-z",
+            code="ALPHA-Z",
+            title="Aaa title",
+            order=0,
+            latest=True,
+            revision_date=date(2020, 1, 1),
+            review_status="accepted",
+        )
+
+        # Curated top-list candidates — distinguishable by code.
+        cls.gg = LawBook.objects.create(
+            slug="gg",
+            code="GG",
+            title="Grundgesetz",
+            order=0,
+            latest=True,
+            revision_date=date(2020, 1, 1),
+            review_status="accepted",
+        )
+        cls.bgb = LawBook.objects.create(
+            slug="bgb",
+            code="BGB",
+            title="Bürgerliches Gesetzbuch",
+            order=0,
+            latest=True,
+            revision_date=date(2020, 1, 1),
+            review_status="accepted",
+        )
+        cls.stgb = LawBook.objects.create(
+            slug="stgb",
+            code="STGB",
+            title="Strafgesetzbuch",
+            order=0,
+            latest=True,
+            revision_date=date(2020, 1, 1),
+            review_status="accepted",
+        )
+
+        # Bypass auto_now to set deterministic updated_date timestamps for
+        # the date-ordering check (latest first):
+        #     gg  > 1book > alpha-a > others
+        now = timezone.now()
+        LawBook.objects.filter(pk=cls.gg.pk).update(
+            updated_date=now - timedelta(days=1)
+        )
+        LawBook.objects.filter(pk=cls.book_1.pk).update(
+            updated_date=now - timedelta(days=2)
+        )
+        LawBook.objects.filter(pk=cls.alpha_a.pk).update(
+            updated_date=now - timedelta(days=3)
+        )
+        for b in (cls.book_2, cls.book_9, cls.alpha_z, cls.bgb, cls.stgb):
+            LawBook.objects.filter(pk=b.pk).update(
+                updated_date=now - timedelta(days=10)
+            )
+
+    def setUp(self):
+        # cache_per_role would otherwise leak responses across tests
+        cache.clear()
+
+    # --- 1. Empty allowlist → top section hidden ---
+
+    @override_settings(TOP_LAW_BOOKS=[])
+    def test_empty_allowlist_hides_top_section(self):
+        res = self.client.get(reverse("laws:index"))
+        self.assertEqual(res.status_code, 200)
+        self.assertEqual(list(res.context["top_items"]), [])
+        # Heading is wrapped by `{% if top_items %}` in the template
+        self.assertNotContains(res, "More Laws")
+
+    # --- 2. Configured allowlist → ordered top books ---
+
+    @override_settings(TOP_LAW_BOOKS=["bgb", "gg", "stgb"])
+    def test_configured_top_books_in_listed_order(self):
+        res = self.client.get(reverse("laws:index"))
+        self.assertEqual(res.status_code, 200)
+        slugs = [b.slug for b in res.context["top_items"]]
+        self.assertEqual(slugs, ["bgb", "gg", "stgb"])
+
+        body = res.content
+        assert_order(self, body, b"BGB", b"GG", "BGB before GG in HTML")
+        assert_order(self, body, b"GG", b"STGB", "GG before STGB in HTML")
+        # "More Laws" heading appears now that top_items is non-empty
+        self.assertContains(res, "More Laws")
+
+    # --- 3. Unknown slugs → silently dropped, no 500 ---
+
+    @override_settings(TOP_LAW_BOOKS=["does-not-exist", "gg", "also-bogus"])
+    def test_unknown_slugs_are_dropped(self):
+        res = self.client.get(reverse("laws:index"))
+        self.assertEqual(res.status_code, 200)
+        slugs = [b.slug for b in res.context["top_items"]]
+        self.assertEqual(slugs, ["gg"])
+
+    # --- 4. Whitespace tolerance ---
+
+    @override_settings(TOP_LAW_BOOKS=[" gg", "bgb ", "  ", ""])
+    def test_whitespace_in_slugs_is_stripped(self):
+        res = self.client.get(reverse("laws:index"))
+        self.assertEqual(res.status_code, 200)
+        slugs = [b.slug for b in res.context["top_items"]]
+        self.assertEqual(slugs, ["gg", "bgb"])
+
+    # --- 5. Main list ordered by -updated_date ---
+
+    @override_settings(TOP_LAW_BOOKS=[])
+    def test_main_list_ordered_by_updated_date_desc(self):
+        res = self.client.get(reverse("laws:index"))
+        items = list(res.context["items"].object_list)
+        # gg (1d ago) → 1book (2d) → alpha-a (3d) → tied 10d-ago group
+        first_three = [b.slug for b in items[:3]]
+        self.assertEqual(first_three, ["gg", "1book", "alpha-a"])
+
+    # --- 6. /law/<char>/ ordered by slug, not title ---
+
+    @override_settings(TOP_LAW_BOOKS=["gg", "bgb"])
+    def test_alpha_filter_orders_by_slug_not_title(self):
+        res = self.client.get(reverse("laws:index_char", args=("a",)))
+        self.assertEqual(res.status_code, 200)
+        items = list(res.context["items"].object_list)
+        slugs = [b.slug for b in items]
+        # alpha-a (titled "Zzz") MUST come before alpha-z (titled "Aaa")
+        self.assertEqual(slugs, ["alpha-a", "alpha-z"])
+        # No top block on char filters even with allowlist populated
+        self.assertEqual(list(res.context["top_items"]), [])
+
+    # --- 7. /law/0-9/ ordered by slug ---
+
+    @override_settings(TOP_LAW_BOOKS=["gg"])
+    def test_digit_filter_orders_by_slug(self):
+        res = self.client.get(reverse("laws:index_char", args=("0-9",)))
+        self.assertEqual(res.status_code, 200)
+        items = list(res.context["items"].object_list)
+        self.assertEqual([b.slug for b in items], ["1book", "2book", "9book"])
+        self.assertEqual(list(res.context["top_items"]), [])
+
+    # --- 8. Top section respects review_status visibility ---
+
+    @override_settings(TOP_LAW_BOOKS=["gg", "bgb"])
+    def test_pending_top_book_hidden_from_anon(self):
+        LawBook.objects.filter(pk=self.gg.pk).update(review_status="pending")
+        res = self.client.get(reverse("laws:index"))
+        slugs = [b.slug for b in res.context["top_items"]]
+        self.assertEqual(slugs, ["bgb"])  # gg dropped from top for anon
+
+    @override_settings(TOP_LAW_BOOKS=["gg", "bgb"])
+    def test_pending_top_book_visible_to_staff(self):
+        LawBook.objects.filter(pk=self.gg.pk).update(review_status="pending")
+        self.client.force_login(self.staff)
+        res = self.client.get(reverse("laws:index"))
+        slugs = [b.slug for b in res.context["top_items"]]
+        self.assertEqual(slugs, ["gg", "bgb"])
+
+    # --- 9. Char filters never render the top block ---
+
+    @override_settings(TOP_LAW_BOOKS=["gg", "bgb", "stgb"])
+    def test_top_block_absent_on_alpha_filter_even_with_allowlist(self):
+        res = self.client.get(reverse("laws:index_char", args=("g",)))
+        self.assertEqual(list(res.context["top_items"]), [])
+
+    @override_settings(TOP_LAW_BOOKS=["gg", "bgb", "stgb"])
+    def test_top_block_absent_on_digit_filter_even_with_allowlist(self):
+        res = self.client.get(reverse("laws:index_char", args=("0-9",)))
+        self.assertEqual(list(res.context["top_items"]), [])

--- a/oldp/apps/laws/urls.py
+++ b/oldp/apps/laws/urls.py
@@ -5,7 +5,10 @@ from . import views
 app_name = "laws"
 urlpatterns = [
     re_path(r"^$", views.view_index, name="index"),
-    re_path(r"^(?P<char>[-a-zA-Z0-9])/$", views.view_index, name="index_char"),
+    # "0-9" matches first so it isn't consumed by the single-char branch;
+    # otherwise a single ASCII letter or digit selects books whose slug
+    # starts with that character.
+    re_path(r"^(?P<char>0-9|[-a-zA-Z0-9])/$", views.view_index, name="index_char"),
     re_path(
         r"^(?P<book_slug>[-a-z0-9_]+)/(?P<law_slug>[-a-z0-9_]+)$",
         views.view_law,

--- a/oldp/apps/laws/views.py
+++ b/oldp/apps/laws/views.py
@@ -18,9 +18,7 @@ logger = logging.getLogger(__name__)
 @cache_per_role(settings.CACHE_TTL)
 def view_index(request, char=None):
     page = request.GET.get("page")
-    items = LawBook.objects.filter(
-        latest=True
-    )  # .values('slug', 'title', 'code').annotate(n=models.Count('slug'))
+    items = LawBook.get_queryset(request).filter(latest=True)
 
     if char is not None and len(char) == 1:
         char = str(char).lower()
@@ -58,9 +56,9 @@ def view_index(request, char=None):
     )
 
 
-def get_latest_law_book(book_slug):
+def get_latest_law_book(request, book_slug):
     """Law book by slug and latest=true (logs warning if multiple instances exist)"""
-    candidates = LawBook.objects.filter(slug=book_slug, latest=True)
+    candidates = LawBook.get_queryset(request).filter(slug=book_slug, latest=True)
     book = candidates.first()
 
     if book is None:
@@ -81,7 +79,9 @@ def get_law_book(request, book_slug):
 
     if revision_date:
         try:
-            return LawBook.objects.get(slug=book_slug, revision_date=revision_date)
+            return LawBook.get_queryset(request).get(
+                slug=book_slug, revision_date=revision_date
+            )
         except LawBook.DoesNotExist:
             logger.debug(
                 "Requested revision not found: book=%s, revision_date=%s",
@@ -95,9 +95,9 @@ def get_law_book(request, book_slug):
                     % revision_date
                 ),
             )
-            return get_latest_law_book(book_slug)
+            return get_latest_law_book(request, book_slug)
     else:
-        return get_latest_law_book(book_slug)
+        return get_latest_law_book(request, book_slug)
 
 
 @cache_per_role(settings.CACHE_TTL)
@@ -107,7 +107,8 @@ def view_book(request, book_slug):
     revision_dates = list(book.get_revision_dates())
 
     items_qs = (
-        Law.objects.filter(book=book)
+        Law.get_queryset(request)
+        .filter(book=book)
         .select_related("book")
         .defer(*Law.defer_fields_list_view)
         .order_by("order")
@@ -133,7 +134,9 @@ def view_book(request, book_slug):
 def view_law(request, law_slug, book_slug):
     book = get_law_book(request, book_slug)
     item = get_object_or_404(
-        Law.objects.select_related("book", "previous"), slug=law_slug, book=book
+        Law.get_queryset(request).select_related("book", "previous"),
+        slug=law_slug,
+        book=book,
     )
     revision_dates = list(book.get_revision_dates())
     related_laws = item.get_related()

--- a/oldp/apps/laws/views.py
+++ b/oldp/apps/laws/views.py
@@ -15,12 +15,19 @@ from oldp.utils.cache_per_user import cache_per_role
 logger = logging.getLogger(__name__)
 
 
+DIGIT_FILTER = "0-9"
+
+
 @cache_per_role(settings.CACHE_TTL)
 def view_index(request, char=None):
     page = request.GET.get("page")
     items = LawBook.get_queryset(request).filter(latest=True)
 
-    if char is not None and len(char) == 1:
+    if char == DIGIT_FILTER:
+        # Aggregate quick-link for books whose slug starts with a digit.
+        items = items.filter(slug__regex=r"^[0-9]")
+        top_items = []
+    elif char is not None and len(char) == 1:
         char = str(char).lower()
         items = items.filter(slug__startswith=char)  # Case sensitive filtering
 
@@ -50,7 +57,7 @@ def view_index(request, char=None):
             "items": items,
             "top_items": top_items,
             "char": char,
-            "chars": list(string.ascii_lowercase),
+            "chars": list(string.ascii_lowercase) + [DIGIT_FILTER],
             "title": _("Laws"),
         },
     )

--- a/oldp/apps/laws/views.py
+++ b/oldp/apps/laws/views.py
@@ -22,21 +22,30 @@ DIGIT_FILTER = "0-9"
 def view_index(request, char=None):
     page = request.GET.get("page")
     items = LawBook.get_queryset(request).filter(latest=True)
+    top_items: list = []
 
     if char == DIGIT_FILTER:
         # Aggregate quick-link for books whose slug starts with a digit.
-        items = items.filter(slug__regex=r"^[0-9]")
-        top_items = []
+        items = items.filter(slug__regex=r"^[0-9]").order_by("slug")
     elif char is not None and len(char) == 1:
         char = str(char).lower()
-        items = items.filter(slug__startswith=char)  # Case sensitive filtering
-
-        top_items = []
+        items = items.filter(slug__startswith=char).order_by("slug")
     else:
-        items = items.all()
-        top_items = items.order_by("-order")[:5]
-
-    items = items.order_by("title")
+        # On the unfiltered index, surface a curated set of top books and
+        # order the rest by most-recently-updated.  The curated set comes
+        # from settings.TOP_LAW_BOOKS (a list of slugs); empty list hides
+        # the top block entirely (the template already gates on it).
+        top_slugs = [s.strip() for s in settings.TOP_LAW_BOOKS if s and s.strip()]
+        if top_slugs:
+            by_slug = {
+                b.slug: b
+                for b in LawBook.get_queryset(request).filter(
+                    latest=True, slug__in=top_slugs
+                )
+            }
+            # Preserve configured order; silently drop unknown slugs.
+            top_items = [by_slug[s] for s in top_slugs if s in by_slug]
+        items = items.order_by("-updated_date")
 
     paginator = Paginator(items, settings.PAGINATE_BY)
 

--- a/oldp/settings.py
+++ b/oldp/settings.py
@@ -47,6 +47,11 @@ class BaseConfiguration(Configuration):
 
     CSRF_TRUSTED_ORIGINS = values.ListValue([])
 
+    # Slugs of LawBooks shown as "top books" on /law/ in the order listed.
+    # Empty/unset hides the top block. Read from env var DJANGO_TOP_LAW_BOOKS
+    # as a comma-separated string (e.g. "gg,bgb,stgb,hgb,estg").
+    TOP_LAW_BOOKS = values.ListValue([])
+
     # Application definition
     INSTALLED_APPS = [
         # local apps


### PR DESCRIPTION
## Summary

Three related changes that all touch `oldp/apps/laws/views.view_index`, so they ship as one PR.

### 1. Hide pending/rejected from non-admin views (Bug 1)

- New shared helper `filter_by_review_status(qs, request)` in `oldp/api/mixins.py`: **staff → all, authenticated → accepted + own (via `created_by_token`), anon → accepted only**. `ReviewStatusFilterMixin` is now a one-liner over it.
- `Case.get_queryset(request)` delegates to the helper. Drops the `DEBUG → all` shortcut and the inline `# TODO superuser?`.
- `Law` and `LawBook` gain matching `get_queryset(request)` statics. `view_index`, `view_book`, `view_law`, `get_latest_law_book`, `get_law_book`, and `LawSitemap` route through them.

### 2. Dedupe duplicate `§` markers in `Law.get_title()` (Bug 2)

- When `title == section` (e.g. `BGB § 13 § 13`) collapse to `BGB § 13`. Empty / whitespace-only titles are also handled.

### 3. /law/ index ordering — config-driven top books, smarter list ordering (Feature)

- New setting `TOP_LAW_BOOKS` / env var `DJANGO_TOP_LAW_BOOKS` (comma-separated slugs, e.g. `gg,bgb,stgb,hgb,estg`). Renders in the configured order; empty hides the top block.
- Replaces the previous `LawBook.order` ranking, which silently broke whenever the ingestor created a new revision (default `order=0` → top books would disappear after each update).
- `/law/` rest-of-list now ordered by `-updated_date` so new revisions surface; `/law/<char>/` and `/law/0-9/` ordered by `slug`.
- Unknown / whitespace-padded slugs in the env var are silently dropped (no 500).
- New `0-9` quick-link aggregates digit-prefix slugs.

## Test plan

- [x] `oldp.api.tests.test_mixins` — `filter_by_review_status` for anon / authenticated / owner / staff
- [x] `oldp.apps.cases.tests.test_view_review_status` — `Case.get_queryset()` + view-level visibility
- [x] `oldp.apps.cases.tests.test_views.test_private_detail` — flipped to assert staff visibility
- [x] `oldp.apps.laws.tests.test_review_visibility` — `Law` / `LawBook` `get_queryset`, view visibility, `Law.get_title` dedup, `0-9` filter
- [x] `oldp.apps.laws.tests.test_top_books` — 9 cases covering empty allowlist, ordered configured allowlist, unknown slugs, whitespace, `-updated_date` rest-list ordering, slug ordering on alpha + digit filters, pending top-book visibility (anon vs staff), top block suppressed on char filters
- [x] CI green on prior commits
- [x] Manual smoke against dev-deployment (`dev-deployment/scripts/smoke_test_laws_view.py`)
- [x] Set `DJANGO_TOP_LAW_BOOKS=gg,bgb,stgb,hgb,estg` in `oldp-de-dev.env`, restart dev-app, confirm top block in browser

## Files modified

| File | Change |
|---|---|
| `oldp/api/mixins.py` | new `filter_by_review_status()`; mixin delegates |
| `oldp/apps/cases/models.py` | `Case.get_queryset` uses helper |
| `oldp/apps/laws/models.py` | new `Law.get_queryset()` + `LawBook.get_queryset()`; `Law.get_title` dedup |
| `oldp/apps/laws/views.py` | top books from `TOP_LAW_BOOKS`; rest by `-updated_date` (index) or `slug` (char); `0-9` quick-link |
| `oldp/apps/laws/sitemaps.py` | use `Law.get_queryset()` |
| `oldp/apps/laws/urls.py` | `0-9` route |
| `oldp/settings.py` | `TOP_LAW_BOOKS = values.ListValue([])` |
| `oldp/apps/cases/tests/test_views.py` | flip `test_private_detail` staff expectation |
| new tests | `test_mixins.py`, `test_view_review_status.py`, `test_review_visibility.py`, `test_top_books.py` |
| `README.md` | document `DJANGO_TOP_LAW_BOOKS` env var |

🤖 Generated with [Claude Code](https://claude.com/claude-code)