### PR TITLE
fix(refs): render references on law-detail pages

### DIFF
--- a/oldp/apps/laws/models.py
+++ b/oldp/apps/laws/models.py
@@ -13,6 +13,7 @@ from django.utils import timezone
 from django.utils.html import strip_tags
 from django.utils.translation import gettext_lazy as _
 
+from oldp.apps.references.content_models import ReferenceContent
 from oldp.apps.search.models import RelatedContent, SearchableContent
 from oldp.apps.topics.models import TopicContent
 
@@ -215,7 +216,7 @@ class LawBook(TopicContent):
         return filter_by_review_status(LawBook.objects.all(), request)
 
 
-class Law(SearchableContent, models.Model):
+class Law(SearchableContent, models.Model, ReferenceContent):
     """Law model contains actual law text and belongs to a law book"""
 
     book = models.ForeignKey(
@@ -480,24 +481,10 @@ class Law(SearchableContent, models.Model):
     def get_referencing_cases_url(self):
         return reverse("cases:index") + "?has_reference_to_law={}".format(self.pk)
 
-    def get_references(self):
-        if self.references is None:
-            from oldp.apps.references.models import Reference
+    def get_reference_marker_model(self):
+        from oldp.apps.references.models import LawReferenceMarker
 
-            self.references = Reference.objects.filter(
-                lawreferencemarker__referenced_by=self
-            )
-
-        return self.references
-
-    def get_reference_markers(self):
-        if self.reference_markers is None:
-            from oldp.apps.references.models import LawReferenceMarker
-
-            self.reference_markers = LawReferenceMarker.objects.filter(
-                referenced_by=self.id
-            )
-        return self.reference_markers
+        return LawReferenceMarker
 
     def get_referencing_cases(self, case_queryset):
         """Returns all cases that cite this law

--- a/oldp/apps/references/content_models.py
+++ b/oldp/apps/references/content_models.py
@@ -1,5 +1,14 @@
 class ReferenceContent(object):
-    """Content models that can contain references inherit from this"""
+    """Content models that can contain references inherit from this.
+
+    Subclasses implement :meth:`get_reference_marker_model` to return
+    the concrete marker model (``CaseReferenceMarker`` for Case,
+    ``LawReferenceMarker`` for Law). The reverse-relation accessor name
+    on ``Reference`` is derived from the marker model's class name —
+    ``CaseReferenceMarker`` → ``casereferencemarker``,
+    ``LawReferenceMarker`` → ``lawreferencemarker`` — matching Django's
+    default reverse lookup.
+    """
 
     references = None
     reference_markers = None
@@ -7,15 +16,23 @@ class ReferenceContent(object):
     def get_reference_marker_model(self):
         raise NotImplementedError()
 
+    def _reverse_marker_accessor(self) -> str:
+        """Reverse accessor on ``Reference`` for this content's marker model."""
+        return self.get_reference_marker_model().__name__.lower()
+
     def get_references(self):
-        """Get reference with custom query (grouped by to_hash).
-        :return:
+        """Reference rows attached to this content, via its marker model.
+
+        Filters on ``<markermodel>__referenced_by=self`` so the query
+        works for both Case and Law content. Without this indirection
+        the query is hardcoded to one model and silently returns empty
+        for the other.
         """
         if self.references is None:
             from oldp.apps.references.models import Reference
 
             self.references = Reference.objects.filter(
-                casereferencemarker__referenced_by=self
+                **{f"{self._reverse_marker_accessor()}__referenced_by": self}
             ).select_related("law", "case")
 
         return self.references
@@ -30,7 +47,7 @@ class ReferenceContent(object):
         return self.reference_markers
 
     def get_grouped_references(self) -> dict:
-        """Group references by `to_hash` field."""
+        """Group references by ``to_hash``."""
         grouped_refs = {}
         for ref in self.get_references():
             if ref.to_hash in grouped_refs:


### PR DESCRIPTION
## Summary

The law-detail view's references panel rendered **"This document does not contain any references"** even when the law had marker rows with assigned `Reference.law` FKs.

Reproduced on `/law/aappro-2002/9`: 3 markers (`§ 1 Abs. 2 Satz 1`, `§ 12`, `§ 12 Abs. 4 Satz 2`) all with `Reference.law` populated, but none rendered. Post-fix, all three appear as clickable links to their target `Law` rows.

## Root cause

Two interlocking issues:

1. `Law` did not inherit the `ReferenceContent` mixin. It defined its own `get_references()` / `get_reference_markers()` directly on the model.
2. `laws/templates/laws/references.html` calls `item.get_grouped_references` — a method that lives **only** on `ReferenceContent`. Calling it on a `Law` instance fell through Django's silent attribute resolution, returned empty, and the template rendered the "no references" branch.

Pulling `Law` into the mixin alone wasn't enough because `ReferenceContent.get_references()` was hardcoded to filter on `casereferencemarker__referenced_by=self` — fine for cases, silent empty for laws.

## Fix

Make the mixin polymorphic: derive the reverse-accessor name from `get_reference_marker_model().__name__.lower()` so the query targets `casereferencemarker` for cases and `lawreferencemarker` for laws — Django's default reverse-lookup convention. `Law` now inherits `ReferenceContent` and implements `get_reference_marker_model()`; the redundant per-model `get_references()` / `get_reference_markers()` overrides are deleted.

## Test plan

- [x] `make test` — 1053 pass, 16 skipped
- [x] `make lint-check` — clean
- [x] Manual verification on `/law/aappro-2002/9` — was "no references", now lists `ÄApprO 2002 § 1`, `§ 12`, `§ 12 Abs. 4 Satz 2` as clickable reference links

🤖 Generated with [Claude Code](https://claude.com/claude-code)