### PR TITLE
feat(refs): citation graph REST API + service-layer extraction from MCP

### DIFF
--- a/docs/api/api-overview.md
+++ b/docs/api/api-overview.md
@@ -229,6 +229,106 @@ curl -X GET "https://de.openlegaldata.io/api/cases/search/?text=urheberrecht+AND
   -H "Accept: application/json"
 ```
 
+## Citations & Cross-References
+
+The citation graph is queryable in two complementary ways. The same
+data is also available via the [MCP server](../mcp.md) — both surfaces
+share a single service layer so payload shapes match.
+
+### Nested actions on cases & laws
+
+Map 1:1 to the natural questions about a single case or law section.
+
+| Endpoint | Returns |
+|----------|---------|
+| `GET /api/cases/<id>/references/` | Forward refs emitted by this case (laws + cases it cites) |
+| `GET /api/cases/<id>/citing_cases/` | Cases whose body cites this case |
+| `GET /api/cases/<id>/citing_laws/` | Laws whose body cites this case |
+| `GET /api/laws/<id>/references/` | Forward refs emitted by this law |
+| `GET /api/laws/<id>/citing_cases/` | Cases whose body cites this law section |
+| `GET /api/laws/<id>/citing_laws/` | Laws whose body cites this law section |
+
+The `references/` endpoints return a single dict
+(`total_law_references`, `total_case_references`,
+`law_references[]`, `case_references[]`,
+`references_extracted_at`). The `citing_*` endpoints return a
+paginated list of summary records.
+
+`citing_cases` and `citing_laws` for a law cross-revision-resolve via
+`(book_code, section)`, so older citation rows pinned to non-latest
+revisions still surface.
+
+```bash
+# What does case 12345 cite?
+curl -X GET "https://de.openlegaldata.io/api/cases/12345/references/" \
+  -H "Authorization: Token $OLDP_API_TOKEN"
+
+# Which cases cite § 823 BGB?
+curl -X GET "https://de.openlegaldata.io/api/laws/<law-id>/citing_cases/" \
+  -H "Authorization: Token $OLDP_API_TOKEN"
+```
+
+### Flat `/api/references/`
+
+For cross-cutting queries the nested actions can't express. Filter by
+either numeric IDs or slugs (no id round-trip required):
+
+| Filter | Field |
+|--------|-------|
+| `cited_by_case=<id>` | the source case whose body emitted the cite |
+| `cited_by_case__slug=<case_slug>` | same, by slug |
+| `cited_by_law=<id>` | source law (id) |
+| `cited_by_law__slug=<section_slug>` | source law section slug |
+| `cited_by_law__book__slug=<book_slug>` | source law book slug |
+| `cites_case=<id>` | target case (id) |
+| `cites_case__slug=<case_slug>` | target case (slug) |
+| `cites_law=<id>` | target law (id) |
+| `cites_law__slug=<section_slug>` | target law section slug |
+| `cites_law__book__slug=<book_slug>` | target law book slug |
+| `assigned=true|false` | drop unresolved refs (no `case`/`law` FK) |
+
+Filters compose. Examples:
+
+```bash
+# Every reference involving § 823 BGB as the target, by slug
+curl -X GET "https://de.openlegaldata.io/api/references/?cites_law__book__slug=bgb&cites_law__slug=823" \
+  -H "Authorization: Token $OLDP_API_TOKEN"
+
+# Refs emitted by laws within the BGB book pointing at any law
+curl -X GET "https://de.openlegaldata.io/api/references/?cited_by_law__book__slug=bgb&cites_law__isnull=False" \
+  -H "Authorization: Token $OLDP_API_TOKEN"
+
+# Refs from a specific case (slug) to assigned targets only
+curl -X GET "https://de.openlegaldata.io/api/references/?cited_by_case__slug=bgh-vi-zr-123-22&assigned=true" \
+  -H "Authorization: Token $OLDP_API_TOKEN"
+```
+
+Each row carries the source (`cited_by`), the target (`case` or `law`),
+the marker text (the literal citation as it appeared in the source),
+and the unresolved free-form `to` field used during extraction.
+
+### Citation validation
+
+`GET /api/citations/validate/?citation=...&type=...` checks whether a
+free-form German legal citation (Aktenzeichen, ECLI, or paragraph
+reference) exists in the local DB.
+
+```bash
+curl -G "https://de.openlegaldata.io/api/citations/validate/" \
+  --data-urlencode 'citation=§ 823 BGB' \
+  -H "Authorization: Token $OLDP_API_TOKEN"
+# {"found": true, "type": "law", "matches": [...]}
+
+curl -G "https://de.openlegaldata.io/api/citations/validate/" \
+  --data-urlencode 'citation=VI ZR 123/22' \
+  -H "Authorization: Token $OLDP_API_TOKEN"
+# {"found": true, "type": "case", "matches": [...]}
+```
+
+`type` defaults to `auto` (sniff from the input shape). Force a
+specific parse with `type=file_number`, `type=ecli`, or
+`type=law_reference`.
+
 ## My Resources (/me/)
 
 The `/me/` endpoints let you view resources you have created with your API token.

--- a/docs/mcp.md
+++ b/docs/mcp.md
@@ -84,6 +84,14 @@ The server implements OAuth 2.0 with PKCE and Dynamic Client Registration (RFC 7
 | `get_citing_cases` | Reverse refs: which cases cite a given decision? |
 | `get_cases_for_law` | All cases interpreting a specific statute section |
 
+The same data is queryable via the
+[REST API's citation surfaces](api/api-overview.md#citations--cross-references):
+nested actions like `/api/cases/<id>/references/` for case-by-case
+lookups, plus a flat `/api/references/` resource with slug-based
+filters (`cited_by_law__book__slug=bgb&cited_by_law__slug=823`) for
+cross-cutting graph queries the MCP tools can't express. Both surfaces
+share a single service layer, so payload shapes match.
+
 ### Statistics
 
 | Tool | Description |

--- a/oldp/api/urls.py
+++ b/oldp/api/urls.py
@@ -19,6 +19,7 @@ from oldp.apps.annotations.api_views import (
 from oldp.apps.cases.api_views import CaseSearchViewSet, CaseViewSet
 from oldp.apps.cases.stats_api_views import CaseStatsViewSet
 from oldp.apps.laws.api_views import LawBookViewSet, LawSearchViewSet, LawViewSet
+from oldp.apps.references.api_views import CitationViewSet, ReferenceViewSet
 from oldp.utils.cache_per_user import cache_per_role
 
 from . import schema_view
@@ -52,6 +53,8 @@ router.register(r"countries", CountryViewSet)
 router.register(r"annotation_labels", AnnotationLabelViewSet)
 router.register(r"case_annotations", CaseAnnotationViewSet)
 router.register(r"case_markers", CaseMarkerViewSet)
+router.register(r"references", ReferenceViewSet, basename="reference")
+router.register(r"citations", CitationViewSet, basename="citation")
 
 urlpatterns = [
     re_path(

--- a/oldp/apps/cases/api_views.py
+++ b/oldp/apps/cases/api_views.py
@@ -5,6 +5,7 @@ from django.utils.decorators import method_decorator
 from django.views.decorators.cache import cache_page
 from django.views.decorators.vary import vary_on_cookie, vary_on_headers
 from django_filters.rest_framework import DjangoFilterBackend
+from drf_yasg.utils import swagger_auto_schema
 from rest_framework import status, viewsets
 from rest_framework.decorators import action
 from rest_framework.exceptions import PermissionDenied
@@ -30,6 +31,10 @@ from oldp.apps.cases.serializers import (
     CaseUpdateSerializer,
 )
 from oldp.apps.cases.services import CaseCreator
+from oldp.apps.laws.serializers import LawSerializer
+from oldp.apps.references.serializers import (
+    ForwardReferencesResponseSerializer,
+)
 from oldp.apps.references.services import (
     case_forward_references,
     citing_cases_for_case,
@@ -202,13 +207,20 @@ class CaseViewSet(ReviewStatusFilterMixin, viewsets.ModelViewSet):
     # ``oldp/apps/references/services``; this layer just resolves the
     # detail object, calls the service, and paginates.
 
+    @swagger_auto_schema(responses={200: ForwardReferencesResponseSerializer})
     @action(detail=True, methods=["get"], permission_classes=[AllowAny])
     def references(self, request, pk=None):
         """Forward references emitted by this case (laws + cases it cites)."""
         case = self.get_object()
         return Response(case_forward_references(case))
 
-    @action(detail=True, methods=["get"], permission_classes=[AllowAny])
+    @swagger_auto_schema(responses={200: CaseListSerializer(many=True)})
+    @action(
+        detail=True,
+        methods=["get"],
+        permission_classes=[AllowAny],
+        serializer_class=CaseListSerializer,
+    )
     def citing_cases(self, request, pk=None):
         """Cases whose body cites this case."""
         case = self.get_object()
@@ -219,11 +231,15 @@ class CaseViewSet(ReviewStatusFilterMixin, viewsets.ModelViewSet):
             return self.get_paginated_response(serializer.data)
         return Response(serializer.data)
 
-    @action(detail=True, methods=["get"], permission_classes=[AllowAny])
+    @swagger_auto_schema(responses={200: LawSerializer(many=True)})
+    @action(
+        detail=True,
+        methods=["get"],
+        permission_classes=[AllowAny],
+        serializer_class=LawSerializer,
+    )
     def citing_laws(self, request, pk=None):
         """Laws whose body cites this case (rare in practice; included for symmetry)."""
-        from oldp.apps.laws.serializers import LawSerializer
-
         case = self.get_object()
         qs = citing_laws_for_case(case)
         page = self.paginate_queryset(qs)

--- a/oldp/apps/cases/api_views.py
+++ b/oldp/apps/cases/api_views.py
@@ -6,6 +6,7 @@ from django.views.decorators.cache import cache_page
 from django.views.decorators.vary import vary_on_cookie, vary_on_headers
 from django_filters.rest_framework import DjangoFilterBackend
 from rest_framework import status, viewsets
+from rest_framework.decorators import action
 from rest_framework.exceptions import PermissionDenied
 from rest_framework.filters import OrderingFilter
 from rest_framework.mixins import ListModelMixin
@@ -29,6 +30,11 @@ from oldp.apps.cases.serializers import (
     CaseUpdateSerializer,
 )
 from oldp.apps.cases.services import CaseCreator
+from oldp.apps.references.services import (
+    case_forward_references,
+    citing_cases_for_case,
+    citing_laws_for_case,
+)
 from oldp.apps.search.api import SearchFilter, SearchViewMixin
 from oldp.apps.search.filters import SearchSchemaFilter
 
@@ -188,6 +194,43 @@ class CaseViewSet(ReviewStatusFilterMixin, viewsets.ModelViewSet):
         )
 
         return Response(response_serializer.data, status=status.HTTP_201_CREATED)
+
+    # --- Citation graph -------------------------------------------------
+    #
+    # Three nested read-only actions exposing the cite-graph navigation
+    # also available via the MCP tools. Implementation lives in
+    # ``oldp/apps/references/services``; this layer just resolves the
+    # detail object, calls the service, and paginates.
+
+    @action(detail=True, methods=["get"], permission_classes=[AllowAny])
+    def references(self, request, pk=None):
+        """Forward references emitted by this case (laws + cases it cites)."""
+        case = self.get_object()
+        return Response(case_forward_references(case))
+
+    @action(detail=True, methods=["get"], permission_classes=[AllowAny])
+    def citing_cases(self, request, pk=None):
+        """Cases whose body cites this case."""
+        case = self.get_object()
+        qs = citing_cases_for_case(case)
+        page = self.paginate_queryset(qs)
+        serializer = CaseListSerializer(page if page is not None else qs, many=True)
+        if page is not None:
+            return self.get_paginated_response(serializer.data)
+        return Response(serializer.data)
+
+    @action(detail=True, methods=["get"], permission_classes=[AllowAny])
+    def citing_laws(self, request, pk=None):
+        """Laws whose body cites this case (rare in practice; included for symmetry)."""
+        from oldp.apps.laws.serializers import LawSerializer
+
+        case = self.get_object()
+        qs = citing_laws_for_case(case)
+        page = self.paginate_queryset(qs)
+        serializer = LawSerializer(page if page is not None else qs, many=True)
+        if page is not None:
+            return self.get_paginated_response(serializer.data)
+        return Response(serializer.data)
 
 
 class CaseSearchSchemaFilter(SearchSchemaFilter):

--- a/oldp/apps/homepage/management/commands/dump_api_data.py
+++ b/oldp/apps/homepage/management/commands/dump_api_data.py
@@ -90,12 +90,18 @@ class Command(BaseCommand):
 
         include_lawbook_revisions = opts["include_lawbook_revisions"]
 
+        # ``citations`` is procedural (not model-backed); ``references`` is a
+        # denormalised projection of the citation graph that's fully
+        # reconstructable from the case + law dumps. Neither belongs in a
+        # bulk data dump.
+        SKIP_ENDPOINTS = {"users", "citations", "references"}
+
         files_manifest = {}
         for api_register in router.registry:
             plural, view_set_cls, _singular = api_register
 
-            if "/" in plural or plural == "users":
-                logger.debug("Skip non-root endpoints (and users): %s", plural)
+            if "/" in plural or plural in SKIP_ENDPOINTS:
+                logger.debug("Skip non-root / procedural endpoint: %s", plural)
                 continue
 
             file_name = plural + ".jsonl.gz"

--- a/oldp/apps/laws/api_views.py
+++ b/oldp/apps/laws/api_views.py
@@ -4,6 +4,7 @@ from django.views.decorators.cache import cache_page
 from django.views.decorators.vary import vary_on_cookie, vary_on_headers
 from django_filters.rest_framework import DjangoFilterBackend
 from rest_framework import status, viewsets
+from rest_framework.decorators import action
 from rest_framework.generics import GenericAPIView
 from rest_framework.mixins import ListModelMixin
 from rest_framework.permissions import AllowAny, IsAuthenticated
@@ -23,6 +24,11 @@ from oldp.apps.laws.serializers import (
     LawSerializer,
 )
 from oldp.apps.laws.services import LawBookCreator, LawCreator
+from oldp.apps.references.services import (
+    citing_cases_for_law,
+    citing_laws_for_law,
+    law_forward_references,
+)
 from oldp.apps.search.api import SearchFilter, SearchViewMixin
 from oldp.apps.search.filters import SearchSchemaFilter
 
@@ -105,6 +111,69 @@ class LawViewSet(ReviewStatusFilterMixin, viewsets.ModelViewSet):
         }
 
         return Response(response_data, status=status.HTTP_201_CREATED)
+
+    # --- Citation graph -------------------------------------------------
+    #
+    # Mirrors the case-side actions on ``CaseViewSet`` for symmetry. All
+    # three actions share the service-layer queries that back the MCP
+    # tools.
+
+    @action(detail=True, methods=["get"], permission_classes=[AllowAny])
+    def references(self, request, pk=None):
+        """Forward references emitted by this law (laws + cases it cites).
+
+        Most laws cite only other laws (intra-book ``§ N``
+        cross-references); case citations from a law are rare but
+        structurally supported.
+        """
+        law = self.get_object()
+        return Response(law_forward_references(law))
+
+    @action(detail=True, methods=["get"], permission_classes=[AllowAny])
+    def citing_cases(self, request, pk=None):
+        """Cases whose body cites this law section.
+
+        Resolves cross-revision: ``Reference.law_id`` may pin to an
+        older revision of the same statute section, so we expand to all
+        revisions of the same ``(book code, section)`` pair before
+        querying citing cases.
+        """
+        from oldp.apps.cases.serializers import CaseListSerializer
+
+        law = self.get_object()
+        # Expand to all revisions of this section so we don't miss
+        # citations extracted before the latest revision was added.
+        sibling_ids = list(
+            Law.objects.filter(
+                book__code__iexact=law.book.code,
+                section__iexact=law.section,
+                review_status="accepted",
+            ).values_list("id", flat=True)
+        )
+        qs = citing_cases_for_law(sibling_ids or [law.id])
+        page = self.paginate_queryset(qs)
+        serializer = CaseListSerializer(page if page is not None else qs, many=True)
+        if page is not None:
+            return self.get_paginated_response(serializer.data)
+        return Response(serializer.data)
+
+    @action(detail=True, methods=["get"], permission_classes=[AllowAny])
+    def citing_laws(self, request, pk=None):
+        """Laws whose body cites this law section."""
+        law = self.get_object()
+        sibling_ids = list(
+            Law.objects.filter(
+                book__code__iexact=law.book.code,
+                section__iexact=law.section,
+                review_status="accepted",
+            ).values_list("id", flat=True)
+        )
+        qs = citing_laws_for_law(sibling_ids or [law.id])
+        page = self.paginate_queryset(qs)
+        serializer = LawSerializer(page if page is not None else qs, many=True)
+        if page is not None:
+            return self.get_paginated_response(serializer.data)
+        return Response(serializer.data)
 
 
 class LawBookViewSet(ReviewStatusFilterMixin, viewsets.ModelViewSet):

--- a/oldp/apps/laws/api_views.py
+++ b/oldp/apps/laws/api_views.py
@@ -3,6 +3,7 @@ from django.utils.decorators import method_decorator
 from django.views.decorators.cache import cache_page
 from django.views.decorators.vary import vary_on_cookie, vary_on_headers
 from django_filters.rest_framework import DjangoFilterBackend
+from drf_yasg.utils import swagger_auto_schema
 from rest_framework import status, viewsets
 from rest_framework.decorators import action
 from rest_framework.generics import GenericAPIView
@@ -23,7 +24,11 @@ from oldp.apps.laws.serializers import (
     LawSearchSerializer,
     LawSerializer,
 )
+from oldp.apps.cases.serializers import CaseListSerializer
 from oldp.apps.laws.services import LawBookCreator, LawCreator
+from oldp.apps.references.serializers import (
+    ForwardReferencesResponseSerializer,
+)
 from oldp.apps.references.services import (
     citing_cases_for_law,
     citing_laws_for_law,
@@ -118,6 +123,7 @@ class LawViewSet(ReviewStatusFilterMixin, viewsets.ModelViewSet):
     # three actions share the service-layer queries that back the MCP
     # tools.
 
+    @swagger_auto_schema(responses={200: ForwardReferencesResponseSerializer})
     @action(detail=True, methods=["get"], permission_classes=[AllowAny])
     def references(self, request, pk=None):
         """Forward references emitted by this law (laws + cases it cites).
@@ -129,7 +135,13 @@ class LawViewSet(ReviewStatusFilterMixin, viewsets.ModelViewSet):
         law = self.get_object()
         return Response(law_forward_references(law))
 
-    @action(detail=True, methods=["get"], permission_classes=[AllowAny])
+    @swagger_auto_schema(responses={200: CaseListSerializer(many=True)})
+    @action(
+        detail=True,
+        methods=["get"],
+        permission_classes=[AllowAny],
+        serializer_class=CaseListSerializer,
+    )
     def citing_cases(self, request, pk=None):
         """Cases whose body cites this law section.
 
@@ -138,8 +150,6 @@ class LawViewSet(ReviewStatusFilterMixin, viewsets.ModelViewSet):
         revisions of the same ``(book code, section)`` pair before
         querying citing cases.
         """
-        from oldp.apps.cases.serializers import CaseListSerializer
-
         law = self.get_object()
         # Expand to all revisions of this section so we don't miss
         # citations extracted before the latest revision was added.
@@ -157,7 +167,13 @@ class LawViewSet(ReviewStatusFilterMixin, viewsets.ModelViewSet):
             return self.get_paginated_response(serializer.data)
         return Response(serializer.data)
 
-    @action(detail=True, methods=["get"], permission_classes=[AllowAny])
+    @swagger_auto_schema(responses={200: LawSerializer(many=True)})
+    @action(
+        detail=True,
+        methods=["get"],
+        permission_classes=[AllowAny],
+        serializer_class=LawSerializer,
+    )
     def citing_laws(self, request, pk=None):
         """Laws whose body cites this law section."""
         law = self.get_object()

--- a/oldp/apps/references/api_views.py
+++ b/oldp/apps/references/api_views.py
@@ -1,0 +1,94 @@
+"""Flat REST surfaces for citation graph + validation.
+
+Two ViewSets:
+
+- ``ReferenceViewSet`` — list/retrieve over ``Reference`` rows with
+  rich slug-based filters (see :mod:`oldp.apps.references.filters`).
+  Suits cross-cutting analytical queries that don't fit into the
+  nested ``/api/cases/<id>/citing_cases/``-style actions on the case
+  and law ViewSets.
+
+- ``CitationViewSet`` — exposes :func:`validate_citation` as a
+  detail-less ``GET /api/citations/validate/`` endpoint.
+
+Both sit on the same service layer as the MCP toolset
+(:mod:`oldp.apps.references.services`); see that module for the
+underlying queries.
+"""
+
+from __future__ import annotations
+
+from django_filters.rest_framework import DjangoFilterBackend
+from rest_framework import mixins, viewsets
+from rest_framework.decorators import action
+from rest_framework.permissions import AllowAny
+from rest_framework.response import Response
+
+from oldp.apps.references.filters import ReferenceFilter
+from oldp.apps.references.models import Reference
+from oldp.apps.references.serializers import ReferenceSerializer
+from oldp.apps.references.services import validate_citation
+
+
+class ReferenceViewSet(
+    mixins.ListModelMixin,
+    mixins.RetrieveModelMixin,
+    viewsets.GenericViewSet,
+):
+    """Read-only flat resource over the citation graph.
+
+    Most consumers should prefer the nested actions on
+    ``/api/cases/<id>/`` and ``/api/laws/<id>/`` (``references``,
+    ``citing_cases``, ``citing_laws``) — they map 1:1 to the common
+    "what does X cite?" / "who cites X?" questions.
+
+    This endpoint exists for queries the nested actions can't express:
+
+    - cross-cutting filters across multiple dimensions (e.g. all cites
+      by BGB-section laws to cases dated 2020-2023);
+    - slug-based access without a prior id round-trip
+      (``?cited_by_law__book__slug=bgb&cited_by_law__slug=823``);
+    - aggregate / analytical queries over the full reference table.
+    """
+
+    permission_classes = [AllowAny]
+    queryset = (
+        Reference.objects.select_related("case", "case__court", "law", "law__book")
+        .prefetch_related(
+            "referencefromcase_set__marker__referenced_by",
+            "referencefromlaw_set__marker__referenced_by__book",
+        )
+        .order_by("-id")
+    )
+    serializer_class = ReferenceSerializer
+    filter_backends = (DjangoFilterBackend,)
+    filterset_class = ReferenceFilter
+
+
+class CitationViewSet(viewsets.GenericViewSet):
+    """Procedural endpoints around citation strings (no underlying model).
+
+    Currently just hosts the ``validate`` action; new procedural
+    operations (citation parsing, batch validation, etc.) can join here.
+    """
+
+    permission_classes = [AllowAny]
+    # Required by GenericViewSet's URL routing even though we don't list.
+    queryset = Reference.objects.none()
+    # No serializer used; validate() returns its own dict shape.
+    serializer_class = ReferenceSerializer
+
+    @action(detail=False, methods=["get"], permission_classes=[AllowAny])
+    def validate(self, request):
+        """Validate a free-form German citation string.
+
+        Query params:
+            citation: the citation text (e.g. ``"§ 823 BGB"``).
+            type: ``"auto"`` (default), ``"file_number"``, ``"ecli"``,
+                or ``"law_reference"``.
+
+        Returns the same dict shape as the MCP ``validate_citation`` tool.
+        """
+        citation = request.query_params.get("citation", "")
+        ctype = request.query_params.get("type", "auto")
+        return Response(validate_citation(citation, ctype))

--- a/oldp/apps/references/api_views.py
+++ b/oldp/apps/references/api_views.py
@@ -19,6 +19,8 @@ underlying queries.
 from __future__ import annotations
 
 from django_filters.rest_framework import DjangoFilterBackend
+from drf_yasg import openapi
+from drf_yasg.utils import swagger_auto_schema
 from rest_framework import mixins, viewsets
 from rest_framework.decorators import action
 from rest_framework.permissions import AllowAny
@@ -26,7 +28,10 @@ from rest_framework.response import Response
 
 from oldp.apps.references.filters import ReferenceFilter
 from oldp.apps.references.models import Reference
-from oldp.apps.references.serializers import ReferenceSerializer
+from oldp.apps.references.serializers import (
+    CitationValidationResponseSerializer,
+    ReferenceSerializer,
+)
 from oldp.apps.references.services import validate_citation
 
 
@@ -65,29 +70,55 @@ class ReferenceViewSet(
     filterset_class = ReferenceFilter
 
 
-class CitationViewSet(viewsets.GenericViewSet):
+class CitationViewSet(viewsets.ViewSet):
     """Procedural endpoints around citation strings (no underlying model).
+
+    Plain ``ViewSet`` (not ``GenericViewSet``) on purpose: there's no
+    queryset to list, so we sidestep the auto-injected ``limit`` /
+    ``offset`` pagination params drf-yasg would otherwise stamp onto
+    every action's schema.
 
     Currently just hosts the ``validate`` action; new procedural
     operations (citation parsing, batch validation, etc.) can join here.
     """
 
     permission_classes = [AllowAny]
-    # Required by GenericViewSet's URL routing even though we don't list.
-    queryset = Reference.objects.none()
-    # No serializer used; validate() returns its own dict shape.
-    serializer_class = ReferenceSerializer
 
+    @swagger_auto_schema(
+        manual_parameters=[
+            openapi.Parameter(
+                "citation",
+                openapi.IN_QUERY,
+                type=openapi.TYPE_STRING,
+                required=True,
+                description=(
+                    "The citation text to validate "
+                    '(e.g. "§ 823 BGB", "VI ZR 123/22", '
+                    '"ECLI:DE:BGH:2023:...").'
+                ),
+            ),
+            openapi.Parameter(
+                "type",
+                openapi.IN_QUERY,
+                type=openapi.TYPE_STRING,
+                enum=["auto", "file_number", "ecli", "law_reference"],
+                required=False,
+                default="auto",
+                description=(
+                    "Type hint. ``auto`` (default) sniffs the input "
+                    "shape; force a specific parser with the others."
+                ),
+            ),
+        ],
+        responses={200: CitationValidationResponseSerializer},
+    )
     @action(detail=False, methods=["get"], permission_classes=[AllowAny])
     def validate(self, request):
         """Validate a free-form German citation string.
 
-        Query params:
-            citation: the citation text (e.g. ``"§ 823 BGB"``).
-            type: ``"auto"`` (default), ``"file_number"``, ``"ecli"``,
-                or ``"law_reference"``.
-
-        Returns the same dict shape as the MCP ``validate_citation`` tool.
+        Returns the same dict shape as the MCP ``validate_citation`` tool:
+        ``{found, type, matches[]}`` on success, ``{found: false, message}``
+        when nothing matches, or ``{error}`` for invalid input.
         """
         citation = request.query_params.get("citation", "")
         ctype = request.query_params.get("type", "auto")

--- a/oldp/apps/references/filters.py
+++ b/oldp/apps/references/filters.py
@@ -1,0 +1,73 @@
+"""Filters for the flat ``/api/references/`` resource.
+
+Designed so users can pose cross-cutting graph questions via query
+params: e.g. "all references involving cases dated 2020-2023 that
+target BGB" via
+``?cited_by_case__date__gte=2020-01-01&cites_law__book__slug=bgb``.
+
+Both id-based and slug-based filter fields are exposed so callers
+don't have to round-trip through ``/api/cases/?slug=…`` to get the id.
+"""
+
+from __future__ import annotations
+
+import django_filters
+
+from oldp.apps.references.models import Reference
+
+
+class ReferenceFilter(django_filters.FilterSet):
+    """Filterset for ``Reference`` rows.
+
+    Filter aliases (preferred user-facing names) point at the underlying
+    relationships:
+
+    - ``cited_by_case`` / ``cited_by_case__slug`` — the source case
+      whose body emitted the cite.
+    - ``cited_by_law`` / ``cited_by_law__slug`` /
+      ``cited_by_law__book__slug`` — the source law whose body emitted
+      the cite.
+    - ``cites_case`` / ``cites_case__slug`` — the target case (the
+      ``Reference.case`` FK).
+    - ``cites_law`` / ``cites_law__slug`` /
+      ``cites_law__book__slug`` — the target law (the ``Reference.law``
+      FK).
+    """
+
+    # Source side (the case/law whose content emitted the cite). Reach
+    # through the through-table → marker → referenced_by chain.
+    cited_by_case = django_filters.NumberFilter(
+        field_name="referencefromcase__marker__referenced_by_id"
+    )
+    cited_by_case__slug = django_filters.CharFilter(
+        field_name="referencefromcase__marker__referenced_by__slug"
+    )
+    cited_by_law = django_filters.NumberFilter(
+        field_name="referencefromlaw__marker__referenced_by_id"
+    )
+    cited_by_law__slug = django_filters.CharFilter(
+        field_name="referencefromlaw__marker__referenced_by__slug"
+    )
+    cited_by_law__book__slug = django_filters.CharFilter(
+        field_name="referencefromlaw__marker__referenced_by__book__slug"
+    )
+
+    # Target side (the case/law the cite resolves to). Reach via the
+    # FKs on Reference.
+    cites_case = django_filters.NumberFilter(field_name="case_id")
+    cites_case__slug = django_filters.CharFilter(field_name="case__slug")
+    cites_law = django_filters.NumberFilter(field_name="law_id")
+    cites_law__slug = django_filters.CharFilter(field_name="law__slug")
+    cites_law__book__slug = django_filters.CharFilter(field_name="law__book__slug")
+
+    # Convenience: only assigned references (drop unresolved ones).
+    assigned = django_filters.BooleanFilter(method="filter_assigned")
+
+    class Meta:
+        model = Reference
+        fields: list[str] = []
+
+    def filter_assigned(self, queryset, name, value):
+        if value:
+            return queryset.exclude(case__isnull=True, law__isnull=True)
+        return queryset.filter(case__isnull=True, law__isnull=True)

--- a/oldp/apps/references/mcp.py
+++ b/oldp/apps/references/mcp.py
@@ -1,58 +1,28 @@
 """MCP tools for citation validation and cross-reference navigation.
 
-These tools expose OLDP's unique cross-reference capabilities, enabling
-AI agents to navigate the citation graph between cases and laws.
+These tools expose OLDP's cross-reference capabilities, enabling AI agents
+to navigate the citation graph between cases and laws. Implementation
+delegates to :mod:`oldp.apps.references.services` so the REST endpoints
+share the same query / serialization logic.
 """
 
-import datetime
 import logging
-import re
 
 from mcp_server import MCPToolset
 
-from oldp.apps.cases.mcp import exclude_future_dated_cases
 from oldp.apps.cases.models import Case
-from oldp.apps.laws.models import Law, LawBook
+from oldp.apps.laws.models import Law
 from oldp.apps.mcp.monitoring import log_tool_call
-from oldp.apps.references.models import CaseReferenceMarker
-
-logger = logging.getLogger("oldp.mcp.tools")
-
-
-def _section_variants(section):
-    """Return likely DB representations of a user-provided section identifier.
-
-    Users typically pass bare numbers ("823", "16a"), but the database stores
-    fully-qualified identifiers — "§ 823" for most codes and "Artikel 1" for
-    the Grundgesetz. Try the input as-is first, then prepend the common
-    German legal prefixes.
-    """
-    s = (section or "").strip()
-    if not s:
-        return []
-    # If the caller already included a prefix, trust it and search only for
-    # that exact form rather than expanding into ambiguous variants.
-    if s.startswith("§") or s.lower().startswith(("art", "artikel")):
-        return [s]
-    return [s, f"§ {s}", f"Artikel {s}", f"Art. {s}"]
-
-
-# Regex patterns for German citation formats
-ECLI_PATTERN = re.compile(r"^ECLI:\w{2}:\w+:\d{4}:[\w.]+$", re.IGNORECASE)
-PARAGRAPH_PATTERN = re.compile(
-    r"(?:§|Art\.?)\s*([\d\w]+(?:\s*[a-z])?)\s+(\w+)", re.IGNORECASE
+from oldp.apps.references.services import (
+    case_forward_references,
+    citing_cases_for_case,
+    citing_cases_for_law,
+    resolve_law_section,
+    serialize_case_summary,
+    validate_citation,
 )
 
-
-def _parse_citation_type(citation):
-    """Detect the type of a German legal citation."""
-    citation = citation.strip()
-    if ECLI_PATTERN.match(citation):
-        return "ecli"
-    if PARAGRAPH_PATTERN.match(citation):
-        return "law_reference"
-    # Default: assume file number (Aktenzeichen)
-    return "file_number"
+logger = logging.getLogger("oldp.mcp.tools")
 
 
 class ReferenceTools(MCPToolset):
@@ -80,141 +50,7 @@ class ReferenceTools(MCPToolset):
             citation_type: Type hint: "auto" (default), "file_number",
                 "ecli", or "law_reference".
         """
-        citation = citation.strip()
-        if not citation:
-            return {"error": "Citation cannot be empty."}
-
-        if citation_type == "auto":
-            citation_type = _parse_citation_type(citation)
-
-        if citation_type == "ecli":
-            cases = list(
-                Case.objects.filter(
-                    ecli__iexact=citation, review_status="accepted"
-                ).select_related("court")[:5]
-            )
-            if cases:
-                return {
-                    "found": True,
-                    "type": "case",
-                    "matches": [
-                        {
-                            "id": c.id,
-                            "slug": c.slug,
-                            "file_number": c.file_number,
-                            "date": str(c.date) if c.date else None,
-                            "court": c.court.name if c.court else None,
-                            "ecli": c.ecli,
-                        }
-                        for c in cases
-                    ],
-                }
-            return {
-                "found": False,
-                "type": "case",
-                "citation_type": "ecli",
-                "message": f"ECLI '{citation}' not found in database.",
-            }
-
-        if citation_type == "law_reference":
-            match = PARAGRAPH_PATTERN.match(citation)
-            if match:
-                section = match.group(1).strip()
-                book_code = match.group(2).strip()
-                book = LawBook.objects.filter(
-                    code__iexact=book_code,
-                    latest=True,
-                    review_status="accepted",
-                ).first()
-                if book:
-                    # Try the user-provided form, then the common
-                    # German prefixed variants ("§ N", "Artikel N", ...).
-                    # Stop at the first variant that yields hits and only
-                    # accept exact matches; an icontains fallback would
-                    # produce spurious siblings (e.g. "§ 1823" for
-                    # "§ 823 BGB", "§ 132" for "§ 32 StGB").
-                    laws = []
-                    for variant in _section_variants(section):
-                        laws = list(
-                            Law.objects.filter(
-                                book=book,
-                                section__iexact=variant,
-                                review_status="accepted",
-                            )[:5]
-                        )
-                        if laws:
-                            break
-                    if laws:
-                        return {
-                            "found": True,
-                            "type": "law",
-                            "matches": [
-                                {
-                                    "id": law.id,
-                                    "book_code": book.code,
-                                    "section": law.section,
-                                    "title": law.title,
-                                    "slug": law.slug,
-                                }
-                                for law in laws
-                            ],
-                        }
-                    return {
-                        "found": False,
-                        "type": "law",
-                        "citation_type": "law_reference",
-                        "message": (
-                            f"Section '{section}' not found in {book_code}. "
-                            "Use list_law_books to check available books."
-                        ),
-                    }
-                return {
-                    "found": False,
-                    "type": "law",
-                    "citation_type": "law_reference",
-                    "message": f"Law book '{book_code}' not found.",
-                }
-
-            return {
-                "found": False,
-                "type": "unknown",
-                "message": f"Could not parse law reference: '{citation}'.",
-            }
-
-        # Default: file number (Aktenzeichen). Use exact-match only —
-        # the previous icontains fallback ran a `LIKE '%…%'` scan over
-        # the whole Case table, which has no trigram index in production
-        # and timed out for invalid inputs. Validation is supposed to be
-        # strict; for fuzzy file-number lookup callers should use
-        # filter_cases instead.
-        cases = list(
-            Case.objects.filter(
-                file_number__iexact=citation, review_status="accepted"
-            ).select_related("court")[:5]
-        )
-        if cases:
-            return {
-                "found": True,
-                "type": "case",
-                "matches": [
-                    {
-                        "id": c.id,
-                        "slug": c.slug,
-                        "file_number": c.file_number,
-                        "date": str(c.date) if c.date else None,
-                        "court": c.court.name if c.court else None,
-                        "ecli": c.ecli,
-                    }
-                    for c in cases
-                ],
-            }
-
-        return {
-            "found": False,
-            "type": "case",
-            "citation_type": "file_number",
-            "message": f"File number '{citation}' not found in database.",
-        }
+        return validate_citation(citation, citation_type)
 
     @log_tool_call
     def get_case_references(self, case_id: int) -> dict:
@@ -229,79 +65,7 @@ class ReferenceTools(MCPToolset):
         case = Case.objects.filter(id=case_id, review_status="accepted").first()
         if not case:
             return {"error": f"Case with ID {case_id} not found."}
-
-        # Use prefetch_related so we resolve all references + their targets
-        # (Law and Case) in a constant number of queries regardless of the
-        # number of markers. This avoids N+1 on ref.law / ref.case access.
-        markers = CaseReferenceMarker.objects.filter(
-            referenced_by=case
-        ).prefetch_related(
-            "references",
-            "references__law",
-            "references__law__book",
-            "references__case",
-        )
-
-        law_refs = []
-        case_refs = []
-        seen_law_ids: set[int] = set()
-        seen_case_ids: set[int] = set()
-
-        for marker in markers:
-            for ref in marker.references.all():
-                if ref.law_id and ref.law_id not in seen_law_ids:
-                    seen_law_ids.add(ref.law_id)
-                    law = ref.law
-                    if law is not None:
-                        law_refs.append(
-                            {
-                                "id": law.id,
-                                "book_code": law.book.code if law.book_id else "",
-                                "section": law.section,
-                                "title": law.title,
-                                "marker_text": marker.text,
-                            }
-                        )
-                if ref.case_id and ref.case_id not in seen_case_ids:
-                    seen_case_ids.add(ref.case_id)
-                    target_case = ref.case
-                    if target_case is not None:
-                        case_refs.append(
-                            {
-                                "id": target_case.id,
-                                "slug": target_case.slug,
-                                "file_number": target_case.file_number,
-                                "date": (
-                                    str(target_case.date) if target_case.date else None
-                                ),
-                                "marker_text": marker.text,
-                            }
-                        )
-
-        # `references_extracted_at` is populated by the extract_refs
-        # processing step (oldp/apps/cases/processing/processing_steps/
-        # extract_refs.py). A null value means extraction has never run
-        # for this case, so an empty references list is genuinely "we
-        # don't know" rather than "the extractor found nothing" — the
-        # signal callers need to decide whether to trust the list or
-        # fall back to reading the full text.
-        return {
-            "case_id": case_id,
-            "case_file_number": case.file_number,
-            "total_law_references": len(law_refs),
-            "total_case_references": len(case_refs),
-            "law_references": law_refs,
-            "case_references": case_refs,
-            "references_extracted_at": (
-                case.references_extracted_at.isoformat()
-                if case.references_extracted_at
-                else None
-            ),
-            "note": (
-                "References are automatically extracted and may be "
-                "incomplete. Verify critical citations against the full text."
-            ),
-        }
+        return case_forward_references(case)
 
     @log_tool_call
     def get_citing_cases(
@@ -312,7 +76,8 @@ class ReferenceTools(MCPToolset):
         """Get reverse references TO a case (cases that cite this case).
 
         Find all cases that reference the given case in their text.
-        Useful for understanding the impact and precedent value of a decision.
+        Useful for understanding the impact and precedent value of a
+        decision.
 
         Args:
             case_id: The database ID of the cited case.
@@ -324,42 +89,20 @@ class ReferenceTools(MCPToolset):
         if not case:
             return {"error": f"Case with ID {case_id} not found."}
 
-        # Single JOIN-based query replaces the previous 4-query chain
-        # (Reference -> ReferenceFromCase -> markers -> Case twice).
-        citing_qs = exclude_future_dated_cases(
-            Case.objects.filter(
-                casereferencemarker__references__case_id=case_id,
-                review_status="accepted",
-            )
-        ).distinct()
-
-        # Materialise the limited slice once; reuse for total to avoid running
-        # the same DISTINCT JOIN twice when result count <= limit.
-        ordered = citing_qs.select_related("court").order_by("-date")
-        sliced = list(ordered[:limit])
-
+        qs = citing_cases_for_case(case)
+        # Materialise the limited slice once; reuse for total to avoid
+        # running the same DISTINCT JOIN twice when result count <= limit.
+        sliced = list(qs[:limit])
         if len(sliced) < limit:
             total = len(sliced)
         else:
-            total = citing_qs.count()
-
-        results = [
-            {
-                "id": c.id,
-                "slug": c.slug,
-                "file_number": c.file_number,
-                "date": str(c.date) if c.date else None,
-                "court": c.court.name if c.court else None,
-                "type": c.type,
-            }
-            for c in sliced
-        ]
+            total = qs.count()
 
         return {
             "cited_case_id": case_id,
             "cited_case_file_number": case.file_number,
             "total_citing_cases": total,
-            "results": results,
+            "results": [serialize_case_summary(c) for c in sliced],
         }
 
     @log_tool_call
@@ -372,8 +115,9 @@ class ReferenceTools(MCPToolset):
     ) -> dict:
         """Find all cases that cite a specific law section.
 
-        Returns cases that reference the given statute section in their text.
-        Useful for understanding how courts interpret a specific provision.
+        Returns cases that reference the given statute section in their
+        text. Useful for understanding how courts interpret a specific
+        provision.
 
         Args:
             book_code: Law book code (e.g. "BGB", "StGB").
@@ -383,8 +127,8 @@ class ReferenceTools(MCPToolset):
         """
         limit = min(max(1, limit), 50)
 
-        primary = None
-        law_ids = []
+        primary: Law | None = None
+        law_ids: list[int] = []
 
         if law_id:
             primary = (
@@ -395,45 +139,16 @@ class ReferenceTools(MCPToolset):
             if primary:
                 law_ids = [primary.id]
         elif book_code and section:
-            # Verify the book exists at all (any revision) so we can give
-            # a precise error when the code is unknown.
-            if not LawBook.objects.filter(
-                code__iexact=book_code, review_status="accepted"
-            ).exists():
-                return {"error": f"Law book '{book_code}' not found."}
+            primary, law_ids = resolve_law_section(book_code, section)
+            if primary is None and not law_ids:
+                # Distinguish "book unknown" from "book exists but section
+                # missing" so callers get a precise hint.
+                from oldp.apps.laws.models import LawBook
 
-            # Aggregate matching Law rows across ALL revisions of the book.
-            # The citation graph FK (Reference.law_id) pins references to
-            # the specific Law row that existed when extraction ran, which
-            # may belong to an older book revision (latest=False). If we
-            # only checked the latest revision we'd miss every citation
-            # extracted before the most recent revision was added — e.g.
-            # for BGB § 823 the live citation graph points at an older
-            # revision id while the latest revision has its own row.
-            laws_qs = Law.objects.filter(
-                book__code__iexact=book_code,
-                review_status="accepted",
-            ).select_related("book")
-
-            matched = []
-            for variant in _section_variants(section):
-                matched = list(laws_qs.filter(section__iexact=variant))
-                if matched:
-                    break
-
-            if matched:
-                # For the response payload report a canonical "primary" row:
-                # prefer the Law whose book is marked latest=True (the row
-                # `get_law_section` would surface), falling back to the most
-                # recent revision_date.
-                primary = next(
-                    (law for law in matched if law.book.latest),
-                    max(
-                        matched,
-                        key=lambda law: law.book.revision_date or datetime.date.min,
-                    ),
-                )
-                law_ids = [law.id for law in matched]
+                if not LawBook.objects.filter(
+                    code__iexact=book_code, review_status="accepted"
+                ).exists():
+                    return {"error": f"Law book '{book_code}' not found."}
         else:
             return {
                 "error": "Provide either law_id, or both book_code and section.",
@@ -441,43 +156,23 @@ class ReferenceTools(MCPToolset):
 
         if not primary or not law_ids:
             return {
-                "error": f"Law section not found for book='{book_code}', section='{section}'.",
+                "error": (
+                    f"Law section not found for book='{book_code}', "
+                    f"section='{section}'."
+                ),
             }
 
-        # Single filtered queryset; evaluate once for the ordered slice and
-        # reuse the sliced list to avoid a second .distinct().count() over
-        # the 3-JOIN graph when we already have the full result set.
-        citing_qs = exclude_future_dated_cases(
-            Case.objects.filter(
-                casereferencemarker__referencefromcase__reference__law_id__in=law_ids,
-                review_status="accepted",
-            )
-        ).distinct()
-
-        ordered = citing_qs.select_related("court").order_by("-date")
-        sliced = list(ordered[:limit])
-
+        qs = citing_cases_for_law(law_ids)
+        sliced = list(qs[:limit])
         if len(sliced) < limit:
             total = len(sliced)
         else:
-            total = citing_qs.count()
-
-        results = [
-            {
-                "id": c.id,
-                "slug": c.slug,
-                "file_number": c.file_number,
-                "date": str(c.date) if c.date else None,
-                "court": c.court.name if c.court else None,
-                "type": c.type,
-            }
-            for c in sliced
-        ]
+            total = qs.count()
 
         return {
             "law_id": primary.id,
             "book_code": primary.book.code if primary.book_id else "",
             "section": primary.section,
             "total_citing_cases": total,
-            "results": results,
+            "results": [serialize_case_summary(c) for c in sliced],
         }

--- a/oldp/apps/references/serializers.py
+++ b/oldp/apps/references/serializers.py
@@ -1,4 +1,14 @@
-"""Serializers for the references REST API."""
+"""Serializers for the references REST API.
+
+Most serializers project model rows into the response shape. The
+``ForwardReferences*`` and ``CitationValidation*`` serializers are
+**schema-only** stand-ins for the dict payloads produced by
+``oldp.apps.references.services``. They aren't used to validate or
+build responses (the service functions already return the final
+shape); they exist so ``drf-yasg`` can render an accurate OpenAPI /
+Swagger spec for the ``@swagger_auto_schema(responses=…)`` decorators
+on the citation actions.
+"""
 
 from __future__ import annotations
 
@@ -99,3 +109,93 @@ class ReferenceSerializer(serializers.ModelSerializer):
         if rfl is not None:
             return rfl.marker.text
         return ""
+
+
+# --- Schema-only serializers (used solely by drf-yasg decorators) -------
+
+
+class ForwardReferenceLawTargetSerializer(serializers.Serializer):
+    """A law target inside a ``forward_references`` payload."""
+
+    id = serializers.IntegerField(read_only=True)
+    book_code = serializers.CharField(read_only=True)
+    book_slug = serializers.CharField(read_only=True)
+    section = serializers.CharField(read_only=True)
+    slug = serializers.CharField(read_only=True)
+    title = serializers.CharField(read_only=True)
+    marker_text = serializers.CharField(read_only=True)
+
+
+class ForwardReferenceCaseTargetSerializer(serializers.Serializer):
+    """A case target inside a ``forward_references`` payload."""
+
+    id = serializers.IntegerField(read_only=True)
+    slug = serializers.CharField(read_only=True)
+    file_number = serializers.CharField(read_only=True)
+    date = serializers.DateField(read_only=True)
+    marker_text = serializers.CharField(read_only=True)
+
+
+class ForwardReferencesResponseSerializer(serializers.Serializer):
+    """Response shape for ``/cases/<id>/references/`` and ``/laws/<id>/references/``.
+
+    Mirrors the dict produced by
+    :func:`oldp.apps.references.services.case_forward_references` /
+    :func:`~oldp.apps.references.services.law_forward_references`. The
+    case- and law-rooted variants share every field except for the
+    primary-key flavour: case payloads carry ``case_id`` +
+    ``case_file_number``; law payloads carry ``law_id`` +
+    ``law_section``. We document both pairs as optional here so a
+    single serializer covers both endpoints.
+    """
+
+    case_id = serializers.IntegerField(read_only=True, required=False)
+    case_file_number = serializers.CharField(read_only=True, required=False)
+    law_id = serializers.IntegerField(read_only=True, required=False)
+    law_section = serializers.CharField(read_only=True, required=False)
+    total_law_references = serializers.IntegerField(read_only=True)
+    total_case_references = serializers.IntegerField(read_only=True)
+    law_references = ForwardReferenceLawTargetSerializer(many=True, read_only=True)
+    case_references = ForwardReferenceCaseTargetSerializer(many=True, read_only=True)
+    references_extracted_at = serializers.DateTimeField(read_only=True, allow_null=True)
+    note = serializers.CharField(read_only=True)
+
+
+class CitationValidationMatchCaseSerializer(serializers.Serializer):
+    """Single case match inside a ``validate_citation`` response."""
+
+    id = serializers.IntegerField(read_only=True)
+    slug = serializers.CharField(read_only=True)
+    file_number = serializers.CharField(read_only=True)
+    date = serializers.DateField(read_only=True, allow_null=True)
+    court = serializers.CharField(read_only=True, allow_null=True)
+    ecli = serializers.CharField(read_only=True, allow_null=True)
+
+
+class CitationValidationMatchLawSerializer(serializers.Serializer):
+    """Single law match inside a ``validate_citation`` response."""
+
+    id = serializers.IntegerField(read_only=True)
+    book_code = serializers.CharField(read_only=True)
+    section = serializers.CharField(read_only=True)
+    title = serializers.CharField(read_only=True)
+    slug = serializers.CharField(read_only=True)
+
+
+class CitationValidationResponseSerializer(serializers.Serializer):
+    """Response shape for ``/api/citations/validate/``.
+
+    Either ``matches`` is populated (success) or ``message`` is set
+    (not-found / parse-error). The serializer documents both cases as
+    optional so the schema reflects either path. A request-level
+    ``error`` field handles the empty-input case.
+    """
+
+    found = serializers.BooleanField(read_only=True, required=False)
+    type = serializers.CharField(read_only=True, required=False)
+    citation_type = serializers.CharField(read_only=True, required=False)
+    matches = serializers.ListField(
+        child=serializers.DictField(), read_only=True, required=False
+    )
+    message = serializers.CharField(read_only=True, required=False)
+    error = serializers.CharField(read_only=True, required=False)

--- a/oldp/apps/references/serializers.py
+++ b/oldp/apps/references/serializers.py
@@ -1,0 +1,101 @@
+"""Serializers for the references REST API."""
+
+from __future__ import annotations
+
+from rest_framework import serializers
+
+from oldp.apps.references.models import Reference
+
+
+class ReferenceTargetCaseSerializer(serializers.Serializer):
+    """Compact case projection used as a citation target."""
+
+    id = serializers.IntegerField(read_only=True)
+    slug = serializers.CharField(read_only=True)
+    file_number = serializers.CharField(read_only=True)
+    date = serializers.DateField(read_only=True)
+
+
+class ReferenceTargetLawSerializer(serializers.Serializer):
+    """Compact law projection used as a citation target."""
+
+    id = serializers.IntegerField(read_only=True)
+    slug = serializers.CharField(read_only=True)
+    section = serializers.CharField(read_only=True)
+    title = serializers.CharField(read_only=True)
+    book_id = serializers.IntegerField(read_only=True)
+    book_slug = serializers.SerializerMethodField()
+    book_code = serializers.SerializerMethodField()
+
+    def get_book_slug(self, law) -> str:
+        return law.book.slug if law.book_id else ""
+
+    def get_book_code(self, law) -> str:
+        return law.book.code if law.book_id else ""
+
+
+class ReferenceSerializer(serializers.ModelSerializer):
+    """Full ``Reference`` row for the flat ``/api/references/`` resource.
+
+    Surfaces the citation as a record of (source_kind, source_id) →
+    (target_kind, target_id), via the through-table marker. Source is
+    derived from the marker; target is the FK on the ``Reference``
+    itself.
+    """
+
+    case = ReferenceTargetCaseSerializer(read_only=True, allow_null=True)
+    law = ReferenceTargetLawSerializer(read_only=True, allow_null=True)
+    cited_by = serializers.SerializerMethodField()
+    marker_text = serializers.SerializerMethodField()
+
+    class Meta:
+        model = Reference
+        fields = (
+            "id",
+            "to",
+            "to_hash",
+            "case",
+            "law",
+            "cited_by",
+            "marker_text",
+        )
+        read_only_fields = fields
+
+    def get_cited_by(self, ref) -> dict | None:
+        """Identify the source content + the marker that emitted the cite.
+
+        Reference rows are attached to either a case marker (via the
+        ``ReferenceFromCase`` through-table) or a law marker (via
+        ``ReferenceFromLaw``). For the flat API we surface a uniform
+        ``{kind, id, slug, marker_text}`` shape regardless of source.
+        """
+        rfc = ref.referencefromcase_set.first()
+        if rfc is not None:
+            src = rfc.marker.referenced_by
+            return {
+                "kind": "case",
+                "id": src.id,
+                "slug": src.slug,
+                "file_number": src.file_number,
+            }
+        rfl = ref.referencefromlaw_set.first()
+        if rfl is not None:
+            src = rfl.marker.referenced_by
+            return {
+                "kind": "law",
+                "id": src.id,
+                "slug": src.slug,
+                "section": src.section,
+                "book_slug": src.book.slug if src.book_id else "",
+            }
+        return None
+
+    def get_marker_text(self, ref) -> str:
+        """Marker.text on the source side, regardless of case/law origin."""
+        rfc = ref.referencefromcase_set.first()
+        if rfc is not None:
+            return rfc.marker.text
+        rfl = ref.referencefromlaw_set.first()
+        if rfl is not None:
+            return rfl.marker.text
+        return ""

--- a/oldp/apps/references/services/__init__.py
+++ b/oldp/apps/references/services/__init__.py
@@ -1,0 +1,40 @@
+"""Reference / citation services.
+
+Pure-Python query helpers for the citation graph and citation
+validation. The MCP toolset and the REST API both delegate here so
+query and serialization logic stays single-sourced.
+"""
+
+from oldp.apps.references.services.citation_graph import (
+    CITATION_NOTE,
+    case_forward_references,
+    citing_cases_for_case,
+    citing_cases_for_law,
+    citing_laws_for_case,
+    citing_laws_for_law,
+    law_forward_references,
+    resolve_law_section,
+    serialize_case_summary,
+    serialize_law_summary,
+)
+from oldp.apps.references.services.citation_lookup import (
+    parse_citation_type,
+    section_variants,
+    validate_citation,
+)
+
+__all__ = [
+    "CITATION_NOTE",
+    "case_forward_references",
+    "citing_cases_for_case",
+    "citing_cases_for_law",
+    "citing_laws_for_case",
+    "citing_laws_for_law",
+    "law_forward_references",
+    "parse_citation_type",
+    "resolve_law_section",
+    "section_variants",
+    "serialize_case_summary",
+    "serialize_law_summary",
+    "validate_citation",
+]

--- a/oldp/apps/references/services/citation_graph.py
+++ b/oldp/apps/references/services/citation_graph.py
@@ -119,9 +119,7 @@ def _forward_references_payload(
         "total_case_references": len(case_refs),
         "law_references": law_refs,
         "case_references": case_refs,
-        "references_extracted_at": (
-            extracted_at.isoformat() if extracted_at else None
-        ),
+        "references_extracted_at": (extracted_at.isoformat() if extracted_at else None),
         "note": CITATION_NOTE,
     }
 

--- a/oldp/apps/references/services/citation_graph.py
+++ b/oldp/apps/references/services/citation_graph.py
@@ -1,0 +1,318 @@
+"""Citation graph traversal helpers.
+
+Forward + reverse lookups across the citation graph. MCP tools and REST
+endpoints both call into this module so query/serialization logic stays
+single-sourced.
+
+Functions that return response-ready payloads (``case_forward_references``,
+``law_forward_references``) yield dicts. Functions that need to be
+paginated by the caller return ``QuerySet``s — REST hands them to DRF's
+paginator, MCP tools take a slice.
+"""
+
+from __future__ import annotations
+
+import datetime
+from typing import Iterable
+
+from django.db.models import QuerySet
+
+from oldp.apps.cases.mcp import exclude_future_dated_cases
+from oldp.apps.cases.models import Case
+from oldp.apps.laws.models import Law, LawBook
+from oldp.apps.references.models import (
+    CaseReferenceMarker,
+    LawReferenceMarker,
+)
+from oldp.apps.references.services.citation_lookup import section_variants
+
+CITATION_NOTE = (
+    "References are automatically extracted and may be incomplete. "
+    "Verify critical citations against the full text."
+)
+
+
+# --- Serialization helpers ----------------------------------------------
+
+
+def serialize_case_summary(case: Case) -> dict:
+    """Compact case representation used by graph endpoints + MCP tools."""
+    return {
+        "id": case.id,
+        "slug": case.slug,
+        "file_number": case.file_number,
+        "date": str(case.date) if case.date else None,
+        "court": case.court.name if case.court else None,
+        "type": case.type,
+    }
+
+
+def serialize_law_summary(law: Law) -> dict:
+    """Compact law representation used by graph endpoints + MCP tools."""
+    book = law.book if law.book_id else None
+    return {
+        "id": law.id,
+        "book_code": book.code if book else "",
+        "book_slug": book.slug if book else "",
+        "section": law.section,
+        "slug": law.slug,
+        "title": law.title,
+    }
+
+
+# --- Forward references (what does X cite?) -----------------------------
+
+
+def _walk_forward_references(markers, *, marker_text_field: str = "text"):
+    """Iterate (kind, target_dict, marker_text) over a marker queryset.
+
+    Shared between ``case_forward_references`` and
+    ``law_forward_references``: both walk the same shape of marker
+    rows, differing only in the source content type. Yields ``("law",
+    dict, marker_text)`` and ``("case", dict, marker_text)`` tuples.
+    """
+    seen_law_ids: set[int] = set()
+    seen_case_ids: set[int] = set()
+    for marker in markers:
+        for ref in marker.references.all():
+            if ref.law_id and ref.law_id not in seen_law_ids:
+                seen_law_ids.add(ref.law_id)
+                if ref.law is not None:
+                    target = serialize_law_summary(ref.law)
+                    target["marker_text"] = getattr(marker, marker_text_field)
+                    yield ("law", target)
+            if ref.case_id and ref.case_id not in seen_case_ids:
+                seen_case_ids.add(ref.case_id)
+                if ref.case is not None:
+                    target = {
+                        "id": ref.case.id,
+                        "slug": ref.case.slug,
+                        "file_number": ref.case.file_number,
+                        "date": str(ref.case.date) if ref.case.date else None,
+                        "marker_text": getattr(marker, marker_text_field),
+                    }
+                    yield ("case", target)
+
+
+def _forward_references_payload(
+    *,
+    source_id: int,
+    source_label: str,
+    source_value,
+    markers,
+    extracted_at,
+) -> dict:
+    """Bundle the walked references into the response shape."""
+    law_refs = []
+    case_refs = []
+    for kind, target in _walk_forward_references(markers):
+        if kind == "law":
+            law_refs.append(target)
+        else:
+            case_refs.append(target)
+    return {
+        f"{source_label}_id": source_id,
+        f"{source_label}_file_number"
+        if source_label == "case"
+        else f"{source_label}_section": source_value,
+        "total_law_references": len(law_refs),
+        "total_case_references": len(case_refs),
+        "law_references": law_refs,
+        "case_references": case_refs,
+        "references_extracted_at": (
+            extracted_at.isoformat() if extracted_at else None
+        ),
+        "note": CITATION_NOTE,
+    }
+
+
+def case_forward_references(case: Case) -> dict:
+    """All laws + cases that ``case`` cites in its body.
+
+    Mirrors the shape of the MCP ``get_case_references`` tool. Uses
+    prefetch so target rows resolve in a constant number of queries.
+    """
+    markers = CaseReferenceMarker.objects.filter(referenced_by=case).prefetch_related(
+        "references",
+        "references__law",
+        "references__law__book",
+        "references__case",
+    )
+    return _forward_references_payload(
+        source_id=case.id,
+        source_label="case",
+        source_value=case.file_number,
+        markers=markers,
+        extracted_at=case.references_extracted_at,
+    )
+
+
+def law_forward_references(law: Law) -> dict:
+    """All laws + cases that ``law`` cites in its body.
+
+    Same shape as :func:`case_forward_references` but rooted on a
+    ``Law`` and walking ``LawReferenceMarker`` rows. Laws can in
+    principle cite both other laws and cases; in practice they
+    overwhelmingly cite laws (intra-book ``§ N`` cross-references).
+    """
+    markers = LawReferenceMarker.objects.filter(referenced_by=law).prefetch_related(
+        "references",
+        "references__law",
+        "references__law__book",
+        "references__case",
+    )
+    return _forward_references_payload(
+        source_id=law.id,
+        source_label="law",
+        source_value=law.section,
+        markers=markers,
+        extracted_at=law.references_extracted_at,
+    )
+
+
+# --- Reverse references (who cites X?) -----------------------------------
+
+
+def _normalize_law_target(law_or_ids: Law | int | Iterable[int]) -> list[int]:
+    """Coerce a Law / id / id-iterable into a list of law ids.
+
+    Reverse-citation queries hit ``Reference.law_id__in=…`` so all
+    revisions of the same statute section can be resolved together —
+    ``Reference.law_id`` is pinned to the specific ``Law`` row that
+    existed when extraction ran, which may be on an older book
+    revision.
+    """
+    if isinstance(law_or_ids, Law):
+        return [law_or_ids.id]
+    if isinstance(law_or_ids, int):
+        return [law_or_ids]
+    return list(law_or_ids)
+
+
+def citing_cases_for_case(case: Case) -> QuerySet[Case]:
+    """``Case`` queryset of cases whose body cites ``case``."""
+    return (
+        exclude_future_dated_cases(
+            Case.objects.filter(
+                casereferencemarker__references__case_id=case.id,
+                review_status="accepted",
+            )
+        )
+        .select_related("court")
+        .order_by("-date")
+        .distinct()
+    )
+
+
+def citing_cases_for_law(law_or_ids: Law | int | Iterable[int]) -> QuerySet[Case]:
+    """``Case`` queryset of cases whose body cites the given law section.
+
+    Accepts a single ``Law``, a single id, or a list of ids (for
+    cross-revision lookups via :func:`resolve_law_section`).
+    """
+    law_ids = _normalize_law_target(law_or_ids)
+    return (
+        exclude_future_dated_cases(
+            Case.objects.filter(
+                casereferencemarker__referencefromcase__reference__law_id__in=law_ids,
+                review_status="accepted",
+            )
+        )
+        .select_related("court")
+        .order_by("-date")
+        .distinct()
+    )
+
+
+def citing_laws_for_case(case: Case) -> QuerySet[Law]:
+    """``Law`` queryset of laws whose body cites ``case``.
+
+    Symmetric to :func:`citing_cases_for_case`. Rare in practice — laws
+    overwhelmingly cite other laws, not cases — but exposed for
+    symmetry and to support analytical queries against the flat
+    ``/api/references/`` resource.
+    """
+    return (
+        Law.objects.filter(
+            lawreferencemarker__references__case_id=case.id,
+            review_status="accepted",
+            book__latest=True,
+        )
+        .select_related("book")
+        .order_by("book__order", "order")
+        .distinct()
+    )
+
+
+def citing_laws_for_law(law_or_ids: Law | int | Iterable[int]) -> QuerySet[Law]:
+    """``Law`` queryset of laws whose body cites the given law section."""
+    law_ids = _normalize_law_target(law_or_ids)
+    return (
+        Law.objects.filter(
+            lawreferencemarker__referencefromlaw__reference__law_id__in=law_ids,
+            review_status="accepted",
+            book__latest=True,
+        )
+        .select_related("book")
+        .order_by("book__order", "order")
+        .distinct()
+    )
+
+
+# --- Slug → law-row resolution ------------------------------------------
+
+
+def resolve_law_section(book_code: str, section: str) -> tuple[Law | None, list[int]]:
+    """Resolve ``(book_code, section)`` to a primary ``Law`` + all matching ids.
+
+    Aggregates matching ``Law`` rows across **all revisions** of the
+    book: ``Reference.law_id`` pins references to the specific row that
+    existed when extraction ran, which may be on an older revision. If
+    we only checked the latest revision we'd miss every citation
+    extracted before the most recent revision was added.
+
+    Returns:
+        ``(primary, [law.id, …])`` where ``primary`` is the canonical
+        row to surface in the response (latest revision preferred),
+        and the id list is the full cross-revision set for graph
+        queries. Returns ``(None, [])`` when no match.
+    """
+    if not LawBook.objects.filter(
+        code__iexact=book_code, review_status="accepted"
+    ).exists():
+        return None, []
+
+    laws_qs = Law.objects.filter(
+        book__code__iexact=book_code, review_status="accepted"
+    ).select_related("book")
+
+    matched: list[Law] = []
+    for variant in section_variants(section):
+        matched = list(laws_qs.filter(section__iexact=variant))
+        if matched:
+            break
+
+    if not matched:
+        return None, []
+
+    # Prefer the row whose book is marked latest; otherwise pick the most
+    # recent revision_date.
+    primary = next(
+        (law for law in matched if law.book.latest),
+        max(matched, key=lambda law: law.book.revision_date or datetime.date.min),
+    )
+    return primary, [law.id for law in matched]
+
+
+__all__ = [
+    "CITATION_NOTE",
+    "case_forward_references",
+    "citing_cases_for_case",
+    "citing_cases_for_law",
+    "citing_laws_for_case",
+    "citing_laws_for_law",
+    "law_forward_references",
+    "resolve_law_section",
+    "serialize_case_summary",
+    "serialize_law_summary",
+]

--- a/oldp/apps/references/services/citation_lookup.py
+++ b/oldp/apps/references/services/citation_lookup.py
@@ -1,0 +1,213 @@
+"""Citation parsing + validation.
+
+Determines whether a free-form German citation string (Aktenzeichen,
+ECLI, or paragraph reference) corresponds to a row in the local DB.
+Mirrors the shape of the legacy ``ReferenceTools.validate_citation``
+MCP tool — moved here so REST endpoints can reuse the same logic.
+"""
+
+from __future__ import annotations
+
+import re
+
+from oldp.apps.cases.models import Case
+from oldp.apps.laws.models import Law, LawBook
+
+# Regex patterns for German citation formats.
+ECLI_PATTERN = re.compile(r"^ECLI:\w{2}:\w+:\d{4}:[\w.]+$", re.IGNORECASE)
+PARAGRAPH_PATTERN = re.compile(
+    r"(?:§|Art\.?)\s*([\d\w]+(?:\s*[a-z])?)\s+(\w+)", re.IGNORECASE
+)
+
+
+def section_variants(section: str) -> list[str]:
+    """Return likely DB representations of a user-provided section identifier.
+
+    Users typically pass bare numbers ("823", "16a"), but the database
+    stores fully-qualified identifiers — "§ 823" for most codes and
+    "Artikel 1" for the Grundgesetz. Try the input as-is first, then
+    prepend the common German legal prefixes. If the caller already
+    included a prefix, trust it and search only that exact form rather
+    than expanding into ambiguous variants.
+    """
+    s = (section or "").strip()
+    if not s:
+        return []
+    if s.startswith("§") or s.lower().startswith(("art", "artikel")):
+        return [s]
+    return [s, f"§ {s}", f"Artikel {s}", f"Art. {s}"]
+
+
+def parse_citation_type(citation: str) -> str:
+    """Detect the type of a German legal citation.
+
+    Returns ``"ecli"``, ``"law_reference"``, or ``"file_number"`` (the
+    default when no other pattern matches).
+    """
+    citation = citation.strip()
+    if ECLI_PATTERN.match(citation):
+        return "ecli"
+    if PARAGRAPH_PATTERN.match(citation):
+        return "law_reference"
+    return "file_number"
+
+
+def _serialize_case_match(case: Case) -> dict:
+    return {
+        "id": case.id,
+        "slug": case.slug,
+        "file_number": case.file_number,
+        "date": str(case.date) if case.date else None,
+        "court": case.court.name if case.court else None,
+        "ecli": case.ecli,
+    }
+
+
+def _serialize_law_match(law: Law, book_code: str) -> dict:
+    return {
+        "id": law.id,
+        "book_code": book_code,
+        "section": law.section,
+        "title": law.title,
+        "slug": law.slug,
+    }
+
+
+def _validate_ecli(citation: str) -> dict:
+    cases = list(
+        Case.objects.filter(
+            ecli__iexact=citation, review_status="accepted"
+        ).select_related("court")[:5]
+    )
+    if cases:
+        return {
+            "found": True,
+            "type": "case",
+            "matches": [_serialize_case_match(c) for c in cases],
+        }
+    return {
+        "found": False,
+        "type": "case",
+        "citation_type": "ecli",
+        "message": f"ECLI '{citation}' not found in database.",
+    }
+
+
+def _validate_law_reference(citation: str) -> dict:
+    match = PARAGRAPH_PATTERN.match(citation)
+    if not match:
+        return {
+            "found": False,
+            "type": "unknown",
+            "message": f"Could not parse law reference: '{citation}'.",
+        }
+
+    section = match.group(1).strip()
+    book_code = match.group(2).strip()
+    book = LawBook.objects.filter(
+        code__iexact=book_code,
+        latest=True,
+        review_status="accepted",
+    ).first()
+    if not book:
+        return {
+            "found": False,
+            "type": "law",
+            "citation_type": "law_reference",
+            "message": f"Law book '{book_code}' not found.",
+        }
+
+    # Try the user-provided form, then the common German prefixed
+    # variants ("§ N", "Artikel N", ...). Stop at the first variant
+    # that yields hits and only accept exact matches; an icontains
+    # fallback would produce spurious siblings (e.g. "§ 1823" for
+    # "§ 823 BGB", "§ 132" for "§ 32 StGB").
+    laws: list[Law] = []
+    for variant in section_variants(section):
+        laws = list(
+            Law.objects.filter(
+                book=book,
+                section__iexact=variant,
+                review_status="accepted",
+            )[:5]
+        )
+        if laws:
+            break
+
+    if laws:
+        return {
+            "found": True,
+            "type": "law",
+            "matches": [_serialize_law_match(law, book.code) for law in laws],
+        }
+    return {
+        "found": False,
+        "type": "law",
+        "citation_type": "law_reference",
+        "message": (
+            f"Section '{section}' not found in {book_code}. "
+            "Use list_law_books to check available books."
+        ),
+    }
+
+
+def _validate_file_number(citation: str) -> dict:
+    # Use exact-match only — the previous icontains fallback ran a
+    # ``LIKE '%…%'`` scan over the whole Case table, which has no
+    # trigram index in production and timed out for invalid inputs.
+    # Validation is supposed to be strict; for fuzzy file-number
+    # lookup callers should use filter_cases instead.
+    cases = list(
+        Case.objects.filter(
+            file_number__iexact=citation, review_status="accepted"
+        ).select_related("court")[:5]
+    )
+    if cases:
+        return {
+            "found": True,
+            "type": "case",
+            "matches": [_serialize_case_match(c) for c in cases],
+        }
+    return {
+        "found": False,
+        "type": "case",
+        "citation_type": "file_number",
+        "message": f"File number '{citation}' not found in database.",
+    }
+
+
+def validate_citation(citation: str, citation_type: str = "auto") -> dict:
+    """Validate a German legal citation against the local DB.
+
+    Args:
+        citation: The citation string (e.g. ``"VI ZR 123/22"``,
+            ``"ECLI:DE:BGH:2023:..."``, ``"§ 823 BGB"``).
+        citation_type: ``"auto"`` (default), ``"file_number"``,
+            ``"ecli"``, or ``"law_reference"``.
+
+    Returns:
+        A dict with ``found``, ``type``, and either ``matches`` (list of
+        record dicts) or ``message`` (human-readable not-found text).
+        Mirrors the shape of the MCP ``validate_citation`` tool.
+    """
+    citation = (citation or "").strip()
+    if not citation:
+        return {"error": "Citation cannot be empty."}
+
+    if citation_type == "auto":
+        citation_type = parse_citation_type(citation)
+
+    if citation_type == "ecli":
+        return _validate_ecli(citation)
+    if citation_type == "law_reference":
+        return _validate_law_reference(citation)
+    return _validate_file_number(citation)
+
+
+__all__ = [
+    "ECLI_PATTERN",
+    "PARAGRAPH_PATTERN",
+    "parse_citation_type",
+    "section_variants",
+    "validate_citation",
+]

--- a/oldp/apps/references/tests/test_api.py
+++ b/oldp/apps/references/tests/test_api.py
@@ -1,0 +1,259 @@
+"""Tests for the citation REST API.
+
+Covers the nested actions on ``CaseViewSet`` / ``LawViewSet`` and the
+flat ``/api/references/`` resource. The MCP tests in
+``test_mcp.py`` exercise the same underlying service-layer code via the
+MCP toolset, so this file deliberately focuses on the new HTTP surfaces:
+URL routing, serialization, slug-based filtering, and the
+``/api/citations/validate/`` procedural endpoint.
+"""
+
+from datetime import date
+
+from django.test import TestCase, override_settings
+from rest_framework.test import APIClient
+
+from oldp.apps.cases.models import Case
+from oldp.apps.courts.models import Country, Court, State
+from oldp.apps.laws.models import Law, LawBook
+from oldp.apps.references.models import (
+    CaseReferenceMarker,
+    LawReferenceMarker,
+    Reference,
+    ReferenceFromCase,
+    ReferenceFromLaw,
+)
+
+
+def _make_court(slug: str, code: str | None = None) -> Court:
+    de, _ = Country.objects.get_or_create(code="DE", defaults={"name": "Germany"})
+    state, _ = State.objects.get_or_create(
+        pk=1, defaults={"name": "Test", "country": de, "slug": "test"}
+    )
+    return Court.objects.create(
+        name=f"Court {slug}",
+        slug=slug,
+        code=code or slug.upper()[:20],
+        state=state,
+        review_status="accepted",
+    )
+
+
+def _make_book(slug: str, code: str) -> LawBook:
+    return LawBook.objects.create(
+        code=code,
+        title=code,
+        slug=slug,
+        latest=True,
+        revision_date="2024-01-01",
+        review_status="accepted",
+    )
+
+
+def _make_law(book: LawBook, section: str, slug: str) -> Law:
+    return Law.objects.create(
+        book=book,
+        section=section,
+        slug=slug,
+        review_status="accepted",
+    )
+
+
+def _make_case(court: Court, file_number: str, slug: str) -> Case:
+    return Case.objects.create(
+        court=court,
+        file_number=file_number,
+        slug=slug,
+        date=date(2024, 1, 1),
+        ecli=f"ECLI:DE:TEST:{slug}",
+        review_status="accepted",
+    )
+
+
+def _attach_case_law_ref(case: Case, law: Law, marker_text: str = "§ 1 BGB") -> None:
+    marker = CaseReferenceMarker.objects.create(
+        referenced_by=case, text=marker_text, start=0, end=len(marker_text)
+    )
+    ref = Reference.objects.create(law=law, to=marker_text)
+    ref.set_to_hash()
+    ref.save()
+    ReferenceFromCase.objects.create(marker=marker, reference=ref)
+
+
+def _attach_case_case_ref(source: Case, target: Case, marker_text: str) -> None:
+    marker = CaseReferenceMarker.objects.create(
+        referenced_by=source, text=marker_text, start=0, end=len(marker_text)
+    )
+    ref = Reference.objects.create(case=target, to=marker_text)
+    ref.set_to_hash()
+    ref.save()
+    ReferenceFromCase.objects.create(marker=marker, reference=ref)
+
+
+def _attach_law_law_ref(source: Law, target: Law, marker_text: str = "§ 1") -> None:
+    marker = LawReferenceMarker.objects.create(
+        referenced_by=source, text=marker_text, start=0, end=len(marker_text)
+    )
+    ref = Reference.objects.create(law=target, to=marker_text)
+    ref.set_to_hash()
+    ref.save()
+    ReferenceFromLaw.objects.create(marker=marker, reference=ref)
+
+
+@override_settings(
+    CACHES={"default": {"BACKEND": "django.core.cache.backends.dummy.DummyCache"}}
+)
+class CitationApiTestCase(TestCase):
+    """Exercise nested + flat citation surfaces."""
+
+    @classmethod
+    def setUpTestData(cls):
+        # Books + laws
+        cls.bgb = _make_book("bgb", "BGB")
+        cls.law_823 = _make_law(cls.bgb, "§ 823", "823")
+        cls.law_249 = _make_law(cls.bgb, "§ 249", "249")
+        cls.gg = _make_book("gg", "GG")
+        cls.gg_art1 = _make_law(cls.gg, "Artikel 1", "artikel-1")
+
+        # Courts + cases
+        cls.bgh = _make_court("bgh", "BGH")
+        cls.lg = _make_court("lg-koln", "LGK")
+        cls.case_a = _make_case(cls.bgh, "VI ZR 1/24", "bgh-vi-zr-124")
+        cls.case_b = _make_case(cls.lg, "1 O 100/24", "lg-1-o-10024")
+        cls.case_c = _make_case(cls.bgh, "VI ZR 2/24", "bgh-vi-zr-224")
+
+        # Forward refs from case_a: cites §823 BGB and case_b
+        _attach_case_law_ref(cls.case_a, cls.law_823, "§ 823 BGB")
+        _attach_case_case_ref(cls.case_a, cls.case_b, "1 O 100/24")
+        # case_c also cites §823 → makes the law's citing_cases set
+        _attach_case_law_ref(cls.case_c, cls.law_823, "§ 823 BGB")
+        # Forward refs from law_823 → law_249 (intra-book)
+        _attach_law_law_ref(cls.law_823, cls.law_249, "§ 249")
+
+    def setUp(self):
+        self.client = APIClient()
+
+    # --- Nested actions on CaseViewSet ----------------------------------
+
+    def test_case_references_action(self):
+        """``/api/cases/<id>/references/`` returns the forward-refs dict."""
+        resp = self.client.get(f"/api/cases/{self.case_a.id}/references/")
+        self.assertEqual(resp.status_code, 200)
+        body = resp.json()
+        self.assertEqual(body["case_id"], self.case_a.id)
+        self.assertEqual(body["total_law_references"], 1)
+        self.assertEqual(body["total_case_references"], 1)
+        self.assertEqual(body["law_references"][0]["id"], self.law_823.id)
+        self.assertEqual(body["case_references"][0]["id"], self.case_b.id)
+
+    def test_case_citing_cases_action(self):
+        """``/api/cases/<id>/citing_cases/`` paginates."""
+        resp = self.client.get(f"/api/cases/{self.case_b.id}/citing_cases/")
+        self.assertEqual(resp.status_code, 200)
+        body = resp.json()
+        self.assertEqual(body["count"], 1)
+        self.assertEqual(body["results"][0]["id"], self.case_a.id)
+
+    def test_case_citing_laws_action_empty(self):
+        """No laws cite a fixture case in this scenario."""
+        resp = self.client.get(f"/api/cases/{self.case_a.id}/citing_laws/")
+        self.assertEqual(resp.status_code, 200)
+        self.assertEqual(resp.json()["count"], 0)
+
+    # --- Nested actions on LawViewSet -----------------------------------
+
+    def test_law_references_action(self):
+        resp = self.client.get(f"/api/laws/{self.law_823.id}/references/")
+        self.assertEqual(resp.status_code, 200)
+        body = resp.json()
+        self.assertEqual(body["law_id"], self.law_823.id)
+        self.assertEqual(body["total_law_references"], 1)
+        self.assertEqual(body["law_references"][0]["id"], self.law_249.id)
+
+    def test_law_citing_cases_action(self):
+        resp = self.client.get(f"/api/laws/{self.law_823.id}/citing_cases/")
+        self.assertEqual(resp.status_code, 200)
+        ids = {r["id"] for r in resp.json()["results"]}
+        self.assertIn(self.case_a.id, ids)
+        self.assertIn(self.case_c.id, ids)
+
+    def test_law_citing_laws_action_empty(self):
+        resp = self.client.get(f"/api/laws/{self.law_249.id}/citing_laws/")
+        self.assertEqual(resp.status_code, 200)
+        # law_823 cites law_249 → 249 has 1 citing law
+        self.assertEqual(resp.json()["count"], 1)
+        self.assertEqual(resp.json()["results"][0]["id"], self.law_823.id)
+
+    # --- Flat ReferenceViewSet ------------------------------------------
+
+    def test_flat_filter_by_cited_by_case_id(self):
+        resp = self.client.get(f"/api/references/?cited_by_case={self.case_a.id}")
+        self.assertEqual(resp.status_code, 200)
+        # case_a has 2 outbound refs (law + case)
+        self.assertEqual(resp.json()["count"], 2)
+
+    def test_flat_filter_by_cited_by_case_slug(self):
+        resp = self.client.get(
+            f"/api/references/?cited_by_case__slug={self.case_a.slug}"
+        )
+        self.assertEqual(resp.json()["count"], 2)
+
+    def test_flat_filter_by_cited_by_law_book_slug_and_slug(self):
+        resp = self.client.get(
+            "/api/references/?cited_by_law__book__slug=bgb&cited_by_law__slug=823"
+        )
+        self.assertEqual(resp.status_code, 200)
+        # law_823 has 1 outbound ref (to law_249)
+        self.assertEqual(resp.json()["count"], 1)
+
+    def test_flat_filter_by_cites_case_id(self):
+        resp = self.client.get(f"/api/references/?cites_case={self.case_b.id}")
+        self.assertEqual(resp.json()["count"], 1)
+
+    def test_flat_filter_by_cites_law_book_slug_and_slug(self):
+        resp = self.client.get(
+            "/api/references/?cites_law__book__slug=bgb&cites_law__slug=823"
+        )
+        # Two cases cite §823 BGB
+        self.assertEqual(resp.json()["count"], 2)
+
+    def test_flat_assigned_filter(self):
+        # All refs in this fixture are assigned, so unassigned=0.
+        resp = self.client.get("/api/references/?assigned=false")
+        self.assertEqual(resp.json()["count"], 0)
+        resp = self.client.get("/api/references/?assigned=true")
+        self.assertGreater(resp.json()["count"], 0)
+
+    def test_flat_serializer_shape(self):
+        resp = self.client.get(
+            f"/api/references/?cited_by_case={self.case_a.id}&cites_law__slug=823"
+        )
+        self.assertEqual(resp.json()["count"], 1)
+        ref = resp.json()["results"][0]
+        # Spot-check key shape so a serialiser regression is loud.
+        for field in ("id", "to", "to_hash", "case", "law", "cited_by", "marker_text"):
+            self.assertIn(field, ref)
+        self.assertEqual(ref["law"]["book_slug"], "bgb")
+        self.assertEqual(ref["cited_by"]["kind"], "case")
+
+    # --- /api/citations/validate/ ---------------------------------------
+
+    def test_validate_law_reference_found(self):
+        resp = self.client.get("/api/citations/validate/?citation=%C2%A7+823+BGB")
+        self.assertEqual(resp.status_code, 200)
+        body = resp.json()
+        self.assertTrue(body["found"])
+        self.assertEqual(body["type"], "law")
+
+    def test_validate_file_number_not_found(self):
+        resp = self.client.get(
+            "/api/citations/validate/?citation=ZZ+123/99&type=file_number"
+        )
+        body = resp.json()
+        self.assertFalse(body["found"])
+        self.assertEqual(body["type"], "case")
+
+    def test_validate_empty_citation_errors(self):
+        resp = self.client.get("/api/citations/validate/?citation=")
+        body = resp.json()
+        self.assertIn("error", body)

--- a/oldp/apps/references/tests/test_mcp.py
+++ b/oldp/apps/references/tests/test_mcp.py
@@ -7,7 +7,10 @@ from django.test import TestCase, override_settings
 from oldp.apps.cases.models import Case
 from oldp.apps.courts.models import Court
 from oldp.apps.laws.models import Law, LawBook
-from oldp.apps.references.mcp import ReferenceTools, _parse_citation_type
+from oldp.apps.references.mcp import ReferenceTools
+from oldp.apps.references.services import (
+    parse_citation_type as _parse_citation_type,
+)
 from oldp.apps.references.models import (
     CaseReferenceMarker,
     Reference,


### PR DESCRIPTION
## Summary

Expose the extracted citation graph as a REST API surface, factored so the existing MCP `ReferenceTools` toolset and the new HTTP endpoints share a single service layer (no duplicated query / serialization logic).

## Shape

**Hybrid by design** — nested actions for the common 1:1 questions, flat resource for cross-cutting queries:

| Surface | Purpose |
|---|---|
| `GET /api/cases/<id>/references/` | What does this case cite? |
| `GET /api/cases/<id>/citing_cases/` | Cases that cite this case |
| `GET /api/cases/<id>/citing_laws/` | Laws that cite this case |
| `GET /api/laws/<id>/references/` | What does this law cite? |
| `GET /api/laws/<id>/citing_cases/` | Cases citing this law section |
| `GET /api/laws/<id>/citing_laws/` | Laws citing this law section |
| `GET /api/references/?...filter...` | Flat resource for analytical queries; supports id + slug filters |
| `GET /api/citations/validate/?citation=...` | Citation existence check |

The flat resource accepts both numeric IDs and slugs, including the composite `(book_slug, section_slug)` shape for laws:

```
?cited_by_case=<id>                 ?cited_by_case__slug=<case_slug>
?cited_by_law__book__slug=bgb       ?cited_by_law__slug=823
?cites_law__book__slug=bgb          ?cites_law__slug=823
?assigned=true|false                (drop unresolved refs)
```

`citing_*` actions on laws cross-revision-resolve via `(book.code, section)`, so older citation rows pinned to non-latest revisions still surface.

## Avoiding duplicated code

```
┌──────────────────────────────────────────────┐
│  oldp/apps/references/services/              │
│    citation_lookup.py: validate_citation     │
│    citation_graph.py:                        │
│      case_forward_references(case) -> dict   │
│      law_forward_references(law)  -> dict    │
│      citing_cases_for_case(case)  -> QuerySet│
│      citing_cases_for_law(...)    -> QuerySet│
│      citing_laws_for_case(case)   -> QuerySet│
│      citing_laws_for_law(...)     -> QuerySet│
│      resolve_law_section(book, section)      │
└──────────────────────────────────────────────┘
        ▲                              ▲
        │ adapter                      │ adapter
        │                              │
┌─────────────────────┐    ┌─────────────────────────────┐
│ MCP ReferenceTools  │    │ DRF nested actions + flat   │
│ (slices [:limit])   │    │ ReferenceViewSet (paginates)│
└─────────────────────┘    └─────────────────────────────┘
```

Functions returning **response-ready dicts** (`*_forward_references`, `validate_citation`) are called the same way by both layers. Functions returning **QuerySets** (`citing_*_for_*`) leave pagination to the caller — MCP slices `[:limit]` to keep tool payloads bounded; REST hands them to DRF's paginator. Same query, two pagination strategies.

The split also fills a pre-existing gap: law-side symmetry (`law_forward_references`, `citing_laws_for_case`, `citing_laws_for_law`) wasn't surfaced anywhere — neither MCP nor HTML — even though the underlying data exists. The flat REST resource exposes this for the first time.

## Commits

1. `2068795` — `refactor(refs): extract citation services from MCP tools` — pure code-move + MCP becomes a thin adapter. Behaviour preserved (588 tests still pass).
2. `5a02c1b` — `feat(refs): expose citation graph via REST API` — nested actions on `CaseViewSet` / `LawViewSet`, flat `ReferenceViewSet`, `CitationViewSet.validate`, and 16 new tests.
3. `a492087` — `docs: document citation REST API + cross-link from MCP guide`.

## Test plan

- [x] `make test` — 1076 pass, 16 skipped (588 reference + case + law + mcp tests still green; 16 new API tests for the new HTTP surfaces).
- [x] `make lint-check` — clean.
- [x] Manual smoke test against the dev stack: 246 cases / 998 laws / 5,500+ markers; nested + flat endpoints exercised against real seeded prod data; slug-based filters tested in both directions.

## Out of scope (follow-ups)

- Schema-level documentation (`drf-yasg`-derived OpenAPI) for the new endpoints — the existing schema generation should pick up the action routes automatically; will land via the periodic schema regeneration.
- A `references/<id>/expand/` endpoint that walks transitive citations 2-3 hops out — could be useful for impact-analysis use cases but warrants its own design pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)