### PR TITLE
fix: drop processed_content per-item leak in processors

### DIFF
--- a/oldp/apps/cases/processing/case_processor.py
+++ b/oldp/apps/cases/processing/case_processor.py
@@ -70,7 +70,6 @@ class CaseProcessor(ContentProcessor):
             logger.debug("Completed: %s" % content)
 
             self.doc_counter += 1
-            self.processed_content.append(content)
             ok = True
 
         except ItemProcessingTimeout as e:

--- a/oldp/apps/laws/processing/law_processor.py
+++ b/oldp/apps/laws/processing/law_processor.py
@@ -76,7 +76,6 @@ class LawProcessor(ContentProcessor):
                         content.save()  # Save again
 
                 self.doc_counter += 1
-                self.processed_content.append(content)
                 ok = True
 
             except ItemProcessingTimeout as e:

--- a/oldp/apps/processing/tests/test_content_processor.py
+++ b/oldp/apps/processing/tests/test_content_processor.py
@@ -3,6 +3,8 @@ import time
 
 from django.test import TestCase
 
+from oldp.apps.cases.models import Case
+from oldp.apps.cases.processing.case_processor import CaseProcessor
 from oldp.apps.laws.models import LawBook
 from oldp.apps.processing.content_processor import (
     ContentProcessor,
@@ -235,3 +237,41 @@ class InputHandlerDBExcludeTestCase(TestCase):
 
         qs.exclude.assert_called_once_with(code="DR")
         qs.filter.assert_not_called()
+
+
+class ProcessedContentRetentionTestCase(TestCase):
+    """Regression: per-item processors must not retain processed instances.
+
+    The 2026-05 prod backfill of references hit a ~37 KiB-per-Case RSS leak
+    because ``process_content_item`` appended every successfully-processed
+    instance to ``self.processed_content`` for the lifetime of the run, and
+    the consumer (``post_processing_steps``) is empty in prod, so the list
+    was never drained. The contract is now: per-item processors do not
+    accumulate processed instances.
+    """
+
+    fixtures = [
+        "locations/countries.json",
+        "locations/states.json",
+        "locations/cities.json",
+        "courts/courts.json",
+        "cases/cases.json",
+    ]
+
+    def test_case_processor_does_not_retain_processed_items(self):
+        cp = CaseProcessor()
+        cases = list(Case.objects.all()[:3])
+        self.assertGreater(
+            len(cases), 0, "Need at least one fixture case to exercise the loop"
+        )
+
+        for case in cases:
+            cp.process_content_item(case)
+
+        self.assertEqual(
+            0,
+            len(cp.processed_content),
+            "Per-item processors must not retain processed instances "
+            "(prevents RSS leak on long backfills).",
+        )
+        self.assertEqual(len(cases), cp.doc_counter)

--- a/oldp/apps/references/processing/reference_processor.py
+++ b/oldp/apps/references/processing/reference_processor.py
@@ -36,7 +36,6 @@ class ReferenceProcessor(ContentProcessor):
                 logger.debug("Completed: %s" % content)
 
                 self.doc_counter += 1
-                self.processed_content.append(content)
 
             except (
                 ValidationError,


### PR DESCRIPTION
## Summary

The 2026-05-09/10 prod backfill of references hit a ~37 KiB-per-Case RSS leak in `process_cases extract_refs`. The per-item path appended every successfully-processed Case (with all 5 TextFields) to `self.processed_content` for the whole run, and the consumer (`post_processing_steps`) is empty in prod, so the list was never drained. Math: 416k cases x ~37 KiB ≈ 16 GiB RSS — host OOMed at ~28% completion. The same pattern exists in two sibling processors. This PR removes the per-item retention; nothing else.

## Changes

- `oldp/apps/cases/processing/case_processor.py` — drop `self.processed_content.append(content)` in `CaseProcessor.process_content_item`.
- `oldp/apps/laws/processing/law_processor.py` — same in `LawProcessor.process_content`.
- `oldp/apps/references/processing/reference_processor.py` — same in `ReferenceContentProcessor.process_content`.

The `post_processing_steps` plumbing in `ContentProcessor.process` stays — it iterates over `self.processed_content`, which now remains the empty list it was initialised to, making the loop a harmless no-op when no post-steps are configured. We didn't have a real consumer of that list in prod anyway.

## Tests

- New contract test `ProcessedContentRetentionTestCase.test_case_processor_does_not_retain_processed_items` in `oldp/apps/processing/tests/test_content_processor.py`: runs `process_content_item` over N fixture cases and asserts `len(processed_content) == 0`. Locks in the new contract.
- No existing tests asserted on `processed_content` length, so no test fixups were needed.

## Notes

- 3 pre-existing failures on `master` are unrelated refex marker drift (`test_extract_law_refs_1`, `test_extract_law_refs_from_case`, `test_extracts_citations_inside_table_cells`) — not introduced or affected by this PR.
- PR #205 (`feat/processing-item-timeout`) is independent — both can land in any order.
- Out-of-scope deferred items spotted during diagnosis but intentionally not addressed here: class-level mutable defaults on `ContentProcessor`, `LawProcessor` materialising the queryset, and dead code around `post_processing_steps`.

## Test plan

- [x] `make test` locally — only the 3 pre-existing master failures listed above; new test passes
- [x] `ruff check` clean against the touched files
- [ ] CI green