### PR TITLE
fix(docs): make sphinx-polyversion build master + new tags again

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -52,7 +52,9 @@ jobs:
         if: github.event_name == 'workflow_dispatch'
         uses: actions/upload-artifact@v4
         with:
-          name: docs-${{ github.ref_name }}-${{ github.run_id }}
+          # `/` is illegal in artifact names; branch refs like `fix/foo`
+          # must be sanitized.
+          name: docs-${{ github.run_id }}-${{ github.sha }}
           path: docs/_build/html
           retention-days: 14
 

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -65,6 +65,11 @@ autodoc_mock_imports = [
 try:
     from sphinx_polyversion import load
     from sphinx_polyversion.api import LoadError
+
+    # Importing `git` registers `GitRef` with the JSON decoder; without
+    # this, `load()` leaves `current` as a raw `__jsonclass__` dict and
+    # the `.name` access below raises AttributeError.
+    from sphinx_polyversion.git import GitRef  # noqa: F401
 except ImportError:
     pass
 else:


### PR DESCRIPTION
## Summary
- `docs/conf.py` only imported `sphinx_polyversion` + `sphinx_polyversion.api`, never `sphinx_polyversion.git` — so `GitRef` (which self-registers with the JSON decoder via a class decorator at import time) was unknown to the decoder.
- `load()` therefore left `polyversion_data["current"]` as a raw `__jsonclass__` dict, and `polyversion_data["current"].name` raised `AttributeError`, failing the Sphinx config step.
- Net effect: every push since #180 silently broke the `master` and post-#180 tag (`v0.9.14`, `v0.10.0`, `v0.10.1`) builds in `sphinx-polyversion poly.py`. Older `v0.9.x` tags pre-date the polyversion-aware conf.py and kept building, which is why gh-pages still has content but its `versions.json` + root redirect are stuck on `v0.9.13`.
- Fix: import `GitRef` (unused) so the decorator runs and the decoder reconstructs the object.

## Verification
- Reproduced locally: `from sphinx_polyversion import load; from sphinx_polyversion.api import LoadError` does not pull in `sphinx_polyversion.git`, so decoding `POLYVERSION_DATA` returns a dict.
- After the fix: same imports + decoder roundtrip returns a `GitRef` with `.name == "master"`.
- `POLYVERSION_DATA=... sphinx-build -q docs /tmp/sphinx-out` exits 0.

## Notes on existing broken tags
- `v0.9.14`, `v0.10.0`, `v0.10.1` will keep failing under the multiversion build because polyversion checks out each tag's own `conf.py`, which still has the bug. They'll be absent from `versions.json` after the next deploy. Future tags cut from a fixed master will build fine.
- Re-tagging those releases is the only way to retro-fix them, which I'd avoid unless we actually need them on the docs site.

## Test plan
- [ ] CI green
- [ ] After merge, the `Docs` workflow run on master pushes `master/` into gh-pages and updates `versions.json` + the root redirect to point at `master`

🤖 Generated with [Claude Code](https://claude.com/claude-code)