### PR TITLE
ci(docs): fix gh-pages race + make PR runs manual

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -4,8 +4,10 @@ on:
   push:
     branches: [master]
     tags: ["v*"]
-  pull_request:
-    branches: [master]
+  # PRs no longer auto-build docs (we burn CI on every push otherwise).
+  # Trigger manually from Actions → Docs → "Run workflow" against the PR
+  # branch when a docs preview is needed.
+  workflow_dispatch:
 
 permissions:
   contents: write
@@ -14,10 +16,11 @@ permissions:
 # Master pushes and v* tag pushes can fire on the same commit (a release
 # typically pushes both at once), and both runs try to push to gh-pages.
 # Serialize so the second one fetches the up-to-date gh-pages before
-# pushing instead of getting a non-fast-forward rejection. PRs are
-# grouped per ref so PR runs don't block deploy runs.
+# pushing instead of getting a non-fast-forward rejection. Manual PR
+# runs (workflow_dispatch) are grouped per ref so they don't block
+# deploys.
 concurrency:
-  group: docs-${{ github.event_name == 'pull_request' && github.ref || 'deploy' }}
+  group: docs-${{ github.event_name == 'push' && 'deploy' || github.ref }}
   cancel-in-progress: false
 
 jobs:
@@ -39,31 +42,19 @@ jobs:
           pip install uv
           uv pip install --system sphinx sphinx-rtd-theme sphinx-polyversion myst-parser
 
-      # Pull Request: single-version build + artifact
-      - name: Build docs (PR)
-        if: github.event_name == 'pull_request'
+      # Manual preview build (workflow_dispatch): single-version + artifact.
+      # No automatic PR comment because workflow_dispatch has no PR context.
+      - name: Build docs (preview)
+        if: github.event_name == 'workflow_dispatch'
         run: sphinx-build docs docs/_build/html
 
-      - name: Upload PR preview artifact
-        if: github.event_name == 'pull_request'
+      - name: Upload preview artifact
+        if: github.event_name == 'workflow_dispatch'
         uses: actions/upload-artifact@v4
         with:
-          name: docs-pr-${{ github.event.number }}
+          name: docs-${{ github.ref_name }}-${{ github.run_id }}
           path: docs/_build/html
           retention-days: 14
-
-      - name: Comment on PR
-        if: github.event_name == 'pull_request'
-        uses: actions/github-script@v7
-        with:
-          script: |
-            const run_url = `${context.serverUrl}/${context.repo.owner}/${context.repo.repo}/actions/runs/${context.runId}`;
-            github.rest.issues.createComment({
-              issue_number: context.issue.number,
-              owner: context.repo.owner,
-              repo: context.repo.repo,
-              body: `Docs preview built. Download artifact **docs-pr-${{ github.event.number }}** from [this run](${run_url}).`
-            });
 
       # Push to master or tag: multiversion deploy
       - name: Build all versions

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -11,6 +11,15 @@ permissions:
   contents: write
   pull-requests: write
 
+# Master pushes and v* tag pushes can fire on the same commit (a release
+# typically pushes both at once), and both runs try to push to gh-pages.
+# Serialize so the second one fetches the up-to-date gh-pages before
+# pushing instead of getting a non-fast-forward rejection. PRs are
+# grouped per ref so PR runs don't block deploy runs.
+concurrency:
+  group: docs-${{ github.event_name == 'pull_request' && github.ref || 'deploy' }}
+  cancel-in-progress: false
+
 jobs:
   build:
     runs-on: ubuntu-latest


### PR DESCRIPTION
## What happened

[Run 25423055367](https://github.com/openlegaldata/oldp/actions/runs/25423055367/job/74569615630) (Docs workflow on tag \`v0.10.0\`) failed:

\`\`\`
! [rejected] gh-pages -> gh-pages (fetch first)
\`\`\`

A release pushed master and the \`v0.10.0\` tag at the same instant. Both push events triggered the Docs workflow on the same commit, both runs built identical content, and they raced on \`git push origin gh-pages\`. First wins; second gets a non-fast-forward.

## What changes

- **Concurrency group** so deploy-eligible runs (master push, tag push) serialize. The second run fetches the latest \`gh-pages\` before pushing instead of racing. \`cancel-in-progress: false\` because we want both to complete (they're cheap and the second one fetches up-to-date state).
- **PR runs are now manual.** Drop the \`pull_request\` trigger; add \`workflow_dispatch\` so a maintainer can build a docs preview from Actions → Docs → "Run workflow" against any branch. Removes the auto-PR-comment step (no PR context on workflow_dispatch). Master/tag pushes still deploy automatically.

## Note on Cloudflare Pages

The "Cloudflare Pages" check that also runs on PRs is **not** a workflow in this repo — it comes from Cloudflare's GitHub-app integration (the check link goes to \`dash.cloudflare.com\`). To make those PR previews opt-in, disable them in Cloudflare's Pages project settings → Builds & deployments → Preview branch settings.

## Test plan
- [x] YAML parses
- [x] CI passes (this PR's checks)
- [x] After merge, next master push deploys cleanly
- [x] Manual workflow_dispatch on a branch produces a preview artifact