### PR TITLE
fix(refs): render in-body markers + resolve verbose-book-name cites

### DIFF
--- a/oldp/api/tests/test_pagination.py
+++ b/oldp/api/tests/test_pagination.py
@@ -94,9 +94,7 @@ class CappedLimitOffsetPaginationTests(TestCase):
 
     def test_offset_at_cap_allowed(self):
         # PAGINATE_UNTIL (10) * max_limit (1000) = 10,000
-        self.paginator.paginate_queryset(
-            list(range(20)), self._request(offset=10_000)
-        )
+        self.paginator.paginate_queryset(list(range(20)), self._request(offset=10_000))
 
     def test_offset_above_cap_raises(self):
         with self.assertRaises(NotFound) as ctx:
@@ -113,6 +111,4 @@ class CappedLimitOffsetPaginationTests(TestCase):
         )
 
     def test_non_integer_offset_is_ignored(self):
-        self.paginator.paginate_queryset(
-            list(range(10)), self._request(offset="bogus")
-        )
+        self.paginator.paginate_queryset(list(range(10)), self._request(offset="bogus"))

--- a/oldp/apps/cases/management/commands/bulk_approve_cases.py
+++ b/oldp/apps/cases/management/commands/bulk_approve_cases.py
@@ -30,20 +30,39 @@ class Command(BaseCommand):
     help = "Bulk approve pending cases (single UPDATE query, no per-row API calls)"
 
     def add_arguments(self, parser):
-        parser.add_argument("--dry-run", action="store_true",
-                            help="Only show count, don't update")
-        parser.add_argument("--state", type=int, default=None,
-                            help="Filter by court state ID")
-        parser.add_argument("--date-after", default=None,
-                            help="Only cases on or after this date (YYYY-MM-DD)")
-        parser.add_argument("--date-before", default=None,
-                            help="Only cases on or before this date (YYYY-MM-DD)")
-        parser.add_argument("--token", type=int, default=None,
-                            help="Filter by API token ID (created_by_token_id)")
-        parser.add_argument("--batch-size", type=int, default=10000,
-                            help="Update in batches of N (default: 10000)")
-        parser.add_argument("--update-index", action="store_true",
-                            help="Update the search index for approved cases")
+        parser.add_argument(
+            "--dry-run", action="store_true", help="Only show count, don't update"
+        )
+        parser.add_argument(
+            "--state", type=int, default=None, help="Filter by court state ID"
+        )
+        parser.add_argument(
+            "--date-after",
+            default=None,
+            help="Only cases on or after this date (YYYY-MM-DD)",
+        )
+        parser.add_argument(
+            "--date-before",
+            default=None,
+            help="Only cases on or before this date (YYYY-MM-DD)",
+        )
+        parser.add_argument(
+            "--token",
+            type=int,
+            default=None,
+            help="Filter by API token ID (created_by_token_id)",
+        )
+        parser.add_argument(
+            "--batch-size",
+            type=int,
+            default=10000,
+            help="Update in batches of N (default: 10000)",
+        )
+        parser.add_argument(
+            "--update-index",
+            action="store_true",
+            help="Update the search index for approved cases",
+        )
 
     def handle(self, *args, **options):
         qs = Case.objects.filter(review_status="pending")

--- a/oldp/apps/cases/tests/test_commands.py
+++ b/oldp/apps/cases/tests/test_commands.py
@@ -108,8 +108,10 @@ class BulkApproveCasesTestCase(TestCase):
         """Combined --date-after and --date-before narrows the window."""
         call_command(
             "bulk_approve_cases",
-            "--date-after", "2018-01-01",
-            "--date-before", "2018-12-31",
+            "--date-after",
+            "2018-01-01",
+            "--date-before",
+            "2018-12-31",
         )
         self.assertEqual(self._pending_count(), 0)
 
@@ -117,8 +119,10 @@ class BulkApproveCasesTestCase(TestCase):
         """Date range that excludes the pending case leaves it untouched."""
         call_command(
             "bulk_approve_cases",
-            "--date-after", "2019-01-01",
-            "--date-before", "2019-12-31",
+            "--date-after",
+            "2019-01-01",
+            "--date-before",
+            "2019-12-31",
         )
         self.assertEqual(self._pending_count(), 1)
 
@@ -160,8 +164,10 @@ class BulkApproveCasesTestCase(TestCase):
         # State matches but date range doesn't
         call_command(
             "bulk_approve_cases",
-            "--state", "1",
-            "--date-after", "2020-01-01",
+            "--state",
+            "1",
+            "--date-after",
+            "2020-01-01",
         )
         self.assertEqual(self._pending_count(), 1)
 

--- a/oldp/apps/laws/models.py
+++ b/oldp/apps/laws/models.py
@@ -323,13 +323,34 @@ class Law(SearchableContent, models.Model, ReferenceContent):
         return "Law(%s §%s, title=%s)" % (self.book.code, self.slug, self.title)
 
     def get_html_content(self):
-        content = self.content
+        """Render this law's body with reference markers as clickable links.
 
-        from oldp.apps.references.models import LawReferenceMarker
+        Picks one of two mutually exclusive rendering paths:
 
-        content = LawReferenceMarker.make_markers_clickable(content)
+        - **Legacy path** (``[ref=UUID]…[/ref]`` brackets present in
+          stored content): use :meth:`LawReferenceMarker.make_markers_clickable`
+          to convert those baked-in brackets into anchors. Used by rows
+          ingested before the typed-citation extractor refactor; will
+          stop firing once those rows are re-extracted with content
+          rewritten clean.
+        - **Offset path** (clean content): use
+          :func:`oldp.apps.lib.markers.insert_markers` with the
+          persisted ``LawReferenceMarker`` rows, mirroring how the
+          case-detail view renders its body
+          (``oldp/apps/cases/views.py``).
 
-        return content
+        Running both produces nested anchors (legacy regex re-wraps the
+        anchor inserted by the offset path), so the branches must not
+        overlap.
+        """
+        if "[ref=" in self.content:
+            from oldp.apps.references.models import LawReferenceMarker
+
+            return LawReferenceMarker.make_markers_clickable(self.content)
+
+        from oldp.apps.lib.markers import insert_markers
+
+        return insert_markers(self.content or "", list(self.get_reference_markers()))
 
     def get_text(self):
         # Convert law content as plain text for ES

--- a/oldp/apps/mcp/views.py
+++ b/oldp/apps/mcp/views.py
@@ -7,7 +7,10 @@ from django.conf import settings
 from django.http import HttpResponseNotAllowed
 from mcp_server.views import MCPServerStreamableHttpView
 from oauth2_provider.contrib.rest_framework import OAuth2Authentication
-from rest_framework.authentication import SessionAuthentication, get_authorization_header
+from rest_framework.authentication import (
+    SessionAuthentication,
+    get_authorization_header,
+)
 from rest_framework.exceptions import AuthenticationFailed, PermissionDenied
 from rest_framework.permissions import AllowAny
 
@@ -96,7 +99,9 @@ class OLDPMCPView(MCPServerStreamableHttpView):
         )
         allowed_origins.discard("")
 
-        if any(_origin_matches(pattern, normalized_origin) for pattern in allowed_origins):
+        if any(
+            _origin_matches(pattern, normalized_origin) for pattern in allowed_origins
+        ):
             return
 
         raise PermissionDenied("Invalid Origin for MCP endpoint.")

--- a/oldp/apps/references/processing/processing_steps/extract_refs.py
+++ b/oldp/apps/references/processing/processing_steps/extract_refs.py
@@ -112,12 +112,21 @@ class BaseExtractRefs(object):
         return ref
 
     def assign_case_ref(self, citation: CaseCitation, ref: Reference) -> Reference:
-        """Find the corresponding ``Case`` row for a case citation."""
+        """Resolve a ``CaseCitation`` to a ``Case`` row and attach it to ``ref``.
+
+        Refex's ``citation.court`` is sometimes the short cite-form that
+        lives in ``Court.code`` ("BGH") and sometimes the verbose form
+        from ``Court.aliases`` ("Landgericht Köln"). Aliases-only
+        matching dropped every cite whose stored court ships only the
+        long form (BGH's aliases ship "Bundesgerichtshof" but not
+        "BGH"), so check both via a single OR'd query.
+        """
         if not citation.court or not citation.file_number:
             raise ProcessingError("Reference data is not set")
 
         candidates = Case.objects.filter(
-            court__aliases__contains=citation.court,
+            models.Q(court__code__iexact=citation.court)
+            | models.Q(court__aliases__contains=citation.court),
             file_number=citation.file_number,
         )
 
@@ -201,9 +210,17 @@ class BaseExtractRefs(object):
         as ``Reference`` rows is a corpus-shape change handled
         separately.
 
-        Marker offsets are translated back to raw-document coordinates
-        via :func:`refex.document.map_span_to_raw` so that
-        ``insert_markers`` can slice the original ``content`` correctly.
+        ``marker.start`` / ``marker.end`` are translated to raw-document
+        coordinates via :func:`refex.document.map_span_to_raw` so
+        ``insert_markers`` can slice the original ``content``. The
+        persisted ``marker.text`` (and the ``Reference.to`` mirror) is
+        the **plain-text** projection of the citation, not
+        ``case.content[raw.start:raw.end]``: when a citation sits inside
+        nested HTML wrappers (e.g. Wolters Kluwer RDFa ``<span>`` blocks
+        wrapping each section), the raw slice can balloon to >1KB of
+        markup while the actual cite is ~20 chars. The references panel,
+        the search-fallback link, and the to-hash grouping all want the
+        clean form.
         """
         saved_markers: List[ReferenceMarker] = []
         saved_refs: List[Reference] = []
@@ -215,10 +232,11 @@ class BaseExtractRefs(object):
             if not group:
                 continue
 
-            raw_span = map_span_to_raw(group[0].span, document)
+            plain_span = group[0].span
+            raw_span = map_span_to_raw(plain_span, document)
             marker = self.marker_model(
                 referenced_by=referenced_by,
-                text=raw_span.text,
+                text=plain_span.text,
                 start=raw_span.start,
                 end=raw_span.end,
             )
@@ -226,7 +244,7 @@ class BaseExtractRefs(object):
 
             for citation in group:
                 for sub_citation in self._expand_range(citation):
-                    ref = Reference(to=raw_span.text)
+                    ref = Reference(to=plain_span.text)
 
                     if assign_references:
                         try:

--- a/oldp/apps/references/processing/processing_steps/extract_refs.py
+++ b/oldp/apps/references/processing/processing_steps/extract_refs.py
@@ -2,12 +2,13 @@ import logging
 from dataclasses import replace
 from typing import List, Tuple
 
+from django.db import models
 from django.utils.text import slugify
 from refex.citations import CaseCitation, Citation, LawCitation
 from refex.document import Document, map_span_to_raw
 
 from oldp.apps.cases.models import Case
-from oldp.apps.laws.models import Law
+from oldp.apps.laws.models import Law, LawBook
 from oldp.apps.processing.errors import ProcessingError
 from oldp.apps.references.models import Reference, ReferenceMarker
 
@@ -66,22 +67,40 @@ class BaseExtractRefs(object):
         book_slug = slugify(citation.book)
         section_slug = self._build_section_slug(citation)
 
-        candidates = Law.objects.filter(
-            book__slug=book_slug,
-            slug=section_slug,
-            book__latest=True,
-        )
-
-        first = candidates.first()
-        if first is None and citation.unit == "article":
-            # Fallback: stored Law may use the bare number ("1") rather
-            # than the prefixed slug ("artikel-1") even for Article cites.
+        section_slugs = [section_slug]
+        if citation.unit == "article":
+            # Stored Law may use the bare number ("1") rather than the
+            # prefixed slug ("artikel-1") even for Article cites.
             bare = slugify(citation.number)
             if bare != section_slug:
+                section_slugs.append(bare)
+
+        first = Law.objects.filter(
+            book__slug=book_slug,
+            slug__in=section_slugs,
+            book__latest=True,
+        ).first()
+
+        if first is None:
+            # Slug lookup missed — refex may emit the verbose book name
+            # ("Grundgesetz") while ``LawBook.slug`` carries the short
+            # code ("gg"). Refex's bundled ``law_book_codes.txt`` keeps
+            # full names; OLDP's books are slugged from their short
+            # codes. Fall back to matching ``LawBook.code`` /
+            # ``LawBook.title`` case-insensitively so verbose-name cites
+            # still resolve.
+            book_ids = list(
+                LawBook.objects.filter(latest=True)
+                .filter(
+                    models.Q(code__iexact=citation.book)
+                    | models.Q(title__iexact=citation.book)
+                )
+                .values_list("pk", flat=True)
+            )
+            if book_ids:
                 first = Law.objects.filter(
-                    book__slug=book_slug,
-                    slug=bare,
-                    book__latest=True,
+                    book_id__in=book_ids,
+                    slug__in=section_slugs,
                 ).first()
 
         if first is None:


### PR DESCRIPTION
## Summary

Four follow-up fixes uncovered while exercising #195's extract_refs migration against real seeded prod data on a local dev stack. Bundled together because they share the same root: assumptions baked into the legacy pipeline (content-rewriting, short book codes, alias-only court matching, raw-HTML marker text) didn't survive the move to refex's typed-citation API.

## Bug 1 — Law detail pages render zero in-body markers (commit 776350c)

`Law.get_html_content` scans the stored content for legacy `[ref=UUID]…[/ref]` brackets via `LawReferenceMarker.make_markers_clickable`. The new extractor (correctly, per the trade-offs in #195) doesn't write those brackets back into `law.content`. Every latest-revision law without stale legacy brackets — 97% of laws on the dev stack — therefore lost in-body marker rendering even though the marker rows were correctly persisted in the DB.

**Fix**: pick one of two mutually exclusive paths, mirroring how `oldp/apps/cases/views.py:97` renders case content. Running both produces nested anchors (legacy regex re-wraps the anchor inserted by the offset path), so the branches must not overlap. Reproduced + verified on `/law/aappro-2002/21`.

## Bug 2 — Verbose book names don't resolve (commit 776350c)

`assign_law_ref` slugifies `citation.book` and matches against `LawBook.slug`. Refex emits the long form from its bundled `law_book_codes.txt` (`book="grundgesetz"`, `book="bürgerliches gesetzbuch"`, etc.) while `LawBook.slug` carries the short code (`"gg"`, `"bgb"`).

**Fix**: when the slug-keyed lookup misses, fall back to matching against `LawBook.code__iexact` / `LawBook.title__iexact` (constrained to `latest=True`). Also collapsed the existing two-step paragraph/article slug query into a single `slug__in=[…]`. Across the dev stack, law-cite assignments rose **205 → 425** once verbose-name Grundgesetz cites unlocked.

## Bug 3 — Marker text persisted as raw HTML, not plain text (commit 4b46625)

`save_citations` was setting `marker.text = raw_span.text` (= `case.content[raw.start:raw.end]`). For citations contiguous in raw HTML (clean `<p>`/`<td>` cases) the slice equals the plain-text citation, but for citations split across nested HTML wrappers — e.g. Wolters Kluwer RDFa `<span>` decorations: `§§ 11</span><span …>, 13 und <span …>14 FeV` — the raw slice balloons to >1KB of inline markup while the actual cite is ~20 chars.

The persisted `marker.text` then overflowed `CharField(max_length=250)` on **7/239 dev-stack cases** (`Data too long for column 'text'`); `Reference.to` (mirrored from marker text) overflowed identically. The references panel and search-fallback links would have rendered the HTML markup verbatim.

**Fix**: switch to `citation.span.text` (refex's plain-text projection — what the panel + search-fallback actually want) for `marker.text` and `Reference.to`. `marker.start`/`end` stay raw-HTML coordinates so `insert_markers` can wrap the original markup correctly.

The 7 previously-failing cases now extract cleanly:

| Case | Markers | Longest text (before) | Longest text (after) |
|---|---|---|---|
| 399123 | 36 | >250 | 24 |
| 399810 | 71 | >250 | 33 |
| 400168 | 37 | >250 | 45 |
| 400516 | 141 | >250 | 59 |
| 400585 | 232 | >250 | 49 |
| 398483 | 106 | >250 | 71 |
| 397791 | 85 | >250 | 34 |

## Bug 4 — `assign_case_ref` matched only on `Court.aliases__contains` (commit 4b46625)

Refex's `citation.court` is sometimes the short cite-form in `Court.code` ("BGH") and sometimes the verbose form in `Court.aliases` ("Landgericht Köln"). Aliases-only matching dropped every cite whose stored court ships only the long form — BGH's prod aliases ship `"Bundesgerichtshof"` but not `"BGH"`, so every `BGH XII ZB 447/16`-style cite stayed unassigned.

**Fix**: OR `Q(court__code__iexact=citation.court)` into the same query so cite-form abbreviations resolve too. On the dev stack with 246 seeded cases, the change lifts case→case assignments from **85 → 212** (2.5×) once the target cases are in the local DB.

## Other

Also rolls in the `oldp/apps/mcp/views.py` line-wrap that ruff `format --check` has been flagging on every CI run since the django-mcp-server bump.

## Verification

- `make test` — 1060 pass, 16 skipped (no test changes needed; the table-shape regression test still holds because its fixture is clean HTML where `raw_span.text == citation.span.text`).
- `make lint-check` — clean.
- 7 previously-failing cases re-extract; full URL sweep across 446 seeded URLs still 0 / 5xx.
- Manual checks on `/law/aappro-2002/{9, 21, 27}`, `/case/laghe-2026-04-10-12-sla-77525`, `/case/sg-dusseldorf-2027-04-06-s-46-as-223015`.

## Commits

1. `776350c` fix(refs): render in-body markers + resolve verbose-book-name cites
2. `4b46625` fix(refs): persist plain-text marker text + match court via code/aliases

🤖 Generated with [Claude Code](https://claude.com/claude-code)
