### PR TITLE
fix(logging): enforce 0o644 on rotated log files

### DIFF
--- a/oldp/settings.py
+++ b/oldp/settings.py
@@ -371,7 +371,7 @@ class BaseConfiguration(Configuration):
             },
             "logfile": {
                 "level": "DEBUG",
-                "class": "logging.handlers.RotatingFileHandler",
+                "class": "oldp.utils.log_handlers.ModeAwareRotatingFileHandler",
                 "filename": BASE_DIR / "logs/oldp.log",
                 "maxBytes": 1024 * 1024 * 15,  # 15MB
                 "backupCount": 10,

--- a/oldp/utils/log_handlers.py
+++ b/oldp/utils/log_handlers.py
@@ -1,0 +1,44 @@
+"""Custom logging handlers for OLDP."""
+
+import os
+from logging.handlers import RotatingFileHandler
+
+
+class ModeAwareRotatingFileHandler(RotatingFileHandler):
+    """RotatingFileHandler that enforces a fixed file mode on every rollover.
+
+    The stdlib RotatingFileHandler opens new log files with ``open(...)``, so
+    the resulting permissions are ``0o666 & ~umask`` of whichever worker
+    happens to create the file. Under multi-worker gunicorn this is racy:
+    workers that inherit a tighter umask (e.g. 0o077) produce 0600 files,
+    which then become unreadable to external log-analysis scripts and to
+    non-root users on the host.
+
+    This subclass chmods the file to a fixed mode (default 0o644) after every
+    open and after every rollover, so external readers can always access the
+    rotated history regardless of which worker performed the rotation.
+    """
+
+    def __init__(self, *args, file_mode: int = 0o644, **kwargs):
+        self.file_mode = file_mode
+        super().__init__(*args, **kwargs)
+        self._ensure_mode(self.baseFilename)
+
+    def _open(self):
+        stream = super()._open()
+        self._ensure_mode(self.baseFilename)
+        return stream
+
+    def doRollover(self):
+        super().doRollover()
+        for i in range(1, self.backupCount + 1):
+            self._ensure_mode(f"{self.baseFilename}.{i}")
+        self._ensure_mode(self.baseFilename)
+
+    def _ensure_mode(self, path: str) -> None:
+        try:
+            os.chmod(path, self.file_mode)
+        except FileNotFoundError:
+            pass
+        except OSError:
+            pass


### PR DESCRIPTION
## Summary
- Stdlib `RotatingFileHandler` opens new log files with the worker's umask. Under multi-worker gunicorn, one worker initialized with `umask 0o077` produces `0600` rotated files that are unreadable to external log-analysis scripts and to non-root users on the host.
- Adds `oldp.utils.log_handlers.ModeAwareRotatingFileHandler` which `chmod`s to `0o644` after every `_open()` and after `doRollover()` (base + each `.N` backup).
- Wires it into the default `LOGGING` config (one-line change in `oldp/settings.py`).

## Why
- The production deployment of de.openlegaldata.io ships rotated logs back to the host. Sporadic `0600` files were breaking `analyze_django_logs.py` with `PermissionError`.
- The chmod-after-open approach is robust regardless of which worker performs the rotation — no need to track down why one worker comes up with a tighter umask.

## Test plan
- [x] `make lint` — clean.
- [x] Smoke test under `umask 0o077`: every rolled file (base + 3 backups) lands at `0o644`.
- [ ] CI (`make test`) — pending on this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)