### PR TITLE
fix(refs): correct ReferenceMarker.__str__ field references

### DIFF
--- a/oldp/apps/references/models.py
+++ b/oldp/apps/references/models.py
@@ -187,12 +187,12 @@ class ReferenceMarker(models.Model, BaseMarker):
         return self.__str__()
 
     def __str__(self):
-        return "RefMarker(ids=%s, line=%s, pos=%i-%i, by=%s)" % (
-            "self.ids",
-            self.line,
+        return "RefMarker(id=%s, line=%s, pos=%i-%i, by=%s)" % (
+            self.pk,
+            self.line_number,
             self.start,
             self.end,
-            self.referenced_by,
+            self.referenced_by_id,
         )
 
     @staticmethod


### PR DESCRIPTION
## Summary

`ReferenceMarker.__str__` referenced `self.line` and the literal string `"self.ids"`, neither of which exists on the Django model (real fields are `line_number` and `pk`). The bug stayed latent because `__str__` is only invoked via `%s`-style logging.

It surfaces when `oldp/apps/lib/markers.py:insert_markers()` detects two overlapping markers and tries to log them:

```python
logger.error("Marker overlaps with previous marker: %s" % marker)
```

The format substitution then raises `AttributeError: 'CaseReferenceMarker' object has no attribute 'line'`, which the case-detail view propagates as a 500.

## Reproduction

Reproduced on real seeded data: case `laghe-2026-04-10-12-sla-77525` (LAGHE) where the legacy extractor emitted a `§ 33 Abs. 1 RVG` law cite (positions 1353-1368) overlapping a `1 RVG auf 71.45` case cite (1363-1378). Loading `/case/laghe-2026-04-10-12-sla-77525` returned `HTTP 500` pre-fix; `HTTP 200` post-fix.

## Verification

Swept all seeded views on the local stack (100 prod-API cases + 200 laws + 35 courts + ~7 fixture rows = 350 URLs):

| Result | Count |
|---|---|
| 200 OK (with redirects followed) | 343 |
| 404 (intentional — pending review or non-latest revisions) | 7 |
| **5xx** | **0** |

The 7 404s correspond to:
- 4 cases with `review_status='pending'` (detail view filters to `accepted`)
- 3 BGB sections on non-latest LawBook revisions (detail view filters to `book__latest=True`)

Both are correct view behaviour, not bugs.

## Changes

- Use `self.pk` instead of the literal `"self.ids"`.
- Use `self.line_number` instead of the non-existent `self.line`.
- Use `self.referenced_by_id` instead of `self.referenced_by` so `__str__` doesn't lazy-load the FK and recursively invoke the parent's `__str__` (which would inflate query counts on every overlap-error path).

## Test plan

- [x] `make test oldp.apps.references` — green
- [x] `curl http://localhost:8000/case/laghe-2026-04-10-12-sla-77525` — was 500, now 200
- [x] Full URL sweep across 350 seeded views — zero 5xx

🤖 Generated with [Claude Code](https://claude.com/claude-code)