### PR TITLE
feat(accounts): restrict /api/users/ to staff users

### DIFF
--- a/oldp/apps/accounts/api_views.py
+++ b/oldp/apps/accounts/api_views.py
@@ -12,11 +12,16 @@ from oldp.apps.accounts.serializers import UserSerializer
 class UserViewSet(viewsets.ModelViewSet):
     """API endpoint that allows a user's profile to be viewed or edited."""
 
-    permission_classes = (permissions.IsAuthenticated,)
     queryset = User.objects.order_by("pk").all()
     serializer_class = UserSerializer
 
     http_method_names = ["get", "head", "options"]  # Read-only endpoint
+
+    def get_permissions(self):
+        # /users/me/ stays open to any authenticated user; list + detail are staff-only.
+        if getattr(self, "action", None) == "me":
+            return [permissions.IsAuthenticated()]
+        return [permissions.IsAdminUser()]
 
     @action(detail=False)
     def me(self, request):

--- a/oldp/apps/accounts/tests/test_users_api.py
+++ b/oldp/apps/accounts/tests/test_users_api.py
@@ -1,0 +1,55 @@
+from django.contrib.auth.models import User
+from django.test import TestCase
+from rest_framework.test import APIClient
+
+
+class UsersApiPermissionTestCase(TestCase):
+    """Tests that /api/users/ list and detail are restricted to staff users."""
+
+    def setUp(self):
+        self.staff = User.objects.create_user(
+            "staffuser", "staff@example.com", "staffpass", is_staff=True
+        )
+        self.regular = User.objects.create_user(
+            "regularuser", "regular@example.com", "regularpass"
+        )
+        self.client = APIClient()
+
+    def test_list_anonymous_returns_401(self):
+        res = self.client.get("/api/users/")
+        self.assertEqual(res.status_code, 401)
+
+    def test_detail_anonymous_returns_401(self):
+        res = self.client.get(f"/api/users/{self.staff.pk}/")
+        self.assertEqual(res.status_code, 401)
+
+    def test_list_regular_user_returns_403(self):
+        self.client.login(username="regularuser", password="regularpass")
+        res = self.client.get("/api/users/")
+        self.assertEqual(res.status_code, 403)
+
+    def test_detail_regular_user_returns_403(self):
+        self.client.login(username="regularuser", password="regularpass")
+        res = self.client.get(f"/api/users/{self.staff.pk}/")
+        self.assertEqual(res.status_code, 403)
+
+    def test_list_staff_user_returns_200(self):
+        self.client.login(username="staffuser", password="staffpass")
+        res = self.client.get("/api/users/")
+        self.assertEqual(res.status_code, 200)
+        usernames = {u["username"] for u in res.json()["results"]}
+        self.assertIn("staffuser", usernames)
+        self.assertIn("regularuser", usernames)
+
+    def test_detail_staff_user_returns_200(self):
+        self.client.login(username="staffuser", password="staffpass")
+        res = self.client.get(f"/api/users/{self.regular.pk}/")
+        self.assertEqual(res.status_code, 200)
+        self.assertEqual(res.json()["username"], "regularuser")
+
+    def test_me_action_accessible_to_regular_user(self):
+        self.client.login(username="regularuser", password="regularpass")
+        res = self.client.get("/api/users/me/")
+        self.assertEqual(res.status_code, 200)
+        usernames = {u["username"] for u in res.json()["results"]}
+        self.assertEqual(usernames, {"regularuser"})

--- a/oldp/apps/laws/api_views.py
+++ b/oldp/apps/laws/api_views.py
@@ -15,6 +15,7 @@ from rest_framework.viewsets import ViewSetMixin
 from oldp.api import SmallResultsSetPagination
 from oldp.api.mixins import ReviewStatusFilterMixin
 from oldp.apps.accounts.permissions import HasTokenPermission
+from oldp.apps.cases.serializers import CaseListSerializer
 from oldp.apps.laws.models import Law, LawBook
 from oldp.apps.laws.search_indexes import LawIndex
 from oldp.apps.laws.serializers import (
@@ -24,7 +25,6 @@ from oldp.apps.laws.serializers import (
     LawSearchSerializer,
     LawSerializer,
 )
-from oldp.apps.cases.serializers import CaseListSerializer
 from oldp.apps.laws.services import LawBookCreator, LawCreator
 from oldp.apps.references.serializers import (
     ForwardReferencesResponseSerializer,

--- a/oldp/apps/references/tests/test_mcp.py
+++ b/oldp/apps/references/tests/test_mcp.py
@@ -8,13 +8,13 @@ from oldp.apps.cases.models import Case
 from oldp.apps.courts.models import Court
 from oldp.apps.laws.models import Law, LawBook
 from oldp.apps.references.mcp import ReferenceTools
-from oldp.apps.references.services import (
-    parse_citation_type as _parse_citation_type,
-)
 from oldp.apps.references.models import (
     CaseReferenceMarker,
     Reference,
     ReferenceFromCase,
+)
+from oldp.apps.references.services import (
+    parse_citation_type as _parse_citation_type,
 )
 
 

--- a/oldp/apps/references/tests/test_processing_extract_refs.py
+++ b/oldp/apps/references/tests/test_processing_extract_refs.py
@@ -267,7 +267,8 @@ class AssignLawRefTestCase(TestCase):
 
     def test_populates_stable_slug_pair(self):
         """``assign_law_ref`` writes the (book_slug, section_slug) pair used by
-        reverse-citation queries, not just the FK."""
+        reverse-citation queries, not just the FK.
+        """
         book = self._make_book(code="BGB", slug="bgb", revision_date="2024-01-01")
         self._make_law(book=book, section="§ 823", slug="823")
 
@@ -363,7 +364,8 @@ class AssignCaseRefTestCase(TestCase):
 
     def test_resolves_via_aliases_exact_line(self):
         """``Court.aliases`` is newline-delimited; the cite resolves only
-        when the citation's court matches a complete alias line."""
+        when the citation's court matches a complete alias line.
+        """
         from refex.citations import CaseCitation, Span
 
         court = self._make_court(


### PR DESCRIPTION
## Summary
- `UserViewSet` now uses `IsAdminUser` for list + detail (was `IsAuthenticated`), so account enumeration via `/api/users/` is no longer possible for regular users/tokens.
- `/api/users/me/` is preserved for any authenticated user via `get_permissions()` (backwards compatible). The richer `/api/me/` endpoint (`MeView`) is unchanged.
- Adds `oldp/apps/accounts/tests/test_users_api.py` with 7 tests covering anonymous, regular, and staff access for list/detail plus a `/users/me/` regression guard.
- Includes ruff auto-fixes in 3 unrelated files picked up by `make lint`.

## Test plan
- [x] `.venv/bin/python manage.py test oldp.apps.accounts.tests.test_users_api oldp.apps.accounts.tests.test_me_api` → 12/12 pass
- [x] CI green
- [x] Manual smoke on dev:
  - anonymous `GET /api/users/` → 401
  - regular token `GET /api/users/` → 403
  - staff token `GET /api/users/` → 200
  - regular token `GET /api/users/me/` → 200

Note: a pre-existing ruff lint error in `oldp/apps/references/processing/processing_steps/extract_refs.py:123` (docstring `r` prefix) exists on master and is intentionally left out of this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)