### PR TITLE
feat: dump only latest LawBook revisions by default

### DIFF
--- a/docs/data-dumps.md
+++ b/docs/data-dumps.md
@@ -18,6 +18,9 @@ Arguments:
 - `output` (positional) — directory path relative to `WORKING_DIR`.
 - `--override` — replace an existing output directory.
 - `--limit N` — cap the number of records per resource (default `0` = unlimited).
+- `--include-lawbook-revisions` — include every historical `LawBook` revision
+  (and its child `Law` rows) in the dump. By default only books with
+  `latest=True` are exported; see [Latest-only LawBooks](#latest-only-lawbooks).
 
 ## Output layout
 
@@ -56,6 +59,19 @@ state, two consecutive dump runs produce byte-identical files. This makes
 downstream snapshots (HuggingFace dataset versions, benchmark resolution
 indices) reproducible.
 
+### Latest-only LawBooks
+
+By default, only `LawBook` rows with `latest=True` are exported, and
+`laws.jsonl.gz` is filtered to laws whose parent book is the latest
+revision. This matches what the public website serves and what most
+downstream consumers (citation matching, search indexing, the public HF
+dataset) actually want.
+
+For archival or law-revision-history use cases, pass
+`--include-lawbook-revisions` to export every historical revision and its
+laws. The active filter setting is recorded in `manifest.json`'s
+`filters.include_lawbook_revisions` field.
+
 ### Self-describing manifest
 
 `manifest.json` records the snapshot identity:
@@ -64,7 +80,10 @@ indices) reproducible.
 {
   "snapshot_date": "2026-04-29T12:34:56+00:00",
   "oldp_version": "0.9.13",
-  "filters": {"review_status": "accepted"},
+  "filters": {
+    "review_status": "accepted",
+    "include_lawbook_revisions": false
+  },
   "files": {
     "cases.jsonl.gz": {"row_count": 318442},
     "laws.jsonl.gz": {"row_count": 47821},
@@ -82,9 +101,13 @@ scores or analyses remain reproducible across OLDP database growth.
 Some serializers denormalize fields that would otherwise require joining
 multiple JSONL files:
 
-- **`laws.jsonl.gz`** records carry a `book_code` field (the parent
-  `LawBook.code`) so a citation matcher can build a
-  `(book_code, slug) -> law_id` index without loading `law_books.jsonl.gz`.
+- **`laws.jsonl.gz`** records carry both `book_code` (the parent
+  `LawBook.code`, e.g., `"BGB"`) and `book_slug` (e.g., `"bgb"`) so
+  consumers can build either a `(book_code, slug) -> law_id` index for
+  citation parsing or a stable `book_slug/law_slug` canonical key
+  (e.g., `bgb/823`) without loading `law_books.jsonl.gz`. Slug-based keys
+  are recommended as the canonical target identifier in benchmarks because
+  numeric `id` values are not stable across OLDP database rebuilds.
 - **`courts.jsonl.gz`** records carry both `code` (canonical, ECLI-derived)
   and `aliases` (newline-separated alternative names like "BGH" /
   "Bundesgerichtshof") for resolving citations to a `court_id`.

--- a/oldp/apps/homepage/management/commands/dump_api_data.py
+++ b/oldp/apps/homepage/management/commands/dump_api_data.py
@@ -27,6 +27,10 @@ class Command(BaseCommand):
     Records with ``review_status`` are always filtered to ``"accepted"``
     — non-accepted records must never appear in published artifacts.
 
+    By default, only the latest revision of each ``LawBook`` (and its
+    associated ``Law`` rows) is dumped. Pass ``--include-lawbook-revisions``
+    to export every historical revision instead.
+
     Pagination iterates rows in ascending primary-key order so the same
     prod state yields a byte-stable dump across runs.
 
@@ -62,6 +66,16 @@ class Command(BaseCommand):
             help="Max. number of records per content type (default: 0, 0=unlimited)",
         )
 
+        parser.add_argument(
+            "--include-lawbook-revisions",
+            action="store_true",
+            default=False,
+            help=(
+                "Include all LawBook revisions (and their child Laws) in the "
+                "dump. By default only books with latest=True are exported."
+            ),
+        )
+
     def handle(self, *args, **opts):
         dir_path = os.path.join(settings.WORKING_DIR, opts["output"])
 
@@ -73,6 +87,8 @@ class Command(BaseCommand):
                 return
 
         os.mkdir(dir_path)
+
+        include_lawbook_revisions = opts["include_lawbook_revisions"]
 
         files_manifest = {}
         for api_register in router.registry:
@@ -92,6 +108,12 @@ class Command(BaseCommand):
             field_names = {f.name for f in model._meta.get_fields()}
             if "review_status" in field_names:
                 qs = qs.filter(review_status=self.REVIEW_STATUS_FILTER)
+
+            if not include_lawbook_revisions:
+                if model.__name__ == "LawBook":
+                    qs = qs.filter(latest=True)
+                elif model.__name__ == "Law":
+                    qs = qs.filter(book__latest=True)
 
             qs = qs.order_by("pk")
 
@@ -121,7 +143,10 @@ class Command(BaseCommand):
         manifest = {
             "snapshot_date": datetime.now(timezone.utc).isoformat(),
             "oldp_version": get_version(),
-            "filters": {"review_status": self.REVIEW_STATUS_FILTER},
+            "filters": {
+                "review_status": self.REVIEW_STATUS_FILTER,
+                "include_lawbook_revisions": include_lawbook_revisions,
+            },
             "files": files_manifest,
         }
         manifest_path = os.path.join(dir_path, "manifest.json")

--- a/oldp/apps/homepage/tests/test_commands.py
+++ b/oldp/apps/homepage/tests/test_commands.py
@@ -27,7 +27,10 @@ class DumpApiDataTestCase(TestCase):
     - Stream-gzip outputs (.jsonl.gz, not .jsonl)
     - Write a manifest.json with snapshot_date, oldp_version, filters, files
     - Iterate records in stable primary-key order
-    - Denormalize book.code into laws.jsonl.gz as `book_code`
+    - Denormalize book.code and book.slug into laws.jsonl.gz as
+      ``book_code`` / ``book_slug``
+    - Default to latest LawBook revisions only; include older revisions
+      when ``--include-lawbook-revisions`` is passed
     """
 
     fixtures = [
@@ -83,6 +86,27 @@ class DumpApiDataTestCase(TestCase):
             review_status="pending",
         )
 
+        # Older accepted LawBook revision (latest=False) plus a child Law,
+        # to exercise the latest-only default and the
+        # --include-lawbook-revisions flag.
+        cls.historic_book = LawBook.objects.create(
+            code="HistoricBook",
+            slug="historic-book",
+            title="Historic LawBook",
+            revision_date="2010-01-01",
+            latest=False,
+            order=0,
+            review_status="accepted",
+        )
+        cls.historic_law = Law.objects.create(
+            book=cls.historic_book,
+            title="Historic Law",
+            slug="historic-law",
+            section="42",
+            order=0,
+            review_status="accepted",
+        )
+
     @classmethod
     def tearDownClass(cls):
         super().tearDownClass()
@@ -94,9 +118,9 @@ class DumpApiDataTestCase(TestCase):
         with gzip.open(path, "rt", encoding="utf-8") as fh:
             return [json.loads(line) for line in fh]
 
-    def _run_dump(self):
+    def _run_dump(self, **kwargs):
         with override_settings(WORKING_DIR=self.tmp_dir):
-            call_command("dump_api_data", self.dump_subdir, override=True)
+            call_command("dump_api_data", self.dump_subdir, override=True, **kwargs)
 
     def test_dump_produces_gzip_files_and_manifest(self):
         self._run_dump()
@@ -109,6 +133,7 @@ class DumpApiDataTestCase(TestCase):
         for key in ("snapshot_date", "oldp_version", "filters", "files"):
             self.assertIn(key, manifest)
         self.assertEqual(manifest["filters"]["review_status"], "accepted")
+        self.assertFalse(manifest["filters"]["include_lawbook_revisions"])
 
         # All declared files exist as .jsonl.gz with row counts matching what's
         # actually written.
@@ -149,7 +174,7 @@ class DumpApiDataTestCase(TestCase):
             ids = [r["id"] for r in records]
             self.assertEqual(ids, sorted(ids), f"{file_name} not pk-ordered")
 
-    def test_laws_dump_contains_book_code(self):
+    def test_laws_dump_contains_book_code_and_slug(self):
         self._run_dump()
 
         records = self._read_jsonl_gz("laws.jsonl.gz")
@@ -157,3 +182,35 @@ class DumpApiDataTestCase(TestCase):
         for rec in records:
             self.assertIn("book_code", rec)
             self.assertTrue(rec["book_code"], f"Empty book_code on law {rec['id']}")
+            self.assertIn("book_slug", rec)
+            self.assertTrue(rec["book_slug"], f"Empty book_slug on law {rec['id']}")
+
+    def test_default_excludes_non_latest_lawbooks(self):
+        self._run_dump()
+
+        book_ids = {r["id"] for r in self._read_jsonl_gz("law_books.jsonl.gz")}
+        self.assertNotIn(self.historic_book.pk, book_ids)
+
+        law_ids = {r["id"] for r in self._read_jsonl_gz("laws.jsonl.gz")}
+        self.assertNotIn(self.historic_law.pk, law_ids)
+
+        # Fixtures contain other latest=False lawbooks; none should appear.
+        for rec in self._read_jsonl_gz("law_books.jsonl.gz"):
+            self.assertTrue(
+                rec.get("latest"),
+                f"Non-latest book leaked: id={rec['id']} code={rec.get('code')}",
+            )
+
+    def test_include_lawbook_revisions_flag_includes_history(self):
+        self._run_dump(include_lawbook_revisions=True)
+
+        book_ids = {r["id"] for r in self._read_jsonl_gz("law_books.jsonl.gz")}
+        self.assertIn(self.historic_book.pk, book_ids)
+
+        law_ids = {r["id"] for r in self._read_jsonl_gz("laws.jsonl.gz")}
+        self.assertIn(self.historic_law.pk, law_ids)
+
+        manifest_path = os.path.join(self.dump_path, "manifest.json")
+        with open(manifest_path, encoding="utf-8") as fh:
+            manifest = json.load(fh)
+        self.assertTrue(manifest["filters"]["include_lawbook_revisions"])

--- a/oldp/apps/laws/serializers.py
+++ b/oldp/apps/laws/serializers.py
@@ -10,6 +10,7 @@ from oldp.apps.search.api import SearchResultSerializer
 
 class LawSerializer(ReviewStatusFieldMixin, serializers.ModelSerializer):
     book_code = serializers.CharField(source="book.code", read_only=True)
+    book_slug = serializers.CharField(source="book.slug", read_only=True)
 
     class Meta:
         model = Law
@@ -17,6 +18,7 @@ class LawSerializer(ReviewStatusFieldMixin, serializers.ModelSerializer):
             "id",
             "book",
             "book_code",
+            "book_slug",
             "title",
             "content",
             "slug",


### PR DESCRIPTION
## Summary

The dump command currently exports every `LawBook` row, including all historical revisions. For downstream consumers — citation matching, search indexing, the public HuggingFace dataset — only the latest revision is meaningful, and including older ones balloons the dump for no benefit.

This PR makes latest-only the default and adds a flag to opt back in to the full history when archival use cases require it. While here, also expose `book_slug` on `LawSerializer` so consumers can build a stable canonical law identifier (`bgb/823`) from `laws.jsonl.gz` alone — useful because numeric `id` values are not stable across OLDP database rebuilds.

## Changes

- **`dump_api_data` default**: filters `LawBook` to `latest=True` and `Law` to `book__latest=True`. Pass `--include-lawbook-revisions` to disable the filter.
- **`manifest.filters.include_lawbook_revisions`** records the active mode so downstream tooling can detect which kind of snapshot it's reading.
- **`LawSerializer.book_slug`** denormalizes `book.slug`, mirroring the existing `book_code` field.
- **Tests**: extend `DumpApiDataTestCase` with a non-latest `LawBook` fixture and three new assertions — default exclusion of non-latest books and their child laws, opt-in inclusion via the flag, and `book_slug` presence on every law record.
- **Docs**: `docs/data-dumps.md` documents the new flag, the latest-only default, and the recommendation to use slug-based keys (`bgb/823`) over numeric ids in benchmarks.

## Compatibility

- `oldp-toolkit` only consumes `cases.jsonl.gz`, ignores extra files, ignores unknown fields, and ignores `manifest.json` — all changes here are invisible to it.
- Adding `book_slug` to the `LawSerializer` is additive on the public REST API.
- The latest-only default narrows what's in `law_books.jsonl.gz` / `laws.jsonl.gz` for unflagged dumps — anyone currently relying on revision history needs to add `--include-lawbook-revisions` to their dump invocation.

## Test plan

- [x] `make lint` clean for changed files
- [x] `manage.py test oldp.apps.homepage.tests.test_commands` — 7 tests pass
- [x] `manage.py test oldp.apps.laws oldp.apps.courts oldp.apps.cases.tests oldp.api` — 577 tests pass
- [x] CI green

🤖 Generated with [Claude Code](https://claude.com/claude-code)