### PR TITLE
chore(processing): log periodic progress during process_cases / process_laws

### DIFF
--- a/oldp/apps/cases/processing/case_processor.py
+++ b/oldp/apps/cases/processing/case_processor.py
@@ -32,6 +32,7 @@ class CaseProcessor(ContentProcessor):
         Case.objects.all().delete()
 
     def process_content_item(self, content: Case) -> Case:
+        ok = False
         try:
             # First save (some processing steps require ids)
             # content.full_clean()  # Validate model
@@ -46,6 +47,7 @@ class CaseProcessor(ContentProcessor):
 
             self.doc_counter += 1
             self.processed_content.append(content)
+            ok = True
 
         except (
             ValidationError,
@@ -58,7 +60,11 @@ class CaseProcessor(ContentProcessor):
             self.processing_errors.append(e)
             self.doc_failed_counter += 1
 
+        if self._progress is not None:
+            self._progress.tick(ok=ok)
         return content
+
+    _progress = None
 
     def process_content(self):
         if (
@@ -71,6 +77,7 @@ class CaseProcessor(ContentProcessor):
             paginator = Paginator(
                 self.pre_processed_content, self.input_handler.per_page
             )
+            self._progress = self.make_progress_tracker(total=paginator.count)
             for page in range(1, paginator.num_pages + 1):
                 logger.debug("Page %i / %i" % (page, paginator.num_pages))
 
@@ -78,8 +85,32 @@ class CaseProcessor(ContentProcessor):
                     self.process_content_item(item)
 
         else:
+            self._progress = self.make_progress_tracker(
+                total=_safe_total(self.pre_processed_content)
+            )
             for content in self.pre_processed_content:
                 self.process_content_item(content)
+
+        self._progress.finish()
+        self._progress = None
+
+
+def _safe_total(items) -> int | None:
+    """Return a count for ``items`` without forcing a queryset to materialise.
+
+    Tries ``QuerySet.count()`` (cheap COUNT query); falls back to ``len`` if
+    available; returns None when neither is callable cheaply (e.g. a generator).
+    """
+    counter = getattr(items, "count", None)
+    if callable(counter):
+        try:
+            return counter()
+        except Exception:  # noqa: BLE001
+            pass
+    try:
+        return len(items)
+    except TypeError:
+        return None
 
 
 class CaseInputHandlerDB(InputHandlerDB):

--- a/oldp/apps/laws/processing/law_processor.py
+++ b/oldp/apps/laws/processing/law_processor.py
@@ -13,6 +13,7 @@ from oldp.apps.processing.content_processor import (
     ContentProcessor,
     InputHandlerDB,
     InputHandlerFS,
+    ProgressTracker,
 )
 from oldp.apps.processing.errors import ProcessingError
 from oldp.apps.references.models import LawReferenceMarker
@@ -41,14 +42,21 @@ class LawProcessor(ContentProcessor):
         )
 
     def process_content(self):
-        for i, content in enumerate(self.pre_processed_content):
+        # Materialise the queryset once so (a) ``content.previous`` lookup by
+        # positional index works and (b) ``len`` gives an accurate total. The
+        # law extractor doesn't run on the full corpus (it's bounded per-book),
+        # so the in-memory cost is acceptable.
+        items = list(self.pre_processed_content)
+        progress = ProgressTracker(total=len(items), log_every=self.log_every)
+        for i, content in enumerate(items):
             if i > 0:
                 # .save() is already called by input handler
-                content.previous = self.pre_processed_content[i - 1]
+                content.previous = items[i - 1]
 
             if not isinstance(content, Law):
                 raise ProcessingError("Invalid processing content: %s" % content)
 
+            ok = False
             try:
                 content.save()  # First save (steps require id)
 
@@ -58,11 +66,15 @@ class LawProcessor(ContentProcessor):
 
                 self.doc_counter += 1
                 self.processed_content.append(content)
+                ok = True
 
             except ProcessingError as e:
                 # logger.error('ERROR: ES - index already created? % s' % e)
                 self.doc_failed_counter += 1
                 logger.error(e)
+
+            progress.tick(ok=ok)
+        progress.finish()
 
 
 class LawInputHandlerDB(InputHandlerDB):

--- a/oldp/apps/processing/content_processor.py
+++ b/oldp/apps/processing/content_processor.py
@@ -1,9 +1,10 @@
 import glob
 import logging.config
 import os
+import time
 from enum import Enum
 from importlib import import_module
-from typing import List
+from typing import List, Optional
 from urllib.parse import parse_qsl
 
 from django.conf import settings
@@ -14,6 +15,93 @@ from oldp.apps.processing.processing_steps import BaseProcessingStep
 ContentStorage = Enum("ContentStorage", "ES FS DB")
 
 logger = logging.getLogger(__name__)
+
+
+def _format_eta(seconds: float) -> str:
+    """Format seconds as ``Hh Mm Ss``, dropping leading zero units."""
+    seconds = int(seconds)
+    if seconds < 0:
+        return "?"
+    h, rem = divmod(seconds, 3600)
+    m, s = divmod(rem, 60)
+    if h:
+        return f"{h}h {m}m {s}s"
+    if m:
+        return f"{m}m {s}s"
+    return f"{s}s"
+
+
+class ProgressTracker(object):
+    """Periodic INFO-level progress reporter for long-running processors.
+
+    Long-running backfills (``manage.py process_cases extract_refs`` over
+    the full ~420k corpus) emit a single end-of-run line and are
+    otherwise silent at INFO. Without progress markers a stalled or
+    long-tailed run is indistinguishable from a healthy one.
+
+    The tracker logs:
+
+    - one line on the first item (sanity check that the loop has begun);
+    - one line every ``log_every`` items (default 100);
+    - one final summary line via :meth:`finish`.
+
+    When the total is known, lines include percentage complete and an
+    ETA computed from a wall-clock rate. ETA is intentionally simple
+    (``remaining / rate`` over the *whole run so far*); a windowed rate
+    would react faster to slowdowns but isn't worth the complexity for
+    operational visibility.
+
+    Construct one per processor run; call :meth:`tick` per item and
+    :meth:`finish` once the loop ends.
+    """
+
+    def __init__(self, total: Optional[int] = None, log_every: int = 100):
+        self.total = total
+        self.log_every = max(1, int(log_every))
+        self.ok = 0
+        self.failed = 0
+        self._start = time.monotonic()
+
+    def tick(self, ok: bool = True) -> None:
+        if ok:
+            self.ok += 1
+        else:
+            self.failed += 1
+        done = self.ok + self.failed
+        if done == 1 or done % self.log_every == 0:
+            self._log(done)
+
+    def finish(self) -> None:
+        done = self.ok + self.failed
+        self._log(done, final=True)
+
+    def _log(self, done: int, final: bool = False) -> None:
+        elapsed = max(time.monotonic() - self._start, 1e-9)
+        rate = done / elapsed
+        prefix = "Progress (final)" if final else "Progress"
+        if self.total:
+            pct = 100.0 * done / self.total
+            eta = _format_eta((self.total - done) / rate) if rate > 0 else "?"
+            logger.info(
+                "%s: %d/%d (%.1f%%) ok=%d failed=%d %.1f items/s eta=%s",
+                prefix,
+                done,
+                self.total,
+                pct,
+                self.ok,
+                self.failed,
+                rate,
+                eta,
+            )
+        else:
+            logger.info(
+                "%s: %d ok=%d failed=%d %.1f items/s",
+                prefix,
+                done,
+                self.ok,
+                self.failed,
+                rate,
+            )
 
 
 class InputHandler(object):
@@ -265,6 +353,12 @@ class ContentProcessor(object):
             default=0,
             help="Skip the number of items before processing",
         )
+        parser.add_argument(
+            "--log-every",
+            type=int,
+            default=100,
+            help="Log a progress line every N processed items (default 100)",
+        )
 
     def set_options(self, options):
         # Set options according to parser options
@@ -272,6 +366,15 @@ class ContentProcessor(object):
 
         if options["verbose"]:
             logger.setLevel(logging.DEBUG)
+        # Stash the progress-logging interval so processors can read it
+        # when constructing their ProgressTracker.
+        self.log_every = int(options.get("log_every", 100) or 100)
+
+    log_every = 100
+
+    def make_progress_tracker(self, total: Optional[int] = None) -> "ProgressTracker":
+        """Build a tracker honoring the parser-supplied ``--log-every`` value."""
+        return ProgressTracker(total=total, log_every=self.log_every)
 
     def empty_content(self):
         raise NotImplementedError()


### PR DESCRIPTION
## Summary

Long-running backfills only emit a single end-of-run summary at INFO, so a stalled or long-tailed `manage.py process_cases extract_refs` over the full ~420k-row corpus was indistinguishable from a healthy one. The existing per-item `Completed: …` line is at DEBUG, which floods the log under `--verbose` and is silent at INFO.

This adds a small `ProgressTracker` that emits a periodic INFO line — no tqdm, no extra dependency.

```
Progress: 30/50 (60.0%) ok=30 failed=0 15.7 items/s eta=1s
…
Progress (final): 50/50 (100.0%) ok=50 failed=0 13.7 items/s eta=0s
```

Lines fire:
- on the first item (sanity check that the loop has begun);
- every `--log-every N` items (default 100);
- once at the end as `Progress (final): …`.

Total comes from the input handler's `Paginator.count` when paginating, otherwise from `QuerySet.count()` / `len(items)`. ETA is `remaining / rate` over the whole run so far — intentionally simple; a windowed rate would react faster to slowdowns but isn't worth the complexity for operational visibility.

## Why this PR

Phase 5 of #195 (the extract-refs migration) requires a backfill of `extract_refs` over the full prod corpus. Without progress markers a multi-hour run is opaque; this lands the visibility piece independently so it can ship before backfill kicks off.

## Changes

- New `ProgressTracker` in `oldp/apps/processing/content_processor.py` plus a `_format_eta` helper.
- New `--log-every N` flag on the processor parser.
- `CaseProcessor.process_content`: tracker constructed once, ticked from `process_content_item`, finished at the end. Works for both the paginated and non-paginated branches.
- `LawProcessor.process_content`: same. Materialises the input as a list once (was already iterated multiple times for `content.previous` lookup, just made the cost explicit).
- Helper `_safe_total(items)` falls back gracefully when `count()`/`len()` aren't available.

## Verification

Smoke test against a running stack:

```
$ podman compose exec -T app python manage.py process_cases extract_refs \
      --limit 50 --log-every 10 --filter 'review_status=accepted'
Progress: 1/50 (2.0%) ok=1 failed=0 13.4 items/s eta=3s
Progress: 10/50 (20.0%) ok=10 failed=0 17.6 items/s eta=2s
Progress: 20/50 (40.0%) ok=20 failed=0 20.3 items/s eta=1s
Progress: 30/50 (60.0%) ok=30 failed=0 15.7 items/s eta=1s
Progress: 40/50 (80.0%) ok=40 failed=0 14.2 items/s eta=0s
Progress: 50/50 (100.0%) ok=50 failed=0 13.7 items/s eta=0s
Progress (final): 50/50 (100.0%) ok=50 failed=0 13.7 items/s eta=0s
- Successful documents: 50 (failed: 0)
```

Same shape on `process_laws`. Existing `--verbose` per-item DEBUG line is unchanged.

## Test plan

- [x] `make test` — 1053 pass, 16 skipped (no test changes needed)
- [x] `make lint-check` — clean
- [x] Manual smoke test on `process_cases` (above)
- [x] Manual smoke test on `process_laws` (101 items/s observed)

🤖 Generated with [Claude Code](https://claude.com/claude-code)