### PR TITLE
fix(laws): cascade LawBook accept/pending to child Law rows

### DIFF
--- a/oldp/apps/laws/processing/processing_steps/set_lawbook_review_accepted.py
+++ b/oldp/apps/laws/processing/processing_steps/set_lawbook_review_accepted.py
@@ -1,15 +1,30 @@
 import logging
 
-from oldp.apps.laws.models import LawBook
+from oldp.apps.laws.models import Law, LawBook
 from oldp.apps.laws.processing.processing_steps import LawBookProcessingStep
 
 logger = logging.getLogger(__name__)
 
 
 class ProcessingStep(LawBookProcessingStep):
-    description = "Set review_status=accepted"
+    description = "Set review_status=accepted (cascades to child laws)"
 
     def process(self, law_book: LawBook):
         law_book.review_status = "accepted"
+
+        # Cascade to child Law rows. Without this, anonymous users see an
+        # empty book because Law.get_queryset() filters out pending rows.
+        if law_book.pk is not None:
+            updated = (
+                Law.objects.filter(book=law_book)
+                .exclude(review_status="accepted")
+                .update(review_status="accepted")
+            )
+            if updated:
+                logger.info(
+                    "Cascaded accepted to %d laws under book %s",
+                    updated,
+                    law_book.code,
+                )
 
         return law_book

--- a/oldp/apps/laws/processing/processing_steps/set_lawbook_review_pending.py
+++ b/oldp/apps/laws/processing/processing_steps/set_lawbook_review_pending.py
@@ -1,15 +1,30 @@
 import logging
 
-from oldp.apps.laws.models import LawBook
+from oldp.apps.laws.models import Law, LawBook
 from oldp.apps.laws.processing.processing_steps import LawBookProcessingStep
 
 logger = logging.getLogger(__name__)
 
 
 class ProcessingStep(LawBookProcessingStep):
-    description = "Set review_status=pending"
+    description = "Set review_status=pending (cascades to child laws)"
 
     def process(self, law_book: LawBook):
         law_book.review_status = "pending"
+
+        # Cascade to child Law rows so visibility stays consistent with the
+        # book. Otherwise un-accepting a book leaves its laws publicly visible.
+        if law_book.pk is not None:
+            updated = (
+                Law.objects.filter(book=law_book)
+                .exclude(review_status="pending")
+                .update(review_status="pending")
+            )
+            if updated:
+                logger.info(
+                    "Cascaded pending to %d laws under book %s",
+                    updated,
+                    law_book.code,
+                )
 
         return law_book

--- a/oldp/apps/laws/tests/test_review_cascade.py
+++ b/oldp/apps/laws/tests/test_review_cascade.py
@@ -1,0 +1,103 @@
+"""Tests for the LawBook review_status processing steps cascading to child laws."""
+
+from datetime import date
+
+from django.test import TestCase
+
+from oldp.apps.laws.models import Law, LawBook
+from oldp.apps.laws.processing.processing_steps.set_lawbook_review_accepted import (
+    ProcessingStep as AcceptStep,
+)
+from oldp.apps.laws.processing.processing_steps.set_lawbook_review_pending import (
+    ProcessingStep as PendingStep,
+)
+
+
+class LawBookReviewCascadeTestCase(TestCase):
+    """When a LawBook's review_status changes, child Law rows must follow."""
+
+    def setUp(self):
+        self.book = LawBook.objects.create(
+            slug="cascade-book",
+            code="CASCADE",
+            title="Cascade test book",
+            order=1,
+            latest=True,
+            revision_date=date(2026, 1, 1),
+            review_status="pending",
+        )
+        self.law_pending_a = Law.objects.create(
+            book=self.book,
+            slug="art-1",
+            section="Art 1",
+            title="L1",
+            order=10,
+            review_status="pending",
+        )
+        self.law_pending_b = Law.objects.create(
+            book=self.book,
+            slug="art-2",
+            section="Art 2",
+            title="L2",
+            order=20,
+            review_status="pending",
+        )
+
+    def test_accept_cascades_to_laws(self):
+        AcceptStep().process(self.book)
+        self.book.save()
+
+        self.law_pending_a.refresh_from_db()
+        self.law_pending_b.refresh_from_db()
+        self.assertEqual(self.law_pending_a.review_status, "accepted")
+        self.assertEqual(self.law_pending_b.review_status, "accepted")
+
+    def test_accept_does_not_touch_other_books(self):
+        other_book = LawBook.objects.create(
+            slug="other-book",
+            code="OTHER",
+            title="Other",
+            order=2,
+            latest=True,
+            revision_date=date(2026, 1, 1),
+            review_status="pending",
+        )
+        other_law = Law.objects.create(
+            book=other_book,
+            slug="x",
+            section="X",
+            title="X",
+            order=10,
+            review_status="pending",
+        )
+
+        AcceptStep().process(self.book)
+        self.book.save()
+
+        other_law.refresh_from_db()
+        self.assertEqual(other_law.review_status, "pending")
+
+    def test_pending_cascades_to_laws(self):
+        Law.objects.filter(book=self.book).update(review_status="accepted")
+
+        PendingStep().process(self.book)
+        self.book.save()
+
+        self.law_pending_a.refresh_from_db()
+        self.law_pending_b.refresh_from_db()
+        self.assertEqual(self.law_pending_a.review_status, "pending")
+        self.assertEqual(self.law_pending_b.review_status, "pending")
+
+    def test_accept_unsaved_book_does_not_query(self):
+        """A book without pk (never saved) should be a no-op for the cascade."""
+        unsaved = LawBook(
+            slug="unsaved",
+            code="UNSAVED",
+            title="Unsaved",
+            order=99,
+            revision_date=date(2026, 1, 1),
+            review_status="pending",
+        )
+        # Must not raise.
+        AcceptStep().process(unsaved)
+        self.assertEqual(unsaved.review_status, "accepted")


### PR DESCRIPTION
## Summary
- Accepting a `LawBook` via the admin dashboard only flipped the book's `review_status`. Its child `Law` rows kept the `pending` state set by `LawCreator.create_law()` at ingest time.
- `Law.get_queryset()` (added in #183) filters anonymous queries to `review_status=accepted`, so logged-out visitors saw an empty book page on `/law/<slug>/` even after the book was accepted.
- Both `set_lawbook_review_accepted` and `set_lawbook_review_pending` now cascade the new state to all child laws via a single bulk `UPDATE`. Symmetric on both sides so un-accepting a book also hides its laws again.

## Test plan
- [x] `make test` (full laws suite, 141 tests, all green)
- [x] New `oldp/apps/laws/tests/test_review_cascade.py` — 4 tests covering accept-cascade, pending-cascade, no cross-book leakage, and unsaved-book no-op
- [x] `make lint` clean

## One-shot for production backfill
Existing already-accepted books need a one-time catch-up so their pending laws become visible. Equivalent SQL covered by `set_lawbook_review_accepted`'s new code path:

```sql
UPDATE laws_law SET review_status = 'accepted'
WHERE book_id IN (SELECT id FROM laws_lawbook WHERE review_status = 'accepted')
  AND review_status <> 'accepted';
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)