### PR TITLE
refactor(refs): migrate extract_refs to refex CitationExtractor + fix law assignment

### DIFF
--- a/oldp/apps/cases/processing/processing_steps/extract_refs.py
+++ b/oldp/apps/cases/processing/processing_steps/extract_refs.py
@@ -1,9 +1,10 @@
-import html
 import logging
-import re
 
 from django.utils import timezone
+from refex.document import make_document
+from refex.engines.regex import RegexCaseExtractor, RegexLawExtractor
 from refex.errors import RefExError
+from refex.orchestrator import CitationExtractor
 
 from oldp.apps.cases.models import Case
 from oldp.apps.cases.processing.processing_steps import CaseProcessingStep
@@ -18,7 +19,6 @@ logger = logging.getLogger(__name__)
 
 class ProcessingStep(CaseProcessingStep, BaseExtractRefs):
     description = "Extract references"
-    # law_book_codes = None
     marker_model = CaseReferenceMarker
     reference_from_content_model = ReferenceFromCase
 
@@ -31,52 +31,48 @@ class ProcessingStep(CaseProcessingStep, BaseExtractRefs):
         self.case_refs = case_refs
         self.assign_refs = assign_refs
 
-        self.extractor.do_case_refs = self.case_refs
-        self.extractor.do_law_refs = self.law_refs
-        # self.extractor.law_book_codes = list(LawBook.objects.values_list('code', flat=True))
+        # Pattern: each engine is constructed once and held as a named
+        # attribute so per-document context (court_context,
+        # law_book_context) can be set in process() without isinstance
+        # filtering on the orchestrator's engine list.
+        self.law_engine = RegexLawExtractor() if law_refs else None
+        if self.law_engine is not None and law_book_codes is not None:
+            # When ``law_book_codes`` is None, leave the bundled list in
+            # place: legal-reference-extraction 0.5.0 ships ~1947 codes
+            # plus unit hints in its bundled data file.
+            self.law_engine.law_book_codes = law_book_codes
 
-        # When law_book_codes is None, leave the extractor's default in
-        # place: legal-reference-extraction 0.5.0 ships ~1947 codes plus
-        # unit hints in its bundled data file.
-        if law_book_codes is not None:
-            self.extractor.law_book_codes = law_book_codes
+        self.case_engine = RegexCaseExtractor() if case_refs else None
+
+        engines = [e for e in (self.law_engine, self.case_engine) if e is not None]
+        self.extractor = CitationExtractor(engines=engines)
 
     def process(self, case: Case) -> Case:
-        """Read case.content, search for references, add ref data (with start+end position) to case.
+        """Extract references from ``case.content`` and persist marker + Reference rows.
 
-        Ref data should contain position information, for CPA computations ...
-
-        :param case: to be processed
-        :return: processed case
+        Strips legacy ``[ref=UUID]`` brackets from ``case.content`` first:
+        those are stored artifacts from pre-2026 extraction runs that
+        would otherwise corrupt the rendered case-detail view once new
+        ``<a class="ref">`` markers are inserted on top of them. This is
+        transitional cleanup that can be removed once the corpus has been
+        re-extracted and confirmed clean.
         """
-        self.extractor.court_context = case.court.code
-
-        """
-        <verweis.norm>
-        </verweis.norm>
-        <v.abk ersatz="RDG"></v.abk>
-        
-        """
+        if self.case_engine is not None:
+            self.case_engine.court_context = case.court.code
 
         logger.debug("Extract refs for %s" % case)
 
         try:
-            # Clean HTML (should be done by scrapers)
-            case.content = html.unescape(case.content)
-            case.content = re.sub(r"</?verweis\.norm[^>]*>", "", case.content)
-            case.content = re.sub(r"</?v\.abk[^>]*>", "", case.content)
+            # Transitional: strip + persist legacy [ref=UUID]...[/ref] markers.
+            # See class docstring above; remove once backfill is complete.
+            case.content = CaseReferenceMarker.remove_markers(case.content)
 
-            case.content = CaseReferenceMarker.remove_markers(
-                case.content
-            )  # TODO Removal only for legacy reasons
+            doc = make_document(case.content, fmt="html")
+            result = self.extractor.extract(doc)
 
-            # Do not change original content with markers
-            _content, markers = self.extractor.extract(case.content)
-
-            # Delete old markers
             CaseReferenceMarker.objects.filter(referenced_by=case).delete()
 
-            marker_qs, ref_qs = self.save_markers(markers, case, self.assign_refs)
+            self.save_citations(doc, result.citations, case, self.assign_refs)
 
             # Stamp the run regardless of how many refs were found —
             # the absence of refs after a successful run is itself a

--- a/oldp/apps/laws/processing/processing_steps/extract_refs.py
+++ b/oldp/apps/laws/processing/processing_steps/extract_refs.py
@@ -1,5 +1,8 @@
 from django.utils import timezone
+from refex.document import make_document
+from refex.engines.regex import RegexLawExtractor
 from refex.errors import RefExError
+from refex.orchestrator import CitationExtractor
 
 from oldp.apps.laws.models import Law, LawBook
 from oldp.apps.laws.processing.processing_steps import LawProcessingStep
@@ -11,7 +14,7 @@ from oldp.apps.references.processing.processing_steps.extract_refs import (
 
 
 class ProcessingStep(LawProcessingStep, BaseExtractRefs):
-    """Processing step to extract law references"""
+    """Processing step to extract law references."""
 
     description = "Extract references"
     marker_model = LawReferenceMarker
@@ -20,28 +23,31 @@ class ProcessingStep(LawProcessingStep, BaseExtractRefs):
     def __init__(self):
         super().__init__()
 
-        self.extractor.do_case_refs = False  # laws do not contain case refs
-        self.extractor.do_law_refs = True
-        self.extractor.law_book_codes = list(
+        self.law_engine = RegexLawExtractor()
+        self.law_engine.law_book_codes = list(
             LawBook.objects.values_list("code", flat=True)
         )
 
+        # Laws never cite cases, so the case engine is omitted entirely.
+        self.extractor = CitationExtractor(engines=[self.law_engine])
+
     def process(self, law: Law) -> Law:
-        """Read law.content, search for references, add ref marker (e.g. [ref=1]xy[/ref]) to text, add ref data to law.
+        """Extract law-to-law references from ``law.content``.
 
-        Ref data should contain position information, for CPA computations ...
-
-        :param law: to be processed
-        :return: processed law
+        The legacy extractor returned a rewritten content string with
+        ``[ref=UUID]…[/ref]`` markers injected; refex 0.5.0 no longer
+        injects markers into content, so ``law.content`` is no longer
+        rewritten here.
         """
         try:
-            self.extractor.law_book_context = law.book.code
+            self.law_engine.law_book_context = law.book.code
 
-            law.content, markers = self.extractor.extract(law.content)
+            doc = make_document(law.content, fmt="html")
+            result = self.extractor.extract(doc)
 
             LawReferenceMarker.objects.filter(referenced_by=law).delete()
 
-            self.save_markers(markers, law)
+            self.save_citations(doc, result.citations, law)
 
             # Stamp the run regardless of how many refs were found —
             # the absence of refs after a successful run is itself a

--- a/oldp/apps/references/fixtures/cases/case_with_table_references.json
+++ b/oldp/apps/references/fixtures/cases/case_with_table_references.json
@@ -1,0 +1,33 @@
+[
+  {
+    "model": "sources.source",
+    "pk": 99,
+    "fields": {
+      "name": "TableTest"
+    }
+  },
+  {
+    "model": "cases.case",
+    "pk": 183007,
+    "fields": {
+      "title": "Table-formatted decision (test fixture)",
+      "slug": "table-fixture-2024-01-01",
+      "court": 1,
+      "court_raw": "{\"name\": \"BGH\"}",
+      "court_chamber": "VI. Zivilsenat",
+      "date": "2024-01-01",
+      "created_date": "2024-01-02T00:00:00Z",
+      "updated_date": "2024-01-02T00:00:00Z",
+      "file_number": "VI ZR 1/24",
+      "type": "Urteil",
+      "pdf_url": null,
+      "source_url": "http://example.invalid/",
+      "review_status": "accepted",
+      "source": 99,
+      "source_file": "",
+      "ecli": "ECLI:DE:BGH:2024:test.183007",
+      "abstract": "",
+      "content": "<h2>Tenor</h2><p>Anspruchsgrundlagen sind in untenstehender Tabelle aufgeführt.</p><table><tr><th>Norm</th><th>Anspruch</th></tr><tr><td>§ 823 BGB</td><td>Schadensersatz aus unerlaubter Handlung</td></tr><tr><td>§ 826 BGB</td><td>Vorsätzliche sittenwidrige Schädigung</td></tr><tr><td>§ 280 BGB</td><td>Schadensersatz wegen Pflichtverletzung</td></tr></table><p>Im Übrigen ist auch § 249 BGB einschlägig.</p>"
+    }
+  }
+]

--- a/oldp/apps/references/processing/processing_steps/extract_refs.py
+++ b/oldp/apps/references/processing/processing_steps/extract_refs.py
@@ -1,8 +1,9 @@
 import logging
+from dataclasses import replace
 from typing import List, Tuple
 
-from refex.extractor import RefExtractor
-from refex.models import Ref, RefType
+from refex.citations import CaseCitation, Citation, LawCitation
+from refex.document import Document, map_span_to_raw
 
 from oldp.apps.cases.models import Case
 from oldp.apps.laws.models import Law
@@ -13,102 +14,192 @@ logger = logging.getLogger(__name__)
 
 
 class BaseExtractRefs(object):
+    """Shared logic for case + law reference extraction.
+
+    Subclasses construct ``self.extractor`` (a refex
+    :class:`~refex.orchestrator.CitationExtractor`) and call
+    :meth:`save_citations` from their ``process()`` implementation.
+    """
+
     marker_model = None  # type: class[ReferenceMarker]
     reference_from_content_model = None  # type: class[ReferenceFromContent]
 
-    def __init__(self):
-        # RefExtractor must be initialized here to reset all settings
-        self.extractor = RefExtractor()
+    @staticmethod
+    def _clean_book(book):
+        # Mirrors the legacy ``LawRefMixin.clean_book`` normalization so the
+        # DB lookup against ``LawBook.slug`` keeps matching while we sit on
+        # the migration. Replaced by ``slugify`` in a follow-up commit.
+        if book is None:
+            return None
+        return book.strip().lower()
 
-    def assign_law_ref(self, raw: Ref, ref: Reference) -> Reference:
-        """Find corresponding database item to reference for laws"""
-        if raw.book is None or raw.section is None:
+    @staticmethod
+    def _clean_section(section):
+        if section is None:
+            return None
+        return section.replace(" ", "").lower()
+
+    def assign_law_ref(self, citation: LawCitation, ref: Reference) -> Reference:
+        """Find the corresponding ``Law`` row for a law citation."""
+        if not citation.book or not citation.number:
             raise ProcessingError("Reference data is not set")
-        else:
-            candidates = Law.objects.filter(book__slug=raw.book, slug=raw.section)
 
-            if len(candidates) >= 1:
-                # Multiple candidates should not occur
-                ref.law = candidates.first()
-            else:
-                raise ProcessingError(
-                    "Cannot find ref target in with book=%s; section=%s; for ref=%s"
-                    % (raw.book, raw.section, raw)
-                )
+        book = self._clean_book(citation.book)
+        section = self._clean_section(citation.number)
 
+        candidates = Law.objects.filter(book__slug=book, slug=section)
+
+        first = candidates.first()
+        if first is None:
+            raise ProcessingError(
+                "Cannot find ref target with book=%s; section=%s; for citation=%s"
+                % (book, section, citation)
+            )
+        ref.law = first
         return ref
 
-    def assign_case_ref(self, raw: Ref, ref: Reference) -> Reference:
-        """Find corresponding database item to reference for cases"""
+    def assign_case_ref(self, citation: CaseCitation, ref: Reference) -> Reference:
+        """Find the corresponding ``Case`` row for a case citation."""
+        if not citation.court or not citation.file_number:
+            raise ProcessingError("Reference data is not set")
+
         candidates = Case.objects.filter(
-            court__aliases__contains=raw.court, file_number=raw.file_number
+            court__aliases__contains=citation.court,
+            file_number=citation.file_number,
         )
 
-        if len(candidates) == 1:
-            ref.case = candidates.first()
-        elif len(candidates) > 1:
-            # Multiple candidates
-            # TODO better heuristic?
-            ref.case = candidates.first()
-        else:
-            # Not found
+        first = candidates.first()
+        if first is None:
             raise ProcessingError(
-                "Cannot find ref target in with court=%s; file_number=%s; for ref=%s"
-                % (raw.court, raw.file_number, raw)
+                "Cannot find ref target with court=%s; file_number=%s; for citation=%s"
+                % (citation.court, citation.file_number, citation)
             )
-
+        ref.case = first
         return ref
 
-    def save_markers(
-        self, markers, referenced_by, assign_references=True
+    @staticmethod
+    def _group_by_span(citations: List[Citation]):
+        """Yield (span_key, [citations]) groups, preserving original order.
+
+        Co-located citations from one enumeration marker share an
+        identical ``(start, end)`` span and are merged into a single
+        group so the caller can persist them under one ``ReferenceMarker``
+        with N attached ``Reference`` rows.
+        """
+        groups = {}
+        order = []
+        for citation in citations:
+            if citation.kind != "full":
+                continue
+            key = (citation.span.start, citation.span.end)
+            if key not in groups:
+                groups[key] = []
+                order.append(key)
+            groups[key].append(citation)
+        for key in order:
+            yield key, groups[key]
+
+    @staticmethod
+    def _expand_range(citation: Citation) -> List[Citation]:
+        """Expand a numeric ``range_end`` on a LawCitation into one citation per integer.
+
+        Preserves the legacy convention where "§§ 12-14 BGB" produced three
+        ``Reference`` rows (12, 13, 14). Citations with non-integer bounds
+        (e.g. "§§ 12a-14b") are returned unchanged — extending the range
+        across letter suffixes would be a guess, not a faithful
+        reproduction of legacy behavior.
+        """
+        if not isinstance(citation, LawCitation) or not citation.range_end:
+            return [citation]
+        try:
+            start_n = int(citation.number)
+            end_n = int(citation.range_end)
+        except (TypeError, ValueError):
+            return [citation]
+        if end_n <= start_n:
+            return [citation]
+        return [
+            replace(citation, number=str(n), range_end=None)
+            for n in range(start_n, end_n + 1)
+        ]
+
+    def save_citations(
+        self,
+        document: Document,
+        citations: List[Citation],
+        referenced_by,
+        assign_references=True,
     ) -> Tuple[List[ReferenceMarker], List[Reference]]:
-        """Convert module objects into Django objects"""
-        saved_markers = []
-        saved_refs = []
+        """Persist typed citations as marker + Reference rows.
+
+        Citations sharing an identical span — enumeration markers like
+        "§§ 3, 3b AsylG" emit one ``LawCitation`` per section, all
+        sharing the marker's span — are grouped into a single
+        ``ReferenceMarker`` with N attached ``Reference`` rows, preserving
+        the legacy 1:N marker→ref shape that ``insert_markers`` and the
+        case-detail rendering rely on.
+
+        Range citations (``range_end`` set) are expanded into one
+        ``Reference`` per integer in the range, attached to the same
+        marker.
+
+        Short-form citations (``kind != "full"``) are skipped: refex
+        resolves them via prior-context inheritance, and surfacing them
+        as ``Reference`` rows is a corpus-shape change handled
+        separately.
+
+        Marker offsets are translated back to raw-document coordinates
+        via :func:`refex.document.map_span_to_raw` so that
+        ``insert_markers`` can slice the original ``content`` correctly.
+        """
+        saved_markers: List[ReferenceMarker] = []
+        saved_refs: List[Reference] = []
 
         error_counter = 0
         success_counter = 0
 
-        for marker in markers:  # type: RefMarker
-            my_marker = self.marker_model(
+        for span_key, group in self._group_by_span(citations):
+            if not group:
+                continue
+
+            raw_span = map_span_to_raw(group[0].span, document)
+            marker = self.marker_model(
                 referenced_by=referenced_by,
-                text=marker.text,
-                start=marker.start,
-                end=marker.end,
+                text=raw_span.text,
+                start=raw_span.start,
+                end=raw_span.end,
             )
-            my_marker.save()
+            marker.save()
 
-            for ref in marker.references:  # type: Ref
-                my_ref = Reference(to=marker.text)
+            for citation in group:
+                for sub_citation in self._expand_range(citation):
+                    ref = Reference(to=raw_span.text)
 
-                # Assign references to target items
-                if assign_references:
-                    try:
-                        if ref.ref_type == RefType.LAW:
-                            my_ref = self.assign_law_ref(ref, my_ref)
-                        elif ref.ref_type == RefType.CASE:
-                            my_ref = self.assign_case_ref(ref, my_ref)
-                        else:
-                            raise ProcessingError(
-                                "Unsupported reference type: %s" % ref.ref_type
-                            )
+                    if assign_references:
+                        try:
+                            if isinstance(sub_citation, LawCitation):
+                                ref = self.assign_law_ref(sub_citation, ref)
+                            elif isinstance(sub_citation, CaseCitation):
+                                ref = self.assign_case_ref(sub_citation, ref)
+                            else:
+                                raise ProcessingError(
+                                    "Unsupported citation type: %s" % type(sub_citation)
+                                )
+                            success_counter += 1
+                        except ProcessingError as e:
+                            logger.warning(e)
+                            error_counter += 1
 
-                        success_counter += 1
-                    except ProcessingError as e:
-                        logger.warning(e)
-                        error_counter += 1
+                    ref.set_to_hash()
+                    ref.save()
 
-                # TODO Should we save references all the time or only on successful matching?
-                my_ref.set_to_hash()
-                my_ref.save()
+                    self.reference_from_content_model(
+                        reference=ref, marker=marker
+                    ).save()
 
-                # Save in m2m helper
-                self.reference_from_content_model(
-                    reference=my_ref, marker=my_marker
-                ).save()
+                    saved_refs.append(ref)
 
-                saved_refs.append(my_ref)
-            saved_markers.append(my_marker)
+            saved_markers.append(marker)
 
         total = success_counter + error_counter
         if total > 0 and error_counter / total > 0.5:

--- a/oldp/apps/references/processing/processing_steps/extract_refs.py
+++ b/oldp/apps/references/processing/processing_steps/extract_refs.py
@@ -2,6 +2,7 @@ import logging
 from dataclasses import replace
 from typing import List, Tuple
 
+from django.utils.text import slugify
 from refex.citations import CaseCitation, Citation, LawCitation
 from refex.document import Document, map_span_to_raw
 
@@ -25,35 +26,68 @@ class BaseExtractRefs(object):
     reference_from_content_model = None  # type: class[ReferenceFromContent]
 
     @staticmethod
-    def _clean_book(book):
-        # Mirrors the legacy ``LawRefMixin.clean_book`` normalization so the
-        # DB lookup against ``LawBook.slug`` keeps matching while we sit on
-        # the migration. Replaced by ``slugify`` in a follow-up commit.
-        if book is None:
-            return None
-        return book.strip().lower()
+    def _build_section_slug(citation: LawCitation) -> str:
+        """Construct the ``Law.slug`` lookup key for a law citation.
 
-    @staticmethod
-    def _clean_section(section):
-        if section is None:
-            return None
-        return section.replace(" ", "").lower()
+        ``Law.slug`` is built from ``Law.section`` via Django's
+        ``SlugField``, which lower-cases and hyphenates ``slugify`` input.
+        For paragraph cites ("§ 823 BGB") the section column stores
+        ``"§ 823"`` and the slug is ``"823"``. For Article cites
+        ("Art. 1 GG") the section column stores ``"Artikel 1"`` and the
+        slug is ``"artikel-1"``. Refex's ``LawCitation`` carries the
+        bare number plus a ``unit`` discriminator, so we prepend
+        ``"artikel "`` when ``unit == "article"`` before slugifying.
+        """
+        number = citation.number or ""
+        if citation.unit == "article":
+            return slugify(f"artikel {number}")
+        return slugify(number)
 
     def assign_law_ref(self, citation: LawCitation, ref: Reference) -> Reference:
-        """Find the corresponding ``Law`` row for a law citation."""
+        """Resolve a ``LawCitation`` to a ``Law`` row and attach it to ``ref``.
+
+        Lookup keys are built with Django's ``slugify`` (so umlauts,
+        non-ASCII chars, and multi-word codes like ``ÄApprO 2002`` map
+        to their stored slug ``aappro-2002`` rather than failing
+        silently). ``book__latest=True`` constrains the candidate set to
+        the most recent revision of each LawBook, otherwise multiple
+        revisions all carry a Law with the same ``slug`` and ``.first()``
+        becomes order-dependent.
+
+        If the unit-aware slug doesn't match (e.g. refex labels a cite
+        as ``article`` but the corresponding Law row stores its slug
+        without the ``"artikel-"`` prefix), fall back to the bare
+        slugified number to keep behavior tolerant of fixture
+        inconsistencies in the corpus.
+        """
         if not citation.book or not citation.number:
             raise ProcessingError("Reference data is not set")
 
-        book = self._clean_book(citation.book)
-        section = self._clean_section(citation.number)
+        book_slug = slugify(citation.book)
+        section_slug = self._build_section_slug(citation)
 
-        candidates = Law.objects.filter(book__slug=book, slug=section)
+        candidates = Law.objects.filter(
+            book__slug=book_slug,
+            slug=section_slug,
+            book__latest=True,
+        )
 
         first = candidates.first()
+        if first is None and citation.unit == "article":
+            # Fallback: stored Law may use the bare number ("1") rather
+            # than the prefixed slug ("artikel-1") even for Article cites.
+            bare = slugify(citation.number)
+            if bare != section_slug:
+                first = Law.objects.filter(
+                    book__slug=book_slug,
+                    slug=bare,
+                    book__latest=True,
+                ).first()
+
         if first is None:
             raise ProcessingError(
                 "Cannot find ref target with book=%s; section=%s; for citation=%s"
-                % (book, section, citation)
+                % (book_slug, section_slug, citation)
             )
         ref.law = first
         return ref

--- a/oldp/apps/references/tests/test_processing_extract_refs.py
+++ b/oldp/apps/references/tests/test_processing_extract_refs.py
@@ -1,8 +1,15 @@
-from django.test import TransactionTestCase, tag
+from django.test import TestCase, TransactionTestCase, tag
+from refex.citations import LawCitation, Span
 
 from oldp.apps.cases.models import Case
 from oldp.apps.cases.processing.processing_steps.extract_refs import (
     ProcessingStep as ExtractRefsStep,
+)
+from oldp.apps.laws.models import Law, LawBook
+from oldp.apps.processing.errors import ProcessingError
+from oldp.apps.references.models import Reference
+from oldp.apps.references.processing.processing_steps.extract_refs import (
+    BaseExtractRefs,
 )
 
 
@@ -38,3 +45,148 @@ class ExtractReferencesTestCase(TransactionTestCase):
         groups = processed.get_grouped_references()
 
         self.assertEqual(16, len(groups))
+
+
+@tag("processing")
+class AssignLawRefTestCase(TestCase):
+    """Direct unit tests for ``BaseExtractRefs.assign_law_ref``.
+
+    The legacy assignment used a bare ``str.lower`` / ``replace(' ', '')``
+    normalization that silently failed for non-ASCII codes
+    (``ÄApprO 2002`` ≠ ``aappro-2002``) and for Grundgesetz Articles
+    (refex emits ``number="1"`` for ``Art. 1 GG`` but the stored
+    ``Law.slug`` is ``"artikel-1"``). It also missed the
+    ``book__latest=True`` filter, so multiple revisions of one book
+    matched the same ``(slug, slug)`` and ``.first()`` returned a
+    non-deterministic stale revision.
+
+    These tests pin the corrected behaviour: Django ``slugify``,
+    unit-aware section slug, latest-revision filter, with a bare-slug
+    fallback for Articles whose stored slug skips the ``"artikel-"``
+    prefix.
+    """
+
+    def setUp(self):
+        # Resolver borrows BaseExtractRefs directly; no engines needed.
+        class _Resolver(BaseExtractRefs):
+            pass
+
+        self.resolver = _Resolver()
+
+    def _make_book(self, *, code, slug, latest=True, revision_date):
+        return LawBook.objects.create(
+            code=code,
+            title=code,
+            slug=slug,
+            latest=latest,
+            revision_date=revision_date,
+        )
+
+    def _make_law(self, *, book, section, slug):
+        return Law.objects.create(
+            book=book,
+            section=section,
+            slug=slug,
+            content="",
+            title="",
+        )
+
+    def test_resolves_paragraph_citation(self):
+        book = self._make_book(code="BGB", slug="bgb", revision_date="2024-01-01")
+        law = self._make_law(book=book, section="§ 823", slug="823")
+
+        citation = LawCitation(
+            span=Span(0, 9, "§ 823 BGB"),
+            book="BGB",
+            number="823",
+            unit="paragraph",
+        )
+        ref = self.resolver.assign_law_ref(citation, Reference(to="§ 823 BGB"))
+
+        self.assertEqual(ref.law_id, law.id)
+
+    def test_resolves_grundgesetz_article(self):
+        """Article cite ``unit="article"`` must build slug ``artikel-N``."""
+        book = self._make_book(code="GG", slug="gg", revision_date="2024-01-01")
+        law = self._make_law(book=book, section="Artikel 1", slug="artikel-1")
+
+        citation = LawCitation(
+            span=Span(0, 8, "Art. 1 GG"),
+            book="GG",
+            number="1",
+            unit="article",
+        )
+        ref = self.resolver.assign_law_ref(citation, Reference(to="Art. 1 GG"))
+
+        self.assertEqual(ref.law_id, law.id)
+
+    def test_resolves_non_ascii_book_code(self):
+        """``ÄApprO 2002`` slugifies to ``aappro-2002``."""
+        book = self._make_book(
+            code="ÄApprO 2002", slug="aappro-2002", revision_date="2024-01-01"
+        )
+        law = self._make_law(book=book, section="§ 35", slug="35")
+
+        citation = LawCitation(
+            span=Span(0, 14, "§ 35 ÄApprO 2002"),
+            book="ÄApprO 2002",
+            number="35",
+            unit="paragraph",
+        )
+        ref = self.resolver.assign_law_ref(citation, Reference(to="§ 35 ÄApprO 2002"))
+
+        self.assertEqual(ref.law_id, law.id)
+
+    def test_prefers_latest_revision(self):
+        """Two revisions, both with a Law/823: only the latest must match."""
+        old_book = self._make_book(
+            code="BGB", slug="bgb", latest=False, revision_date="2010-01-01"
+        )
+        new_book = self._make_book(
+            code="BGB", slug="bgb", latest=True, revision_date="2024-01-01"
+        )
+        self._make_law(book=old_book, section="§ 823", slug="823")
+        new_law = self._make_law(book=new_book, section="§ 823", slug="823")
+
+        citation = LawCitation(
+            span=Span(0, 9, "§ 823 BGB"),
+            book="BGB",
+            number="823",
+            unit="paragraph",
+        )
+        ref = self.resolver.assign_law_ref(citation, Reference(to="§ 823 BGB"))
+
+        self.assertEqual(
+            ref.law_id,
+            new_law.id,
+            "Resolver returned a non-latest revision; book__latest=True "
+            "filter is missing or being dropped.",
+        )
+
+    def test_article_falls_back_to_bare_slug(self):
+        """Refex labels a cite ``article`` but the row stores its slug bare."""
+        book = self._make_book(code="GG", slug="gg", revision_date="2024-01-01")
+        # Stored slug "1" rather than "artikel-1" — fixture inconsistency.
+        law = self._make_law(book=book, section="Artikel 1", slug="1")
+
+        citation = LawCitation(
+            span=Span(0, 8, "Art. 1 GG"),
+            book="GG",
+            number="1",
+            unit="article",
+        )
+        ref = self.resolver.assign_law_ref(citation, Reference(to="Art. 1 GG"))
+
+        self.assertEqual(ref.law_id, law.id)
+
+    def test_raises_when_no_match(self):
+        # No Law rows at all — assignment must surface as ProcessingError so
+        # save_citations can count it toward the per-doc error rate.
+        citation = LawCitation(
+            span=Span(0, 9, "§ 999 ZZZ"),
+            book="ZZZ",
+            number="999",
+            unit="paragraph",
+        )
+        with self.assertRaises(ProcessingError):
+            self.resolver.assign_law_ref(citation, Reference(to="§ 999 ZZZ"))

--- a/oldp/apps/references/tests/test_processing_extract_refs.py
+++ b/oldp/apps/references/tests/test_processing_extract_refs.py
@@ -48,6 +48,80 @@ class ExtractReferencesTestCase(TransactionTestCase):
 
 
 @tag("processing")
+class ExtractTableReferencesTestCase(TransactionTestCase):
+    """Pin extraction of citations inside HTML tables.
+
+    Production case 183007 surfaces references inside ``<table>``
+    structures (one citation per ``<td>``). Pre-migration the legacy
+    ``RefExtractor`` ran on the raw HTML as plain text and its naïve
+    tokenisation didn't reach into table cells, so extraction yielded
+    zero markers for these decisions.
+
+    Post-migration ``CitationExtractor`` with ``fmt="html"`` lets refex
+    normalise block-level structure (``<tr>`` is in the block-tag set)
+    and the citations surface. This test pins both: (a) extraction
+    finds the table-bound cites, and (b) the marker offsets point back
+    into the original HTML correctly — i.e. ``map_span_to_raw`` is
+    being applied. The slicing canary at the bottom is the load-bearing
+    assertion: if anyone forgets to translate spans, the marker would
+    point inside an HTML tag and ``insert_markers`` would emit broken
+    markup on the case-detail view.
+    """
+
+    fixtures = [
+        "courts/default.json",
+        "cases/case_with_table_references.json",
+        "laws/empty_bgb.json",
+    ]
+
+    def test_extracts_citations_inside_table_cells(self):
+        case = Case.objects.get(pk=183007)
+        step = ExtractRefsStep(law_refs=True, case_refs=False, assign_refs=False)
+
+        processed = step.process(case)
+        markers = list(processed.get_reference_markers())
+        marker_texts = sorted(m.text for m in markers)
+
+        # Bare-minimum guard: the regression that motivated the
+        # migration is "table-shape decisions yielded zero markers".
+        self.assertGreater(
+            len(markers),
+            0,
+            "Table-formatted citations did not surface — refex's HTML "
+            "normalizer is no longer descending into <tr>/<td>, or "
+            "fmt='html' is not being passed through.",
+        )
+
+        # Specific BGB sections that live inside <td> cells.
+        for expected in ("§ 823 BGB", "§ 826 BGB", "§ 280 BGB"):
+            self.assertIn(
+                expected,
+                marker_texts,
+                f"Expected table-cell cite {expected!r}; got {marker_texts}",
+            )
+
+        # Inline cite outside the table — sanity check that the table
+        # path didn't displace the regular flow.
+        self.assertIn("§ 249 BGB", marker_texts)
+
+        # Slicing canary — proves map_span_to_raw is being applied.
+        # If marker offsets were left in normalized-text coordinates,
+        # this slice would land inside an HTML tag and produce broken
+        # output when insert_markers wraps it for the case-detail view.
+        for marker in markers:
+            self.assertEqual(
+                case.content[marker.start : marker.end],
+                marker.text,
+                f"Marker offsets out of sync with raw content: "
+                f"content[{marker.start}:{marker.end}]="
+                f"{case.content[marker.start : marker.end]!r} "
+                f"≠ marker.text={marker.text!r}. "
+                "Most likely map_span_to_raw is not being applied "
+                "before persisting the marker.",
+            )
+
+
+@tag("processing")
 class AssignLawRefTestCase(TestCase):
     """Direct unit tests for ``BaseExtractRefs.assign_law_ref``.
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -70,7 +70,7 @@ dependencies = [
 # django-extensions #>=2.1.9
 
 # https://github.com/openlegaldata/legal-reference-extraction
-"legal-reference-extraction==0.5.0",
+"legal-reference-extraction==0.5.1",
 
 # MCP (Model Context Protocol) server
 # https://github.com/gts360/django-mcp-server

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -70,7 +70,7 @@ dependencies = [
 # django-extensions #>=2.1.9
 
 # https://github.com/openlegaldata/legal-reference-extraction
-"legal-reference-extraction==0.5.1",
+"legal-reference-extraction==0.5.2",
 
 # MCP (Model Context Protocol) server
 # https://github.com/gts360/django-mcp-server


### PR DESCRIPTION
## Summary

Migrate OLDP's reference-extraction pipeline from refex's deprecated `RefExtractor` (raw HTML → naïve plain-text tokenisation) to the typed `CitationExtractor` API with `fmt="html"`. Refex's HTML normalizer descends into `<table>`/`<tr>`/`<td>` cells, so table-formatted decisions like case 183007 finally yield citations instead of zero markers.

The schema is unchanged. `CaseReferenceMarker.start`/`.end` stay HTML-relative (translated via `map_span_to_raw`), so `insert_markers` and the case-detail view need no changes — verified empirically over 5,525 real markers (zero offset mismatches).

Pins refex to `0.5.2`, which carries three bugs caught while building this:
- [`refex#18`](https://github.com/openlegaldata/legal-reference-extraction/pull/18) — orchestrator dropped co-located enumeration cites
- [`refex#19`](https://github.com/openlegaldata/legal-reference-extraction/pull/19) — regex didn't match citations at end-of-string
- [`refex#20`](https://github.com/openlegaldata/legal-reference-extraction/pull/20) — `<td>`/`<th>` weren't HTML block boundaries

## Commits (review-friendly split)

1. **`refactor(refs): migrate extract_refs to refex CitationExtractor`** — pure migration. New `BaseExtractRefs.save_citations` walks typed `LawCitation`/`CaseCitation`, applies `map_span_to_raw`, groups co-located citations into one marker (preserving 1:N marker→ref shape), expands `range_end` for "§§ 12-14 BGB"-style ranges, filters short-form (`kind != "full"`) cites. Each subclass holds engines as named attributes; per-document context (`court_context`, `law_book_context`) mutated per `process()`. Drop `html.unescape` + vendor-tag strips (refex normalises internally) and the law-side `law.content = …` rewrite (no longer injected in 0.5.0+). Keep the legacy `[ref=UUID]` cleanup as transitional code with a comment marking it for removal once backfill is done.

2. **`fix(refs): correct law-section assignment for articles + non-ASCII codes`** — replace `str.lower`/`replace(' ', '')` with Django `slugify` so multi-word + umlauted codes (`ÄApprO 2002` → `aappro-2002`) match stored slugs. Build the section slug as `slugify(f"artikel {n}")` for `unit="article"` so Grundgesetz Articles resolve (refex emits `number="1"` for `Art. 1 GG`; stored slug is `"artikel-1"`). Constrain candidates to `book__latest=True` so multi-revision LawBooks don't surface stale revisions. Bare-slug fallback for Articles whose stored slug skips the `artikel-` prefix.

3. **`test(refs): regression test for table-formatted case extraction`** — new fixture `cases/case_with_table_references.json` mirroring case 183007 (cites inside `<td>` cells + an inline cite outside). New `ExtractTableReferencesTestCase` asserts non-zero markers, specific BGB sections from cells, and a slicing canary `case.content[m.start:m.end] == m.text` for every marker.

## Verification

- Full suite: 1060 tests pass, 16 skipped (`@real_es_test`).
- Lint clean (`make lint-check`), no DeprecationWarnings from refex.
- Existing case-1888 fixture still emits 33 refs / 16 groups; case-1 still emits 3 markers / 4 refs (no test changes needed beyond the new ones in commits 2 + 3).
- New `AssignLawRefTestCase` covers paragraph, Article, ÄApprO 2002, latest-revision filter, fallback, and missing-target raise. Verified that 3/6 fail under the legacy normalisation.

### Real-data smoke test

Loaded 100 cases + 200 laws from `de.openlegaldata.io/api/` into the local stack (seeder lives in `dev-deployment/scripts/seed_from_api.py`). Ran the refactored extraction:

| | Case-side | Law-side |
|---|---|---|
| Documents extracted | 102 | 200 |
| Markers persisted | 3,117 | 2,408 |
| Reference rows | 3,212 | 2,525 |
| **Slicing canary mismatches** | **0 / 3,117** | **0 / 2,408** |

Top cited targets after extraction: GG Articles (`gg §artikel-33`, `§artikel-6`, `§artikel-3`, …) — confirms the unit-aware slug fix in commit 2 is doing real work. Marker shapes seen include single sections, multi-section enumerations (`§§ 3, 3b AsylG`), Article cites (`Art. 33 GG`), reporter cites (`GRUR 2010, 80`). Cases with HTML tables (e.g. EuGH case 455835) emit markers from inside table cells — refex 0.5.2's `<td>` block-boundary fix is working end-to-end.

## Out of scope (follow-ups)

- **Backfill on prod** (Phase 5 of the plan). Use existing `process_cases --filter references_extracted_at__isnull=True` then `--filter references_extracted_at__lt=<deploy_date>`. The `references_extracted_at` field is the resume token; partial runs are safe.
- **DeprecationWarning gate** — one-line addition to pytest filterwarnings to catch any future `RefExtractor` re-introduction. Trivial; deferred so it doesn't ride this PR.
- **Drop transitional `[ref=UUID]` cleanup** once backfill confirms no live row carries legacy brackets in `case.content`.
- **Surface short-form citations** (`kind != "full"`) as Reference rows. Strict superset of current behaviour; corpus-shape change, separate PR.
- Audit `assign_case_ref`'s `aliases__contains` substring matching against newline-delimited TextField (sub-optimal, pre-existing).

## Test plan

- [x] `make test` — 1060 pass, 16 skipped
- [x] `make lint-check` — clean
- [x] Real-data smoke test against 102 cases + 200 laws from prod (above)
- [x] Slicing canary (`case.content[m.start:m.end] == m.text`) — zero mismatches across 5,525 markers
- [ ] Manual visual check of a case-detail view post-merge to confirm `<a class="ref">` markup renders correctly on real content
- [ ] Backfill execution on prod with `references_extracted_at` filter

🤖 Generated with [Claude Code](https://claude.com/claude-code)