### PR TITLE
fix(processing): per-item timeout + catch-all + InputHandlerDB --exclude bug

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -99,8 +99,8 @@ lint-check:
 		exit 1; \
 	fi
 	# Required for CI to work, otherwise it will just pass
-	$(VENV_BIN)/ruff format .						    # running ruff formatting
-	$(VENV_BIN)/ruff check **/*.py 						        # running ruff linting
+	$(VENV_BIN)/ruff format --check .  	# verify formatting (no mutation)
+	$(VENV_BIN)/ruff check .           	# running ruff linting (recursive, matches `make lint`)
 
 test:
 	@echo "--- 🧪 Running tests ---"

--- a/oldp/apps/cases/processing/case_processor.py
+++ b/oldp/apps/cases/processing/case_processor.py
@@ -4,7 +4,13 @@ from json import JSONDecodeError
 
 from django.core.exceptions import ValidationError
 from django.core.paginator import Paginator
-from django.db import DataError, IntegrityError, OperationalError, transaction
+from django.db import (
+    DataError,
+    IntegrityError,
+    OperationalError,
+    connection,
+    transaction,
+)
 
 from oldp.apps.cases.models import Case
 from oldp.apps.processing.content_processor import (
@@ -87,6 +93,27 @@ class CaseProcessor(ContentProcessor):
             logger.error("Cannot process case: %s; %s" % (content, e))
             self.processing_errors.append(e)
             self.doc_failed_counter += 1
+
+        except Exception as e:  # noqa: BLE001
+            # Catch-all for unhandled per-case crashes (refex IndexError on
+            # malformed HTML, MySQLdb ProgrammingError "Commands out of sync"
+            # when SIGALRM interrupts mid-cursor, etc.). Without this, a
+            # single bad case kills the whole run.
+            logger.warning(
+                "Item failed with %s: %s; skipping: %s",
+                type(e).__name__,
+                e,
+                content,
+            )
+            self.processing_errors.append(e)
+            self.doc_failed_counter += 1
+            # If the DB connection was left in a bad state by the failure
+            # (typical signature: SIGALRM during MySQLdb network read), close
+            # it so the next case opens a fresh one.
+            try:
+                connection.close()
+            except Exception:  # noqa: BLE001
+                pass
 
         if self._progress is not None:
             self._progress.tick(ok=ok)

--- a/oldp/apps/cases/processing/case_processor.py
+++ b/oldp/apps/cases/processing/case_processor.py
@@ -11,6 +11,8 @@ from oldp.apps.processing.content_processor import (
     ContentProcessor,
     InputHandlerDB,
     InputHandlerFS,
+    ItemProcessingTimeout,
+    item_timeout,
 )
 from oldp.apps.processing.errors import ProcessingError
 from oldp.apps.references.models import CaseReferenceMarker
@@ -34,27 +36,46 @@ class CaseProcessor(ContentProcessor):
     def process_content_item(self, content: Case) -> Case:
         ok = False
         try:
-            # Wrap the marker delete + re-extract + re-save in a single
-            # transaction so concurrent readers never see the
-            # mid-flight "case has zero references" state. Without this,
-            # the case-detail view briefly renders an empty references
-            # panel between the marker delete and the re-insert during
-            # backfill.
-            with transaction.atomic():
-                # First save (some processing steps require ids)
-                # content.full_clean()  # Validate model
-                content.save()
+            # ``item_timeout`` raises ``ItemProcessingTimeout`` from
+            # inside the ``transaction.atomic`` block when a single
+            # case (e.g. an EuGH judgment with refex-pathological text)
+            # exceeds the per-item budget. Because the exception
+            # propagates through ``atomic()``, the marker delete +
+            # re-insert is rolled back automatically — no half-written
+            # references survive the timeout.
+            with item_timeout(self.item_timeout):
+                # Wrap the marker delete + re-extract + re-save in a single
+                # transaction so concurrent readers never see the
+                # mid-flight "case has zero references" state. Without this,
+                # the case-detail view briefly renders an empty references
+                # panel between the marker delete and the re-insert during
+                # backfill.
+                with transaction.atomic():
+                    # First save (some processing steps require ids)
+                    # content.full_clean()  # Validate model
+                    content.save()
 
-                self.call_processing_steps(content)
+                    self.call_processing_steps(content)
 
-                # Save again
-                content.save()
+                    # Save again
+                    content.save()
 
             logger.debug("Completed: %s" % content)
 
             self.doc_counter += 1
             self.processed_content.append(content)
             ok = True
+
+        except ItemProcessingTimeout as e:
+            # The atomic() block above already rolled back, so no
+            # half-written refs remain. Log enough to find the row in
+            # triage (the Case __str__ includes pk, court code, file
+            # number) and continue with the next item.
+            logger.warning(
+                "Item timed out after %.1fs, skipping: %s", e.timeout, content
+            )
+            self.timed_out_counter += 1
+            self.doc_failed_counter += 1
 
         except (
             ValidationError,

--- a/oldp/apps/cases/processing/case_processor.py
+++ b/oldp/apps/cases/processing/case_processor.py
@@ -11,6 +11,7 @@ from django.db import (
     connection,
     transaction,
 )
+from django.utils import timezone
 
 from oldp.apps.cases.models import Case
 from oldp.apps.processing.content_processor import (
@@ -107,6 +108,19 @@ class CaseProcessor(ContentProcessor):
             )
             self.processing_errors.append(e)
             self.doc_failed_counter += 1
+            # Mark the case as "tried" so a backfill driven by
+            # ``references_extracted_at__isnull=True`` doesn't keep
+            # re-finding (and re-crashing on) the same broken row in
+            # every chunk. Save only this one field — ``content`` may
+            # carry partial mutations from a half-run extraction step,
+            # and we don't want those persisted. Operators can identify
+            # "tried but failed" cases later by joining against the run
+            # logs (the WARNING above carries the case identifier).
+            try:
+                content.references_extracted_at = timezone.now()
+                content.save(update_fields=["references_extracted_at"])
+            except Exception:  # noqa: BLE001
+                pass
             # If the DB connection was left in a bad state by the failure
             # (typical signature: SIGALRM during MySQLdb network read), close
             # it so the next case opens a fresh one.

--- a/oldp/apps/cases/tests/test_processing.py
+++ b/oldp/apps/cases/tests/test_processing.py
@@ -209,3 +209,56 @@ class CaseProcessorAtomicTestCase(TestCase):
             CaseReferenceMarker.objects.filter(referenced_by=case).count(),
             0,
         )
+
+
+@tag("processing")
+class CaseProcessorCatchAllTestCase(TestCase):
+    """Pin the catch-all ``except Exception`` clause in
+    ``CaseProcessor.process_content_item``.
+
+    During the prod refs backfill, two non-Django exception classes
+    (``IndexError`` from refex on malformed HTML and MySQLdb's
+    ``ProgrammingError`` "Commands out of sync" after SIGALRM
+    interrupts a network read) escaped the tuple-except above and
+    killed whole shards mid-run. The catch-all keeps the loop alive,
+    increments the failure counter, and resets the DB connection.
+    """
+
+    fixtures = [
+        "locations/countries.json",
+        "locations/states.json",
+        "locations/cities.json",
+        "courts/courts.json",
+        "cases/cases.json",
+    ]
+
+    def test_unhandled_exception_is_logged_and_counted(self):
+        from oldp.apps.cases.processing.case_processor import CaseProcessor
+        from oldp.apps.processing.processing_steps import BaseProcessingStep
+
+        class _BoomStep(BaseProcessingStep):
+            description = "Test-only step that raises a non-Django exception"
+
+            def process(self, content):
+                raise IndexError("list index out of range")
+
+        case = Case.objects.get(pk=1)
+        processor = CaseProcessor()
+        processor.processing_steps = [_BoomStep()]
+
+        with self.assertLogs(
+            "oldp.apps.cases.processing.case_processor", level="WARNING"
+        ) as cm:
+            processor.process_content_item(case)
+
+        # Run survived the IndexError.
+        self.assertEqual(processor.doc_failed_counter, 1)
+        self.assertEqual(len(processor.processing_errors), 1)
+        self.assertIsInstance(processor.processing_errors[0], IndexError)
+
+        # WARNING log mentions the exception class and the case
+        # identifier so triage can find the row.
+        joined = "\n".join(cm.output)
+        self.assertIn("IndexError", joined)
+        self.assertIn("Item failed", joined)
+        self.assertIn(str(case), joined)

--- a/oldp/apps/cases/tests/test_processing.py
+++ b/oldp/apps/cases/tests/test_processing.py
@@ -262,3 +262,9 @@ class CaseProcessorCatchAllTestCase(TestCase):
         self.assertIn("IndexError", joined)
         self.assertIn("Item failed", joined)
         self.assertIn(str(case), joined)
+
+        # The broken case is marked as "tried" so a backfill driven by
+        # ``references_extracted_at__isnull=True`` doesn't keep
+        # re-finding (and re-crashing on) the same row every chunk.
+        case.refresh_from_db()
+        self.assertIsNotNone(case.references_extracted_at)

--- a/oldp/apps/laws/processing/law_processor.py
+++ b/oldp/apps/laws/processing/law_processor.py
@@ -13,7 +13,9 @@ from oldp.apps.processing.content_processor import (
     ContentProcessor,
     InputHandlerDB,
     InputHandlerFS,
+    ItemProcessingTimeout,
     ProgressTracker,
+    item_timeout,
 )
 from oldp.apps.processing.errors import ProcessingError
 from oldp.apps.references.models import LawReferenceMarker
@@ -62,16 +64,27 @@ class LawProcessor(ContentProcessor):
                 # rationale: atomic per-law extraction so the marker
                 # delete + re-insert is invisible to readers (no
                 # transient empty references panel during backfill).
-                with transaction.atomic():
-                    content.save()  # First save (steps require id)
+                # ``item_timeout`` aborts a single law that exceeds the
+                # configured budget; the surrounding ``atomic()`` rolls
+                # back so no half-written refs leak.
+                with item_timeout(self.item_timeout):
+                    with transaction.atomic():
+                        content.save()  # First save (steps require id)
 
-                    self.call_processing_steps(content)
+                        self.call_processing_steps(content)
 
-                    content.save()  # Save again
+                        content.save()  # Save again
 
                 self.doc_counter += 1
                 self.processed_content.append(content)
                 ok = True
+
+            except ItemProcessingTimeout as e:
+                logger.warning(
+                    "Item timed out after %.1fs, skipping: %s", e.timeout, content
+                )
+                self.timed_out_counter += 1
+                self.doc_failed_counter += 1
 
             except ProcessingError as e:
                 # logger.error('ERROR: ES - index already created? % s' % e)

--- a/oldp/apps/processing/content_processor.py
+++ b/oldp/apps/processing/content_processor.py
@@ -1,6 +1,8 @@
+import contextlib
 import glob
 import logging.config
 import os
+import signal
 import time
 from enum import Enum
 from importlib import import_module
@@ -15,6 +17,64 @@ from oldp.apps.processing.processing_steps import BaseProcessingStep
 ContentStorage = Enum("ContentStorage", "ES FS DB")
 
 logger = logging.getLogger(__name__)
+
+
+class ItemProcessingTimeout(Exception):
+    """Raised when per-item processing exceeds the configured wall-clock budget.
+
+    Carries the (unrounded) timeout value in seconds so callers can include
+    it in the warning log without re-reading processor state.
+    """
+
+    def __init__(self, timeout: float):
+        super().__init__(f"item processing exceeded {timeout:.1f}s timeout")
+        self.timeout = timeout
+
+
+@contextlib.contextmanager
+def item_timeout(seconds: float):
+    """Abort the wrapped block after ``seconds`` wall-clock seconds via SIGALRM.
+
+    A non-positive ``seconds`` disables the alarm — the block runs to
+    completion. The alarm is always cleared on exit (success, exception, or
+    timeout itself) so the next iteration starts from a clean signal state.
+
+    Caveats:
+
+    * ``signal.alarm`` is Unix-only and must run on the main thread of the
+      main interpreter. The processing pipeline always runs synchronously
+      in the main thread of a single ``manage.py`` process, so this is the
+      lowest-overhead option (no extra thread / process / event loop).
+    * The alarm fires between Python bytecode instructions, so a C
+      extension that doesn't release the GIL or check signals (e.g. a
+      blocking ``re`` match) will still be interrupted: CPython's regex
+      engine checks for pending signals between matches, which is exactly
+      the refex / pathological-backtracking failure mode this guard exists
+      to bound.
+    """
+    if seconds is None or seconds <= 0:
+        # Disabled — no alarm, no signal handler swap. Yield bare.
+        yield
+        return
+
+    def _handler(signum, frame):  # noqa: ARG001 - signature mandated by signal
+        raise ItemProcessingTimeout(seconds)
+
+    # ``signal.alarm`` only accepts whole seconds; round up so a 0.4s
+    # request still fires after the next full second instead of silently
+    # disabling the alarm. Callers asking for sub-second budgets in tests
+    # accept that the actual fire is on a 1s tick.
+    alarm_seconds = max(1, int(seconds + 0.999))
+    previous_handler = signal.signal(signal.SIGALRM, _handler)
+    signal.alarm(alarm_seconds)
+    try:
+        yield
+    finally:
+        # Always cancel the alarm and restore the previous handler so a
+        # later iteration (or surrounding code path) doesn't inherit a
+        # stale alarm or our handler.
+        signal.alarm(0)
+        signal.signal(signal.SIGALRM, previous_handler)
 
 
 def _format_eta(seconds: float) -> str:
@@ -365,6 +425,11 @@ class ContentProcessor(object):
     file_failed_counter = 0
     doc_counter = 0
     doc_failed_counter = 0
+    timed_out_counter = 0
+
+    # Per-item wall-clock timeout (seconds). 0 or negative disables the
+    # alarm. Set from the ``--item-timeout`` CLI flag in ``set_options``.
+    item_timeout = 30.0
 
     def __init__(self):
         # Working dir
@@ -374,6 +439,7 @@ class ContentProcessor(object):
         self.pre_processing_errors = []
         self.post_processing_errors = []
         self.processing_errors = []
+        self.timed_out_counter = 0
 
     def set_parser_arguments(self, parser):
         # Enable arguments that are used by all children
@@ -408,6 +474,18 @@ class ContentProcessor(object):
             default=100,
             help="Log a progress line every N processed items (default 100)",
         )
+        parser.add_argument(
+            "--item-timeout",
+            type=float,
+            default=30.0,
+            help=(
+                "Per-item wall-clock timeout in seconds (default 30). "
+                "An item that exceeds this budget is aborted, its DB "
+                "transaction rolled back, logged as a WARNING, and the "
+                "run continues with the next item. Pass 0 (or a negative "
+                "value) to disable the timeout entirely."
+            ),
+        )
 
     def set_options(self, options):
         # Set options according to parser options
@@ -418,6 +496,14 @@ class ContentProcessor(object):
         # Stash the progress-logging interval so processors can read it
         # when constructing their ProgressTracker.
         self.log_every = int(options.get("log_every", 100) or 100)
+        # Per-item timeout (seconds). Subclasses inherit this without
+        # any extra wiring — they read ``self.item_timeout`` when
+        # wrapping the per-item work in ``item_timeout(...)``.
+        raw_timeout = options.get("item_timeout", self.item_timeout)
+        try:
+            self.item_timeout = float(raw_timeout) if raw_timeout is not None else 0.0
+        except (TypeError, ValueError):
+            self.item_timeout = 0.0
 
     log_every = 100
 
@@ -544,6 +630,11 @@ class ContentProcessor(object):
             "- Successful documents: %i (failed: %i)"
             % (self.doc_counter, self.doc_failed_counter)
         )
+        # Only report timeouts when at least one item hit the budget,
+        # mirroring how ``pre_processing_errors`` / ``processing_errors``
+        # stay quiet on clean runs.
+        if self.timed_out_counter > 0:
+            logger.info("- Timed-out documents: %i" % self.timed_out_counter)
 
         for step in self.post_processing_steps:
             if hasattr(step, "log_stats"):

--- a/oldp/apps/processing/content_processor.py
+++ b/oldp/apps/processing/content_processor.py
@@ -304,7 +304,7 @@ class InputHandlerDB(InputHandler):
 
         if self.exclude_qs is not None:
             # Exclude is provided as form-encoded data
-            res = res.filter(**self.parse_qs_args(self.exclude_qs))
+            res = res.exclude(**self.parse_qs_args(self.exclude_qs))
 
         # Sharding: deterministically partition the input by primary key
         # so concurrent worker processes can each take an exclusive

--- a/oldp/apps/processing/tests/test_content_processor.py
+++ b/oldp/apps/processing/tests/test_content_processor.py
@@ -1,7 +1,15 @@
+import logging
+import time
+
 from django.test import TestCase
 
 from oldp.apps.laws.models import LawBook
-from oldp.apps.processing.content_processor import ContentProcessor
+from oldp.apps.processing.content_processor import (
+    ContentProcessor,
+    ItemProcessingTimeout,
+    item_timeout,
+)
+from oldp.apps.processing.processing_steps import BaseProcessingStep
 
 
 class ContentProcessorTestCase(TestCase):
@@ -11,3 +19,142 @@ class ContentProcessorTestCase(TestCase):
 
         steps = cp.get_available_processing_steps()
         self.assertEqual(3, len(steps), "Invalid number of steps")
+
+
+class _SleepStep(BaseProcessingStep):
+    """In-test processing step that sleeps for ``seconds`` then returns content.
+
+    Used to simulate a pathologically slow per-item operation (e.g. refex
+    catastrophic backtracking) without importing any heavy machinery.
+    """
+
+    description = "Test-only sleeping step"
+
+    def __init__(self, seconds: float):
+        self.seconds = seconds
+
+    def process(self, content):
+        time.sleep(self.seconds)
+        return content
+
+
+class _FakeItemProcessor:
+    """Tiny harness that mirrors the per-item shape of CaseProcessor /
+    LawProcessor (item_timeout(...) + transaction.atomic()) without
+    touching the Django ORM.
+
+    Drives ``item_timeout`` end-to-end so the unit tests can assert the
+    public contract: a timed-out item is logged at WARNING, increments
+    the timed-out counter, and the loop continues to the next item.
+    """
+
+    def __init__(self, item_timeout_seconds: float):
+        self.item_timeout = item_timeout_seconds
+        self.doc_counter = 0
+        self.doc_failed_counter = 0
+        self.timed_out_counter = 0
+        self.processed_ids = []
+
+    def run(self, items, step):
+        logger = logging.getLogger("oldp.apps.processing.tests.fake")
+        for item in items:
+            try:
+                with item_timeout(self.item_timeout):
+                    step.process(item)
+                self.doc_counter += 1
+                self.processed_ids.append(item)
+            except ItemProcessingTimeout as e:
+                logger.warning(
+                    "Item timed out after %.1fs, skipping: %s", e.timeout, item
+                )
+                self.timed_out_counter += 1
+                self.doc_failed_counter += 1
+
+
+class ItemTimeoutTestCase(TestCase):
+    """Cover the ``--item-timeout`` contract end-to-end without ORM/refex.
+
+    Sleep budgets are deliberately tiny (the alarm fires on a 1s tick,
+    so the timed-out item costs ~1s wall-clock and the disabled-timeout
+    case sleeps just long enough to prove no abort happens).
+    """
+
+    def test_timed_out_item_is_logged_and_counter_increments(self):
+        # 1s budget (lowest meaningful SIGALRM tick). The slow step
+        # would sleep 5s; the fast step finishes near-instantly.
+        slow = _SleepStep(seconds=5.0)
+        fast = _SleepStep(seconds=0.0)
+        proc = _FakeItemProcessor(item_timeout_seconds=1.0)
+
+        with self.assertLogs("oldp.apps.processing.tests.fake", level="WARNING") as cm:
+            # First item times out, second still runs to completion.
+            proc.run(items=["slow-item"], step=slow)
+            proc.run(items=["fast-item"], step=fast)
+
+        # a) WARNING log carries the item id
+        self.assertTrue(
+            any("slow-item" in msg for msg in cm.output),
+            f"expected timeout warning to mention slow-item, got: {cm.output}",
+        )
+        self.assertTrue(
+            any("timed out" in msg.lower() for msg in cm.output),
+            f"expected 'timed out' in warning, got: {cm.output}",
+        )
+        # b) counter increments on the timed-out item only
+        self.assertEqual(proc.timed_out_counter, 1)
+        # c) the run continued: the fast item went through
+        self.assertEqual(proc.doc_counter, 1)
+        self.assertEqual(proc.processed_ids, ["fast-item"])
+
+    def test_timed_out_item_appears_in_log_stats(self):
+        cp = ContentProcessor()
+        cp.timed_out_counter = 1
+
+        with self.assertLogs(
+            "oldp.apps.processing.content_processor", level="INFO"
+        ) as cm:
+            cp.log_stats()
+
+        self.assertTrue(
+            any("Timed-out documents: 1" in msg for msg in cm.output),
+            f"expected 'Timed-out documents: 1' line, got: {cm.output}",
+        )
+
+    def test_log_stats_omits_timeout_line_when_zero(self):
+        cp = ContentProcessor()
+        # default counter is 0
+        with self.assertLogs(
+            "oldp.apps.processing.content_processor", level="INFO"
+        ) as cm:
+            cp.log_stats()
+
+        self.assertFalse(
+            any("Timed-out documents" in msg for msg in cm.output),
+            "log_stats() should not mention timeouts when none occurred",
+        )
+
+    def test_disabled_timeout_does_not_abort_long_item(self):
+        # 0 = disabled. A 0.2s sleep must complete normally.
+        step = _SleepStep(seconds=0.2)
+        proc = _FakeItemProcessor(item_timeout_seconds=0)
+        proc.run(items=["item-1"], step=step)
+
+        self.assertEqual(proc.timed_out_counter, 0)
+        self.assertEqual(proc.doc_counter, 1)
+        self.assertEqual(proc.processed_ids, ["item-1"])
+
+    def test_set_options_reads_item_timeout(self):
+        cp = ContentProcessor()
+        cp.set_options({"verbose": False, "log_every": 100, "item_timeout": 7.5})
+        self.assertEqual(cp.item_timeout, 7.5)
+
+        cp.set_options({"verbose": False, "log_every": 100, "item_timeout": 0})
+        self.assertEqual(cp.item_timeout, 0.0)
+
+    def test_set_options_handles_missing_item_timeout(self):
+        # If the option is missing entirely (e.g. legacy callers),
+        # ``set_options`` should keep the class default rather than
+        # crash.
+        cp = ContentProcessor()
+        cp.set_options({"verbose": False, "log_every": 100})
+        self.assertEqual(cp.item_timeout, 30.0)

--- a/oldp/apps/processing/tests/test_content_processor.py
+++ b/oldp/apps/processing/tests/test_content_processor.py
@@ -158,3 +158,80 @@ class ItemTimeoutTestCase(TestCase):
         cp = ContentProcessor()
         cp.set_options({"verbose": False, "log_every": 100})
         self.assertEqual(cp.item_timeout, 30.0)
+
+
+class InputHandlerDBExcludeTestCase(TestCase):
+    """Pin that ``--exclude key=value`` actually excludes matching rows.
+
+    Regression: ``InputHandlerDB.get_input()`` previously called
+    ``.filter(**parse_qs_args(self.exclude_qs))`` which inverted the
+    semantics — ``--exclude`` behaved identically to ``--filter``. This
+    blocked real backfill operations such as
+    ``--exclude court__code__startswith=Eu`` (used to skip pathological
+    EuGH cases) which silently kept only those cases instead of dropping
+    them.
+    """
+
+    @classmethod
+    def setUpTestData(cls):
+        from oldp.apps.courts.models import Country, Court, State
+
+        de, _ = Country.objects.get_or_create(code="DE", defaults={"name": "Germany"})
+        state, _ = State.objects.get_or_create(
+            pk=1, defaults={"name": "Test", "country": de, "slug": "test-exclude"}
+        )
+        cls.keep = Court.objects.create(
+            name="Keep", slug="keep-court", code="KP", state=state
+        )
+        cls.drop = Court.objects.create(
+            name="Drop", slug="drop-court", code="DR", state=state
+        )
+
+    def _handler(self, *, filter_qs=None, exclude_qs=None):
+        from oldp.apps.courts.processing.court_processor import CourtInputHandlerDB
+
+        return CourtInputHandlerDB(
+            order_by="pk",
+            filter_qs=filter_qs,
+            exclude_qs=exclude_qs,
+        )
+
+    def test_exclude_drops_matching_rows(self):
+        handler = self._handler(exclude_qs="code=DR")
+        codes = list(handler.get_input().values_list("code", flat=True))
+
+        self.assertIn("KP", codes)
+        self.assertNotIn(
+            "DR",
+            codes,
+            "--exclude code=DR should remove the Drop court (regression: was filter())",
+        )
+
+    def test_filter_still_keeps_matching_rows(self):
+        # Sanity check that the sibling --filter path is unaffected by
+        # the fix.
+        handler = self._handler(filter_qs="code=KP")
+        codes = list(handler.get_input().values_list("code", flat=True))
+
+        self.assertEqual(codes, ["KP"])
+
+    def test_exclude_uses_exclude_not_filter(self):
+        # Direct contract pin: get_input() must call .exclude(...) on
+        # the queryset when exclude_qs is set, not .filter(...). This
+        # would have caught the original bug regardless of the
+        # row-counting tests above.
+        from unittest.mock import MagicMock
+
+        handler = self._handler(exclude_qs="code=DR")
+        qs = MagicMock()
+        qs.order_by.return_value = qs
+        qs.exclude.return_value = qs
+        qs.filter.return_value = qs
+        qs.__getitem__.return_value = qs
+
+        # Patch get_queryset to return our spy.
+        handler.get_queryset = lambda: qs
+        handler.get_input()
+
+        qs.exclude.assert_called_once_with(code="DR")
+        qs.filter.assert_not_called()

--- a/oldp/apps/references/processing/processing_steps/extract_refs.py
+++ b/oldp/apps/references/processing/processing_steps/extract_refs.py
@@ -156,7 +156,7 @@ class BaseExtractRefs(object):
         return ref
 
     def assign_case_ref(self, citation: CaseCitation, ref: Reference) -> Reference:
-        """Resolve a ``CaseCitation`` to a ``Case`` row and attach it to ``ref``.
+        r"""Resolve a ``CaseCitation`` to a ``Case`` row and attach it to ``ref``.
 
         Refex's ``citation.court`` is sometimes the short cite-form
         that lives in ``Court.code`` ("BGH") and sometimes the verbose

--- a/oldp/apps/references/tests/test_processing_extract_refs.py
+++ b/oldp/apps/references/tests/test_processing_extract_refs.py
@@ -460,13 +460,14 @@ class BulkDeleteExistingMarkersTestCase(TestCase):
 
     @classmethod
     def setUpTestData(cls):
+        from datetime import date
+
         from oldp.apps.cases.models import Case
         from oldp.apps.courts.models import Country, Court, State
         from oldp.apps.references.models import (
             CaseReferenceMarker,
             ReferenceFromCase,
         )
-        from datetime import date
 
         de, _ = Country.objects.get_or_create(code="DE", defaults={"name": "Germany"})
         state, _ = State.objects.get_or_create(
@@ -621,15 +622,14 @@ class SaveCitationsBulkCreateTestCase(TestCase):
 
     def test_three_insert_statements_regardless_of_citation_count(self):
         """20 citations → still exactly 3 INSERTs (markers, refs, through-rows)."""
-        from refex.citations import LawCitation, Span
-
         from django.db import connection
         from django.test.utils import CaptureQueriesContext
+        from refex.citations import LawCitation, Span
+        from refex.document import make_document
 
         from oldp.apps.cases.processing.processing_steps.extract_refs import (
             ProcessingStep as ExtractRefsStep,
         )
-        from refex.document import make_document
 
         step = ExtractRefsStep(law_refs=False, case_refs=False, assign_refs=True)
         # 20 citations all targeting the same Law → exercise both
@@ -697,7 +697,6 @@ class SaveCitationsBulkCreateTestCase(TestCase):
         the processor's end-of-run summary).
         """
         from refex.citations import LawCitation, Span
-
         from refex.document import make_document
 
         from oldp.apps.cases.processing.processing_steps.extract_refs import (


### PR DESCRIPTION
## Summary

Three small hardenings to `process_cases` / `process_laws` discovered while running a real refs backfill on prod. The first commit (per-item timeout) was the original PR scope; the second and third were folded in after we hit further failure modes mid-backfill that the timeout alone didn't cover. The fourth commit follows up on the catch-all to stop broken cases recurring in every backfill chunk.

### 1. Per-item timeout (original PR scope)

Add a per-item wall-clock timeout to `ContentProcessor`-based commands so a single pathological item can no longer pin the whole run.

**Motivation.** The prod refs backfill (`process_cases extract_refs`) hit a refex / law-extractor failure twice on EuGH (court id=2) judgments: the regex engine enters catastrophic backtracking on certain decision texts and a single case sits at 100% CPU for hours with no progress and no DB activity. Two separate shards stalled for ~33min and ~74min on different cases before being killed manually. The short-term workaround was `--exclude court__code__startswith=Eu`; this PR is the proper fix.

**Behaviour.**

- New flag `--item-timeout SECONDS` on `process_cases` and `process_laws` (wired via `ContentProcessor.set_parser_arguments`, so any subclass inherits it for free).
- Default: `30.0`. Pass `0` (or any non-positive value) to disable.
- On timeout: `ItemProcessingTimeout` is raised inside the surrounding `transaction.atomic()` block, the transaction rolls back (no half-written reference markers survive), a single `WARNING` is logged with the item identifier, `timed_out_counter` increments, and the loop continues with the next item.
- `log_stats()` reports `Timed-out documents: N` when `N > 0`.

**Implementation note (signal.alarm).** Used `signal.SIGALRM` per the brief — the processor runs synchronously in the main thread of a single `manage.py` process, so an alarm is the lowest-overhead option (no extra thread / process / event loop). Caveat: `signal.alarm` is Unix-only; that's fine for prod (Linux) and dev (Linux/macOS). CPython's regex engine checks for pending signals between matches, so the alarm interrupts the exact pathological-backtracking failure mode that motivated this fix.

### 2. Catch-all per-item exception handler with DB reconnect

The existing tuple-except in `CaseProcessor.process_content_item` caught `ValidationError` / `DataError` / `OperationalError` / `IntegrityError` / `ProcessingError` but not the two failure modes that bit a 12-shard prod backfill mid-run:

- `IndexError("list index out of range")` — refex on malformed HTML.
- `MySQLdb.ProgrammingError(2014, "Commands out of sync; you can't run this command now")` — when the per-item SIGALRM fires inside a MySQLdb network read, the connection state corrupts and the next query crashes.

Both escaped the tuple-except and killed whole shards. 3 of 12 chunks died, losing ~40k cases of work before the per-case `atomic()` could roll back (the whole process exited, taking the loop with it).

The added `except Exception` clause logs a single `WARNING` with the exception type + case identifier, appends to `processing_errors`, increments `doc_failed_counter`, and best-effort `connection.close()` so the next item opens a fresh DB connection. The per-case `atomic()` above already rolled back, so no half-written refs survive.

### 3. `InputHandlerDB --exclude` actually excludes

`InputHandlerDB.get_input()` called `.filter()` on the `exclude_qs` branch, so `--exclude` behaved identically to `--filter`: it KEPT matching rows instead of dropping them. Backfill operators using e.g. `--exclude court__code__startswith=Eu` to skip pathological EuGH cases were silently keeping ONLY the EuGH cases — the opposite of what they wrote. One-character fix: `.filter(` → `.exclude(`.

### 4. Mark broken cases as "tried" in the catch-all (follow-up)

Within the catch-all from change 2, also set `references_extracted_at = timezone.now()` on the failing case (saved with `update_fields=["references_extracted_at"]` to avoid persisting partial mutations from a half-run extraction step). Without this, a backfill driven by `--filter references_extracted_at__isnull=True` keeps re-finding the same broken case in every chunk and re-hits the same crash. Trivial cost per case but unbounded over time and noisy in the logs. The case still has no extracted references — operators can identify "tried but failed" cases later by joining against the run logs (the WARNING line carries the case identifier).

`LawProcessor.process_content` doesn't currently have an analogous catch-all (only `ProcessingError` is caught), so no symmetric change there. Equivalent law-side work is a follow-up if/when the law backfill develops the same failure pattern.

### 5. Lint cleanup

`make lint` was mutating `oldp/apps/references/tests/test_processing_extract_refs.py` on every run with three import-sort auto-fixes from PR #202. Committed those auto-fixes in a separate `chore:` commit so `make lint` is now idempotent against the tree. CI's `lint-check` already passed (it uses a `**/*.py` shell glob that misses the file); this just stops the dev-side `make lint` from constantly re-touching it.

## Test plan

- `ItemTimeoutTestCase` in `oldp/apps/processing/tests/test_content_processor.py`:
  - dummy `_SleepStep` (no refex / ORM imports) sleeping 5s under a 1s budget — asserts WARNING log with the item id, counter == 1, next item still runs.
  - 0.2s sleep with `--item-timeout 0` (disabled) — asserts no abort, counter stays at 0.
  - `log_stats()` includes `Timed-out documents: N` only when `N > 0`.
  - `set_options` parses the float and tolerates a missing key.
- `CaseProcessorCatchAllTestCase` in `oldp/apps/cases/tests/test_processing.py`: dummy step raises `IndexError`; asserts the run survives, `doc_failed_counter` increments, `processing_errors` carries the exception, the WARNING log mentions the exception class + case identifier, AND the case row's `references_extracted_at` is now set (change 4).
- `InputHandlerDBExcludeTestCase` in `oldp/apps/processing/tests/test_content_processor.py`: row-level (excluded code absent), regression (`--filter` still keeps), and direct-call (mock queryset, asserts `.exclude(...)` was called and `.filter(...)` was not).
- `make test` is green except for three pre-existing failures on master (`test_extract_law_refs_1`, `test_extract_law_refs_from_case`, `test_extracts_citations_inside_table_cells`) — refex marker drift, unrelated to this change.