### PR TITLE
fix(search): set highlight.max_analyzed_offset to avoid ES 400 on long docs

### DIFF
--- a/oldp/apps/search/search_backend.py
+++ b/oldp/apps/search/search_backend.py
@@ -162,7 +162,15 @@ class SearchBackend(Elasticsearch7SearchBackend):
             # `highlight` can either be True or a dictionary containing custom parameters
             # which will be passed to the backend and may override our default settings:
 
-            kwargs["highlight"] = {"fields": {content_field: {}}}
+            kwargs["highlight"] = {
+                # ES rejects highlighting on fields longer than
+                # index.highlight.max_analyzed_offset (default 1MB). A few
+                # case texts exceed this and surfaced as
+                # search_phase_execution_exception 400s. Setting the per-query
+                # offset limit lets ES truncate analysis of long docs instead.
+                "max_analyzed_offset": 1_000_000,
+                "fields": {content_field: {}},
+            }
 
             if isinstance(highlight, dict):
                 kwargs["highlight"].update(highlight)

--- a/oldp/apps/search/tests/test_search_backend.py
+++ b/oldp/apps/search/tests/test_search_backend.py
@@ -12,15 +12,29 @@ def _make_backend():
     with patch.object(SearchBackend, "__init__", return_value=None):
         b = SearchBackend.__new__(SearchBackend)
         SearchBackend.__init__(b)
-    b.connections = MagicMock()
+    b.connection_alias = "default"
     b.RESERVED_WORDS = ()
+    b.include_spelling = False
     return b
 
 
 class HighlightKwargsTest(SimpleTestCase):
     """Highlight kwargs must include max_analyzed_offset to avoid 400s on
     long doc fields (see incident 2026-05-05: case texts >1MB triggered
-    search_phase_execution_exception in ES highlighter)."""
+    search_phase_execution_exception in ES highlighter).
+    """
+
+    def setUp(self):
+        index = MagicMock()
+        index.document_field = "text"
+        connection = MagicMock()
+        connection.get_unified_index.return_value = index
+        patcher = patch(
+            "oldp.apps.search.search_backend.haystack.connections",
+            {"default": connection},
+        )
+        patcher.start()
+        self.addCleanup(patcher.stop)
 
     def test_highlight_true_sets_max_analyzed_offset(self):
         backend = _make_backend()

--- a/oldp/apps/search/tests/test_search_backend.py
+++ b/oldp/apps/search/tests/test_search_backend.py
@@ -1,0 +1,48 @@
+"""Unit tests for the custom SearchBackend kwargs construction."""
+
+from unittest.mock import MagicMock, patch
+
+from django.test import SimpleTestCase
+
+from oldp.apps.search.search_backend import SearchBackend
+
+
+def _make_backend():
+    """Instantiate SearchBackend without connecting to ES."""
+    with patch.object(SearchBackend, "__init__", return_value=None):
+        b = SearchBackend.__new__(SearchBackend)
+        SearchBackend.__init__(b)
+    b.connections = MagicMock()
+    b.RESERVED_WORDS = ()
+    return b
+
+
+class HighlightKwargsTest(SimpleTestCase):
+    """Highlight kwargs must include max_analyzed_offset to avoid 400s on
+    long doc fields (see incident 2026-05-05: case texts >1MB triggered
+    search_phase_execution_exception in ES highlighter)."""
+
+    def test_highlight_true_sets_max_analyzed_offset(self):
+        backend = _make_backend()
+        kwargs = backend.build_search_kwargs("test", highlight=True)
+        self.assertIn("highlight", kwargs)
+        self.assertEqual(kwargs["highlight"]["max_analyzed_offset"], 1_000_000)
+
+    def test_highlight_false_omits_highlight_kwarg(self):
+        backend = _make_backend()
+        kwargs = backend.build_search_kwargs("test", highlight=False)
+        self.assertNotIn("highlight", kwargs)
+
+    def test_caller_overrides_can_replace_max_analyzed_offset(self):
+        backend = _make_backend()
+        kwargs = backend.build_search_kwargs(
+            "test", highlight={"max_analyzed_offset": 500_000}
+        )
+        self.assertEqual(kwargs["highlight"]["max_analyzed_offset"], 500_000)
+
+    def test_caller_overrides_preserve_max_analyzed_offset_when_not_set(self):
+        backend = _make_backend()
+        kwargs = backend.build_search_kwargs(
+            "test", highlight={"fields": {"text": {"fragment_size": 200}}}
+        )
+        self.assertEqual(kwargs["highlight"]["max_analyzed_offset"], 1_000_000)


### PR DESCRIPTION
## Summary
- Adds `max_analyzed_offset: 1_000_000` to the ES highlight clause so long doc fields (>1MB) get truncated for analysis instead of throwing `search_phase_execution_exception` 400s.
- Caller-supplied `highlight` dicts can still override the value when needed.
- Unit tests for kwargs construction.

## Why

Production logs (`docker/data/logs/oldp.log`) on de.openlegaldata.io showed repeated:

```
ERROR oldp.apps.search.views Search backend unavailable: RequestError(400,
  'search_phase_execution_exception',
  'The length [4218073] of field [text] in doc[2935]/index[oldp] exceeds the
   [index.highlight.max_analyzed_offset] limit [1000000]. ...')
```

A few case `text` values (e.g. transcripts) are larger than 1MB. ES's default highlighter rejects these queries entirely. Setting `max_analyzed_offset` on the highlight clause makes ES analyze only the first 1MB and produce a snippet rather than failing the whole search.

## Test plan
- [x] CI passes (unit tests + real-ES highlight integration test still green)
- [x] After deploy: no more `search_phase_execution_exception` entries in `oldp.log`
- [x] Spot-check a search query against a known long-text case still returns highlighted snippets