### PR TITLE
feat(laws-api): omit `content` field from list responses

### DIFF
--- a/docs/api/api-overview.md
+++ b/docs/api/api-overview.md
@@ -113,7 +113,14 @@ curl -X GET "https://de.openlegaldata.io/api/cases/?date_after=2020-01-01&date_b
 
 ### Laws
 
-**List all laws:**
+> **Field availability:** the list endpoint (`/api/laws/`) returns
+> summary records **without the `content` field**, mirroring how `/api/cases/`
+> behaves. Use the detail endpoint (`/api/laws/<id>/`) to retrieve a law
+> section's full HTML body. This keeps bulk pagination cheap on bandwidth
+> and origin CPU; for whole-dataset access prefer the
+> [data dumps](../data-dumps.md).
+
+**List all laws (no `content`):**
 ```bash
 curl -X GET "https://de.openlegaldata.io/api/laws/" \
   -H "Authorization: Token YOUR_API_TOKEN_HERE" \
@@ -127,7 +134,7 @@ curl -X GET "https://de.openlegaldata.io/api/laws/?book_id=5" \
   -H "Accept: application/json"
 ```
 
-**Get a specific law:**
+**Get a specific law (includes `content`):**
 ```bash
 curl -X GET "https://de.openlegaldata.io/api/laws/123/" \
   -H "Authorization: Token YOUR_API_TOKEN_HERE" \
@@ -252,7 +259,9 @@ The `references/` endpoints return a single dict
 (`total_law_references`, `total_case_references`,
 `law_references[]`, `case_references[]`,
 `references_extracted_at`). The `citing_*` endpoints return a
-paginated list of summary records.
+paginated list of summary records — **`content` is omitted** on these
+list-style responses for both cases and laws; fetch the detail endpoint
+when the body HTML is actually needed.
 
 `citing_cases` and `citing_laws` for a law cross-revision-resolve via
 `(book_code, section)`, so older citation rows pinned to non-latest

--- a/oldp/apps/laws/api_views.py
+++ b/oldp/apps/laws/api_views.py
@@ -45,6 +45,18 @@ class LawViewSet(ReviewStatusFilterMixin, viewsets.ModelViewSet):
     Lists, retrieves, creates, and updates law sections within law books.
     Filter by `book_id`, `book__slug`, `book__latest`, or `book__revision_date`.
     Write operations require authentication.
+
+    Response shape mirrors the Case API:
+
+    * **List** (`GET /api/laws/`) returns the summary serializer
+      (`LawListSerializer`), which omits the potentially-large `content`
+      field. Use this for pagination, indexing, and discovery.
+    * **Detail** (`GET /api/laws/<id>/`) returns the full
+      `LawSerializer`, including `content`. Use this when the HTML body
+      of a specific section is actually needed.
+
+    For whole-dataset access, prefer the data dumps over scripted
+    pagination — see ``docs/data-dumps.md``.
     """
 
     permission_classes = [HasTokenPermission]
@@ -182,7 +194,12 @@ class LawViewSet(ReviewStatusFilterMixin, viewsets.ModelViewSet):
         serializer_class=LawListSerializer,
     )
     def citing_laws(self, request, pk=None):
-        """Laws whose body cites this law section."""
+        """Laws whose body cites this law section.
+
+        Returns paginated summary records (``LawListSerializer``) —
+        ``content`` is omitted; fetch ``/api/laws/<id>/`` if the full
+        body of a citing law is needed.
+        """
         law = self.get_object()
         sibling_ids = list(
             Law.objects.filter(

--- a/oldp/apps/laws/api_views.py
+++ b/oldp/apps/laws/api_views.py
@@ -22,6 +22,7 @@ from oldp.apps.laws.serializers import (
     LawBookCreateSerializer,
     LawBookSerializer,
     LawCreateSerializer,
+    LawListSerializer,
     LawSearchSerializer,
     LawSerializer,
 )
@@ -64,8 +65,14 @@ class LawViewSet(ReviewStatusFilterMixin, viewsets.ModelViewSet):
 
     def get_serializer_class(self):
         """Return appropriate serializer based on action."""
-        if getattr(self, "action", None) == "create":
+        action = getattr(self, "action", None)
+        if action == "create":
             return LawCreateSerializer
+        if action == "list":
+            # /api/laws/ excludes the large `content` field; use the
+            # detail view (/api/laws/<id>/) to fetch a section's full
+            # content. Mirrors the Case list/detail split.
+            return LawListSerializer
         return LawSerializer
 
     @method_decorator(cache_page(settings.CACHE_TTL))
@@ -167,12 +174,12 @@ class LawViewSet(ReviewStatusFilterMixin, viewsets.ModelViewSet):
             return self.get_paginated_response(serializer.data)
         return Response(serializer.data)
 
-    @swagger_auto_schema(responses={200: LawSerializer(many=True)})
+    @swagger_auto_schema(responses={200: LawListSerializer(many=True)})
     @action(
         detail=True,
         methods=["get"],
         permission_classes=[AllowAny],
-        serializer_class=LawSerializer,
+        serializer_class=LawListSerializer,
     )
     def citing_laws(self, request, pk=None):
         """Laws whose body cites this law section."""
@@ -186,7 +193,7 @@ class LawViewSet(ReviewStatusFilterMixin, viewsets.ModelViewSet):
         )
         qs = citing_laws_for_law(sibling_ids or [law.id])
         page = self.paginate_queryset(qs)
-        serializer = LawSerializer(page if page is not None else qs, many=True)
+        serializer = LawListSerializer(page if page is not None else qs, many=True)
         if page is not None:
             return self.get_paginated_response(serializer.data)
         return Response(serializer.data)

--- a/oldp/apps/laws/serializers.py
+++ b/oldp/apps/laws/serializers.py
@@ -7,6 +7,26 @@ from oldp.apps.laws.models import Law, LawBook
 from oldp.apps.laws.search_indexes import LawIndex
 from oldp.apps.search.api import SearchResultSerializer
 
+LAW_API_FIELDS = (
+    "id",
+    "book",
+    "book_code",
+    "book_slug",
+    "title",
+    "content",
+    "slug",
+    "created_date",
+    "updated_date",
+    "section",
+    "amtabk",
+    "kurzue",
+    "doknr",
+    "order",
+    "review_status",
+)
+
+LAW_API_LIST_FIELDS = tuple(f for f in LAW_API_FIELDS if f != "content")
+
 
 class LawSerializer(ReviewStatusFieldMixin, serializers.ModelSerializer):
     book_code = serializers.CharField(source="book.code", read_only=True)
@@ -14,24 +34,25 @@ class LawSerializer(ReviewStatusFieldMixin, serializers.ModelSerializer):
 
     class Meta:
         model = Law
-        fields = (
-            "id",
-            "book",
-            "book_code",
-            "book_slug",
-            "title",
-            "content",
-            "slug",
-            "created_date",
-            "updated_date",
-            "section",
-            "amtabk",
-            "kurzue",
-            "doknr",
-            "order",
-            "review_status",
-        )
+        fields = LAW_API_FIELDS
         # depth = 2
+
+
+class LawListSerializer(ReviewStatusFieldMixin, serializers.ModelSerializer):
+    """Serializer for law list views, excluding the large content field.
+
+    The content field on Law can be megabytes of HTML; returning it on
+    every list response inflated `/api/laws/` payloads by 10-100x and
+    drove origin CPU during bulk pagination. The detail view
+    (`/api/laws/<id>/`) continues to return content.
+    """
+
+    book_code = serializers.CharField(source="book.code", read_only=True)
+    book_slug = serializers.CharField(source="book.slug", read_only=True)
+
+    class Meta:
+        model = Law
+        fields = LAW_API_LIST_FIELDS
 
 
 class LawBookSerializer(ReviewStatusFieldMixin, serializers.ModelSerializer):

--- a/oldp/apps/laws/tests/test_api_list_omits_content.py
+++ b/oldp/apps/laws/tests/test_api_list_omits_content.py
@@ -1,0 +1,89 @@
+"""Verify /api/laws/ list responses omit the `content` field.
+
+Law content can be megabytes of HTML; returning it in the list view
+makes bulk pagination expensive on origin CPU and bandwidth. The
+detail view (`/api/laws/<id>/`) continues to return content. Mirrors
+the existing Case list/detail split.
+"""
+
+import datetime
+
+from django.contrib.auth import get_user_model
+from django.test import override_settings
+from rest_framework import status
+from rest_framework.test import APIClient, APITestCase
+
+from oldp.apps.accounts.models import (
+    APIToken,
+    APITokenPermission,
+    APITokenPermissionGroup,
+)
+from oldp.apps.laws.models import Law, LawBook
+
+User = get_user_model()
+
+
+@override_settings(
+    CACHES={"default": {"BACKEND": "django.core.cache.backends.dummy.DummyCache"}}
+)
+class LawListOmitsContentAPITestCase(APITestCase):
+    def setUp(self):
+        self.user = User.objects.create_user(
+            username="reader", email="reader@example.com", password="pass"
+        )
+        read_perm, _ = APITokenPermission.objects.get_or_create(
+            resource="laws", action="read"
+        )
+        group = APITokenPermissionGroup.objects.create(name="laws_read")
+        group.permissions.add(read_perm)
+        self.token = APIToken.objects.create(
+            user=self.user, name="reader-token", permission_group=group
+        )
+
+        self.book = LawBook.objects.create(
+            code="BGB",
+            title="Bürgerliches Gesetzbuch",
+            slug="bgb",
+            revision_date=datetime.date(2021, 1, 1),
+            review_status="accepted",
+            latest=True,
+        )
+        self.content_html = "<p>Some statutory text " + ("x" * 5_000) + "</p>"
+        self.law = Law.objects.create(
+            book=self.book,
+            title="§ 1 BGB",
+            slug="1",
+            section="1",
+            order=1,
+            content=self.content_html,
+            review_status="accepted",
+        )
+
+        self.client = APIClient()
+        self.client.force_authenticate(user=self.user, token=self.token)
+
+    def test_list_response_omits_content(self):
+        response = self.client.get("/api/laws/")
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        self.assertGreaterEqual(len(response.data["results"]), 1)
+        for item in response.data["results"]:
+            self.assertNotIn("content", item)
+            # Other expected fields stay present
+            self.assertIn("id", item)
+            self.assertIn("title", item)
+            self.assertIn("slug", item)
+
+    def test_detail_response_includes_content(self):
+        response = self.client.get(f"/api/laws/{self.law.pk}/")
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        self.assertIn("content", response.data)
+        self.assertEqual(response.data["content"], self.content_html)
+
+    def test_citing_laws_action_omits_content(self):
+        # citing_laws returns a paginated list of related laws; same
+        # rationale as the main list view — should omit `content`.
+        response = self.client.get(f"/api/laws/{self.law.pk}/citing_laws/")
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        results = response.data.get("results", response.data)
+        for item in results:
+            self.assertNotIn("content", item)


### PR DESCRIPTION
## Summary

Mirrors the existing Case list/detail serializer split for laws: the `content` field is dropped from `/api/laws/` list responses (and the `citing_laws` action) and remains in the detail view `/api/laws/<id>/`.

## Why

Law content can be megabytes of HTML. Returning it on every list-view record makes `/api/laws/?limit=1000` 10–100× larger than needed and pressures origin CPU during legitimate bulk pagination. Observed in production: a research scraper iterating laws book-by-book at ~1.6k req / 30 min — entirely compliant with the public API, but each response was paying for `content` it didn't need at that step.

The Case API already handles this with `CaseSerializer` (detail) vs `CaseListSerializer` (list); this PR replicates that pattern for laws.

## Changes

- `oldp/apps/laws/serializers.py`:
  - Extract `LAW_API_FIELDS` and derive `LAW_API_LIST_FIELDS = tuple(f for f in LAW_API_FIELDS if f != "content")`.
  - Add `LawListSerializer` — same fields as `LawSerializer` minus `content`.
- `oldp/apps/laws/api_views.py`:
  - `LawViewSet.get_serializer_class()` returns `LawListSerializer` for `action == "list"`.
  - `citing_laws` action switched from `LawSerializer` → `LawListSerializer` (matches `citing_cases` → `CaseListSerializer`).
- `oldp/apps/laws/tests/test_api_list_omits_content.py` — 3 new tests covering list, detail, and `citing_laws`.

## Test plan

- [x] `make lint` clean.
- [x] New tests pass.
- [x] Full `oldp.apps.laws` suite: 160 tests, all pass.
- [x] CI on this PR.

## Backwards compatibility

Consumers that previously fetched `content` from list responses must switch to the detail view (one extra request per record they actually need content for). That is the correct usage pattern anyway — keeping `content` in lists encouraged inefficient bulk fetches.

🤖 Generated with [Claude Code](https://claude.com/claude-code)