### PR TITLE
feat(cache): AnonymousPublicCacheMiddleware for CDN-friendly anon responses

### DIFF
--- a/README.md
+++ b/README.md
@@ -139,6 +139,11 @@ You can as well override specific settings from `src/oldp/settings.py` with envi
 | `DJANGO_FILE_CACHE_LOCATION` | `/var/tmp/django_cache` | File cache directory when `DJANGO_CACHE_BACKEND=file`; must be writable by the app. |
 | `DJANGO_MCP_ANTHROPIC_ANON_RATE` | `500/hour` | Anonymous MCP request rate limit. Anthropic MCP IPs share a single anonymous bucket. |
 | `DJANGO_MCP_USER_RATE` | `1000/hour` | Authenticated MCP request rate limit per user. |
+| `DJANGO_ANON_CACHE_ENABLED` | `True` | Master switch for `AnonymousPublicCacheMiddleware` (strips `Vary: Cookie` / `Set-Cookie` and emits `Cache-Control: public` for anonymous GET/HEAD on public pages so a CDN can cache them). |
+| `DJANGO_ANON_CACHE_PATH_PREFIXES` | `/case/,/law/,/court/,/pages/,/search/` | Comma-separated URL prefixes treated as anonymous-cacheable. |
+| `DJANGO_ANON_CACHE_PATHS_EXACT` | `/` | Comma-separated exact paths treated as anonymous-cacheable (e.g. the homepage). |
+| `DJANGO_ANON_CACHE_S_MAXAGE` | `600` | CDN edge TTL in seconds for anonymous public-cacheable responses. |
+| `DJANGO_ANON_CACHE_MAX_AGE` | `60` | Browser TTL in seconds for anonymous public-cacheable responses. |
 
 
 

--- a/oldp/settings.py
+++ b/oldp/settings.py
@@ -131,6 +131,17 @@ class BaseConfiguration(Configuration):
     EMAIL_HOST_USER = values.Value("")
     EMAIL_HOST_PASSWORD = values.Value("")
 
+    # AnonymousPublicCacheMiddleware — see oldp/utils/middleware.py.
+    # Makes anonymous GETs on public paths CDN-cacheable by stripping
+    # Vary: Cookie and Set-Cookie and emitting Cache-Control: public.
+    ANON_CACHE_ENABLED = values.BooleanValue(True)
+    ANON_CACHE_PATH_PREFIXES = values.ListValue(
+        ["/case/", "/law/", "/court/", "/pages/", "/search/"]
+    )
+    ANON_CACHE_PATHS_EXACT = values.ListValue(["/"])
+    ANON_CACHE_S_MAXAGE = values.IntegerValue(600)
+    ANON_CACHE_MAX_AGE = values.IntegerValue(60)
+
     MIDDLEWARE = [
         # Runs last on the response phase (it's first in the list), so it
         # sees the final Vary/Set-Cookie set by Django and can normalize

--- a/oldp/settings.py
+++ b/oldp/settings.py
@@ -132,6 +132,10 @@ class BaseConfiguration(Configuration):
     EMAIL_HOST_PASSWORD = values.Value("")
 
     MIDDLEWARE = [
+        # Runs last on the response phase (it's first in the list), so it
+        # sees the final Vary/Set-Cookie set by Django and can normalize
+        # them for CDN-friendly caching of anonymous responses.
+        "oldp.utils.middleware.AnonymousPublicCacheMiddleware",
         "django.middleware.gzip.GZipMiddleware",
         "django.middleware.http.ConditionalGetMiddleware",
         # Simplified static file serving.

--- a/oldp/utils/middleware.py
+++ b/oldp/utils/middleware.py
@@ -1,0 +1,104 @@
+"""Middleware utilities for OLDP."""
+
+from __future__ import annotations
+
+from typing import Callable
+
+from django.conf import settings
+from django.http import HttpRequest, HttpResponseBase
+
+DEFAULT_ANON_CACHE_PATH_PREFIXES: tuple[str, ...] = (
+    "/case/",
+    "/law/",
+    "/court/",
+    "/pages/",
+    "/search/",
+)
+DEFAULT_ANON_CACHE_PATHS_EXACT: tuple[str, ...] = ("/",)
+DEFAULT_ANON_CACHE_S_MAXAGE: int = 600  # 10 minutes at the CDN edge
+DEFAULT_ANON_CACHE_MAX_AGE: int = 60  # 1 minute in the browser
+
+
+class AnonymousPublicCacheMiddleware:
+    """Make anonymous GETs on public pages CDN-cacheable.
+
+    Without this, ``SessionMiddleware``/``AuthenticationMiddleware`` tag
+    every response with ``Vary: Cookie`` whenever the session is touched
+    (which happens on virtually every page because the navbar tests
+    ``user.is_authenticated``). A CDN respecting ``Vary: Cookie`` keys
+    each unique cookie value separately, and anonymous bots typically
+    carry several cookies (``csrftoken``, analytics, etc.), so cache
+    key fan-out collapses the effective hit rate.
+
+    For anonymous GET/HEAD on cacheable paths this middleware:
+
+    * Replaces ``Vary: Cookie`` with ``Vary: Accept-Encoding`` so all
+      anonymous responses share one cache key per URL.
+    * Clears any ``Set-Cookie`` headers (the cacheable pages render only
+      GET forms — no ``{% csrf_token %}`` — so no cookies need to flow
+      to anonymous visitors).
+    * Sets ``Cache-Control: public`` with finite ``s-maxage`` so the
+      CDN treats the response as cacheable.
+
+    Logged-in users (carrying ``sessionid``) are untouched: they keep
+    their ``Vary: Cookie`` responses, and the CDN bypasses cache for
+    them via its own rule. This middleware is therefore safe to enable
+    by default in production.
+
+    Configurable Django settings (all optional):
+
+    * ``ANON_CACHE_ENABLED`` (bool, default ``True``): master switch.
+      Set to ``False`` to neutralize the middleware without removing
+      it from ``MIDDLEWARE``.
+    * ``ANON_CACHE_PATH_PREFIXES`` (iterable of str): URL prefixes that
+      should become public-cacheable for anonymous visitors. Default:
+      ``("/case/", "/law/", "/court/", "/pages/", "/search/")``.
+    * ``ANON_CACHE_PATHS_EXACT`` (iterable of str): exact paths to
+      cover. Default: ``("/",)`` so the homepage is included.
+    * ``ANON_CACHE_S_MAXAGE`` (int, seconds): CDN edge TTL. Default 600.
+    * ``ANON_CACHE_MAX_AGE`` (int, seconds): browser TTL. Default 60.
+    """
+
+    def __init__(self, get_response: Callable[[HttpRequest], HttpResponseBase]):
+        self.get_response = get_response
+        self.enabled: bool = getattr(settings, "ANON_CACHE_ENABLED", True)
+        self.prefixes: tuple[str, ...] = tuple(
+            getattr(
+                settings, "ANON_CACHE_PATH_PREFIXES", DEFAULT_ANON_CACHE_PATH_PREFIXES
+            )
+        )
+        self.exact: frozenset[str] = frozenset(
+            getattr(settings, "ANON_CACHE_PATHS_EXACT", DEFAULT_ANON_CACHE_PATHS_EXACT)
+        )
+        self.s_maxage: int = int(
+            getattr(settings, "ANON_CACHE_S_MAXAGE", DEFAULT_ANON_CACHE_S_MAXAGE)
+        )
+        self.max_age: int = int(
+            getattr(settings, "ANON_CACHE_MAX_AGE", DEFAULT_ANON_CACHE_MAX_AGE)
+        )
+
+    def __call__(self, request: HttpRequest) -> HttpResponseBase:
+        response = self.get_response(request)
+        if self.enabled and self._applies(request, response):
+            self._make_public_cacheable(response)
+        return response
+
+    def _applies(self, request: HttpRequest, response: HttpResponseBase) -> bool:
+        if request.method not in ("GET", "HEAD"):
+            return False
+        if response.status_code != 200:
+            return False
+        user = getattr(request, "user", None)
+        if user is not None and not getattr(user, "is_anonymous", True):
+            return False
+        path = request.path or ""
+        if path in self.exact:
+            return True
+        return any(path.startswith(p) for p in self.prefixes)
+
+    def _make_public_cacheable(self, response: HttpResponseBase) -> None:
+        response.headers["Vary"] = "Accept-Encoding"
+        response.cookies.clear()
+        response.headers["Cache-Control"] = (
+            f"public, s-maxage={self.s_maxage}, max-age={self.max_age}"
+        )

--- a/oldp/utils/tests/test_middleware.py
+++ b/oldp/utils/tests/test_middleware.py
@@ -1,0 +1,121 @@
+"""Tests for AnonymousPublicCacheMiddleware."""
+
+from unittest.mock import MagicMock
+
+from django.http import HttpResponse
+from django.test import RequestFactory, TestCase, override_settings, tag
+
+from oldp.utils.middleware import AnonymousPublicCacheMiddleware
+
+
+def _anon(req):
+    user = MagicMock()
+    user.is_anonymous = True
+    req.user = user
+    return req
+
+
+def _authed(req):
+    user = MagicMock()
+    user.is_anonymous = False
+    req.user = user
+    return req
+
+
+@tag("utils", "middleware")
+class AnonymousPublicCacheMiddlewareTestCase(TestCase):
+    def setUp(self):
+        self.factory = RequestFactory()
+
+    def _build(self, response: HttpResponse):
+        def get_response(request):
+            return response
+
+        return AnonymousPublicCacheMiddleware(get_response)
+
+    def _response_with_cookie_and_vary(self) -> HttpResponse:
+        resp = HttpResponse("body")
+        resp["Vary"] = "Cookie"
+        resp.set_cookie("csrftoken", "abc123")
+        return resp
+
+    def test_rewrites_anon_get_on_cacheable_prefix(self):
+        mw = self._build(self._response_with_cookie_and_vary())
+        request = _anon(self.factory.get("/case/lg-foo-2024-01-01"))
+        response = mw(request)
+        self.assertEqual(response["Vary"], "Accept-Encoding")
+        self.assertNotIn("csrftoken", response.cookies)
+        self.assertIn("public", response["Cache-Control"])
+        self.assertIn("s-maxage=", response["Cache-Control"])
+
+    def test_rewrites_anon_get_on_homepage(self):
+        mw = self._build(self._response_with_cookie_and_vary())
+        request = _anon(self.factory.get("/"))
+        response = mw(request)
+        self.assertEqual(response["Vary"], "Accept-Encoding")
+        self.assertIn("public", response["Cache-Control"])
+
+    def test_skips_authenticated_user(self):
+        mw = self._build(self._response_with_cookie_and_vary())
+        request = _authed(self.factory.get("/case/lg-foo-2024-01-01"))
+        response = mw(request)
+        self.assertEqual(response["Vary"], "Cookie")
+        self.assertIn("csrftoken", response.cookies)
+        self.assertNotIn("Cache-Control", response.headers)
+
+    def test_skips_non_cacheable_path(self):
+        mw = self._build(self._response_with_cookie_and_vary())
+        request = _anon(self.factory.get("/api/cases/"))
+        response = mw(request)
+        self.assertEqual(response["Vary"], "Cookie")
+        self.assertIn("csrftoken", response.cookies)
+
+    def test_skips_non_200(self):
+        resp = HttpResponse("not found", status=404)
+        resp["Vary"] = "Cookie"
+        resp.set_cookie("csrftoken", "abc123")
+        mw = self._build(resp)
+        request = _anon(self.factory.get("/case/missing"))
+        response = mw(request)
+        self.assertEqual(response["Vary"], "Cookie")
+        self.assertIn("csrftoken", response.cookies)
+
+    def test_skips_post(self):
+        mw = self._build(self._response_with_cookie_and_vary())
+        request = _anon(self.factory.post("/case/lg-foo-2024-01-01"))
+        response = mw(request)
+        self.assertEqual(response["Vary"], "Cookie")
+        self.assertIn("csrftoken", response.cookies)
+
+    @override_settings(ANON_CACHE_ENABLED=False)
+    def test_kill_switch(self):
+        mw = self._build(self._response_with_cookie_and_vary())
+        request = _anon(self.factory.get("/case/lg-foo-2024-01-01"))
+        response = mw(request)
+        self.assertEqual(response["Vary"], "Cookie")
+        self.assertIn("csrftoken", response.cookies)
+
+    @override_settings(
+        ANON_CACHE_PATH_PREFIXES=("/custom/",),
+        ANON_CACHE_PATHS_EXACT=(),
+    )
+    def test_custom_prefix_setting(self):
+        mw = self._build(self._response_with_cookie_and_vary())
+        # Default-cacheable path no longer matches
+        request = _anon(self.factory.get("/case/lg-foo-2024-01-01"))
+        response = mw(request)
+        self.assertEqual(response["Vary"], "Cookie")
+
+        # Custom-configured prefix now matches
+        mw2 = self._build(self._response_with_cookie_and_vary())
+        request2 = _anon(self.factory.get("/custom/foo"))
+        response2 = mw2(request2)
+        self.assertEqual(response2["Vary"], "Accept-Encoding")
+
+    @override_settings(ANON_CACHE_S_MAXAGE=120, ANON_CACHE_MAX_AGE=10)
+    def test_custom_ttl_settings(self):
+        mw = self._build(self._response_with_cookie_and_vary())
+        request = _anon(self.factory.get("/case/foo"))
+        response = mw(request)
+        self.assertIn("s-maxage=120", response["Cache-Control"])
+        self.assertIn("max-age=10", response["Cache-Control"])


### PR DESCRIPTION
## Summary

Django's `SessionMiddleware`/`AuthenticationMiddleware` tag every response that touches the session with `Vary: Cookie`. The default navbar template hits `user.is_authenticated` on every render, so virtually every response carries `Vary: Cookie`. Combined with cookies sent by anonymous bots (`csrftoken`, analytics, etc.), CDN cache keys fragment per-cookie-value and the effective hit rate collapses.

This was directly confirmed on production: in a 6-hour window the Cloudflare Cache Rule produced **18,574 MISS** vs only **331 HIT** on `/case/` — the rule was matching, the fragmentation was killing it.

This PR adds `AnonymousPublicCacheMiddleware` which, for anonymous GET/HEAD on configurable URL prefixes:

- Replaces `Vary: Cookie` with `Vary: Accept-Encoding` so all anonymous responses share one cache key per URL.
- Clears any `Set-Cookie` headers (safe: the cacheable pages render only GET forms — search bar, filter facets — with no `{% csrf_token %}`).
- Sets `Cache-Control: public, s-maxage=600, max-age=60`.

Authenticated users (carrying `sessionid`) are untouched: they keep their `Vary: Cookie` responses, and the CDN-side rule bypasses cache for them.

## Configuration

All optional Django settings, with sensible defaults baked in:

| Setting | Default | Purpose |
|--|--|--|
| `ANON_CACHE_ENABLED` | `True` | Master switch |
| `ANON_CACHE_PATH_PREFIXES` | `("/case/", "/law/", "/court/", "/pages/", "/search/")` | Prefix-matched cacheable paths |
| `ANON_CACHE_PATHS_EXACT` | `("/",)` | Exact-match cacheable paths (homepage) |
| `ANON_CACHE_S_MAXAGE` | `600` | CDN edge TTL (seconds) |
| `ANON_CACHE_MAX_AGE` | `60` | Browser TTL (seconds) |

## Why this is safe for forms on cacheable pages

Confirmed by `grep`ing all templates under cacheable URL prefixes:

- The global search bar (rendered on every page) is `<form method="get">` → no CSRF needed.
- Case list / court list filter sidebars are `<form method="get">`.
- Homepage banner search is `<form method="get">`.
- Case/law/court/pages detail templates: no forms at all.
- Zero `{% csrf_token %}` calls under `/case/*`, `/law/*`, `/court/*`, `/pages/*`, `/` templates.

POST forms (login, contact, account) live under `/accounts/*` and `/contact/*`, which are not in the default `ANON_CACHE_PATH_PREFIXES`.

## Test plan

- [x] 9 unit tests covering: anon GET on prefix, anon GET on homepage, authed user skipped, non-cacheable path skipped, non-200 skipped, POST skipped, kill-switch, custom prefix setting, custom TTL settings — all pass via `make test`.
- [x] `make lint` clean.
- [ ] CI on this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)