### PR TITLE
fix(cases): catch Court.MultipleObjectsReturned in CourtResolver

### DIFF
--- a/oldp/apps/cases/services/court_resolver.py
+++ b/oldp/apps/cases/services/court_resolver.py
@@ -17,6 +17,34 @@ from oldp.utils import find_from_mapping
 logger = logging.getLogger(__name__)
 
 
+def _lookup_one(**filters) -> Optional[Court]:
+    """Look up a single Court by exact-match filters.
+
+    Returns the Court when exactly one matches; returns ``None`` for both
+    "no matches" and "multiple matches". The caller should treat ``None``
+    as "this resolution strategy was inconclusive" and fall through to
+    the next. Ambiguous results are logged at WARNING so data-quality
+    issues surface in logs without breaking the API.
+
+    Catching ``MultipleObjectsReturned`` here is what keeps an ambiguous
+    name (two ``Court`` rows sharing ``name``) from leaking out of
+    ``CourtResolver.find_court`` as an uncaught 500. See PR for the
+    incident where dev → prod case migration tripped on two
+    "Hanseatisches Oberlandesgericht" rows (Bremen + Hamburg).
+    """
+    try:
+        return Court.objects.get(**filters)
+    except Court.DoesNotExist:
+        return None
+    except Court.MultipleObjectsReturned:
+        logger.warning(
+            "Ambiguous court lookup %s — multiple rows match; "
+            "falling through to next resolution strategy",
+            filters,
+        )
+        return None
+
+
 class CourtResolver:
     """Service to resolve court from name/string input.
 
@@ -98,32 +126,28 @@ class CourtResolver:
         """
         # Try to find by code first
         if court_code:
-            try:
-                return Court.objects.get(code=court_code)
-            except Court.DoesNotExist:
-                pass
+            court = _lookup_one(code=court_code)
+            if court:
+                return court
 
         if not court_name:
             raise CourtNotFoundError("Court name is required")
 
         # Handle special case for EU court
         if court_name == "EU":
-            try:
-                return Court.objects.get(code="EuGH")
-            except Court.DoesNotExist:
-                pass
+            court = _lookup_one(code="EuGH")
+            if court:
+                return court
 
         # Try exact name match first
-        try:
-            return Court.objects.get(name=court_name)
-        except Court.DoesNotExist:
-            pass
+        court = _lookup_one(name=court_name)
+        if court:
+            return court
 
         # Try matching by court code (e.g. "BVerfG", "BGH")
-        try:
-            return Court.objects.get(code=court_name)
-        except Court.DoesNotExist:
-            pass
+        court = _lookup_one(code=court_name)
+        if court:
+            return court
 
         # Try alias match early — aliases are more precise than geographic inference
         court = self._find_by_alias(court_name)
@@ -176,11 +200,10 @@ class CourtResolver:
         state_id = find_from_mapping(court_name, state_id_mapping)
 
         if state_id is not None:
-            try:
-                logger.debug("Look for state=%i, type=%s", state_id, court_type)
-                return Court.objects.get(state_id=state_id, court_type=court_type)
-            except Court.DoesNotExist:
-                pass
+            logger.debug("Look for state=%i, type=%s", state_id, court_type)
+            court = _lookup_one(state_id=state_id, court_type=court_type)
+            if court:
+                return court
 
         return None
 
@@ -194,11 +217,10 @@ class CourtResolver:
         city_id = find_from_mapping(court_name, city_id_mapping)
 
         if city_id is not None:
-            try:
-                logger.debug("Look for city=%i, type=%s", city_id, court_type)
-                return Court.objects.get(city_id=city_id, court_type=court_type)
-            except Court.DoesNotExist:
-                pass
+            logger.debug("Look for city=%i, type=%s", city_id, court_type)
+            court = _lookup_one(city_id=city_id, court_type=court_type)
+            if court:
+                return court
 
         return None
 
@@ -229,15 +251,19 @@ class CourtResolver:
         # Try city → state resolution: München is in Bayern → find VGH in Bayern
         try:
             city = City.objects.get(name=location)
-            if city.state_id:
-                try:
-                    return Court.objects.get(
-                        court_type=court_type, state_id=city.state_id
-                    )
-                except Court.DoesNotExist:
-                    pass
         except City.DoesNotExist:
-            pass
+            return None
+        except City.MultipleObjectsReturned:
+            logger.warning(
+                "Ambiguous city lookup name=%r in _find_by_partial_name; "
+                "falling through",
+                location,
+            )
+            return None
+        if city.state_id:
+            court = _lookup_one(court_type=court_type, state_id=city.state_id)
+            if court:
+                return court
 
         return None
 

--- a/oldp/apps/cases/tests/test_case_creation_api.py
+++ b/oldp/apps/cases/tests/test_case_creation_api.py
@@ -203,6 +203,51 @@ class CourtResolverTestCase(TestCase):
         found = self.resolver.find_court("AG Teststadt")
         self.assertEqual(found.pk, court.pk)
 
+    def test_find_court_ambiguous_name_no_other_signal_raises(self):
+        """If every strategy is inconclusive, raise CourtNotFoundError (NOT 500)."""
+        state = State.objects.first()
+        # Same exact name with no extractable court type prefix — every
+        # downstream resolution strategy (alias, type+state, type+city,
+        # partial-name) returns None, so we end up at the final raise.
+        Court.objects.create(
+            name="Zweideutiges Gericht",
+            code="ZG-A",
+            slug="zg-a",
+            state=state,
+            court_type="",
+        )
+        Court.objects.create(
+            name="Zweideutiges Gericht",
+            code="ZG-B",
+            slug="zg-b",
+            state=state,
+            court_type="",
+        )
+        with self.assertRaises(CourtNotFoundError):
+            self.resolver.find_court("Zweideutiges Gericht")
+
+    def test_find_court_ambiguous_name_resolves_via_unique_code(self):
+        """Two name-twins coexisting shouldn't break code-based resolution."""
+        state = State.objects.first()
+        Court.objects.create(
+            name="Doppelgänger Gericht",
+            code="DG-A",
+            slug="dg-a",
+            state=state,
+            court_type="OLG",
+        )
+        winner = Court.objects.create(
+            name="Doppelgänger Gericht",
+            code="DG-B",
+            slug="dg-b",
+            state=state,
+            court_type="OLG",
+        )
+        found = self.resolver.find_court(
+            court_name="Doppelgänger Gericht", court_code="DG-B"
+        )
+        self.assertEqual(found.pk, winner.pk)
+
 
 class CaseCreatorTestCase(TestCase):
     """Tests for the CaseCreator service."""


### PR DESCRIPTION
## Summary

`CourtResolver.find_court` called `Court.objects.get()` at six sites that caught only `Court.DoesNotExist`. When two `Court` rows shared the same `name` (or any other lookup key), `MultipleObjectsReturned` leaked out — propagating through `CaseCreator` and the DRF view as an uncaught HTTP **500** instead of a clean **400** with the existing `court_not_found` code.

**Triggering scenario from prod**: a dev → prod case migration tripped on:

- two `Hanseatisches Oberlandesgericht` rows (Bremen + Hamburg — both legitimate historical courts that share the legal name), and
- one duplicate `Thüringer Verfassungsgerichtshof` row (a stray slug-style code, likely auto-created by an older ingestor run).

30 cases failed with 500. Investigation traced it to `CourtResolver.find_court` line 118.

## Fix

Introduce `_lookup_one(**filters)` — a small helper that returns `None` for both `DoesNotExist` *and* `MultipleObjectsReturned`, logging a WARNING in the ambiguous case so data-quality issues still surface in logs without breaking the API.

Each of the six `Court.objects.get(...)` sites in `court_resolver.py` now uses the helper:

- `code=court_code` (line 102)
- `code="EuGH"` (line 112, EU special case)
- `name=court_name` (line 118)
- `code=court_name` (line 124, name-interpreted-as-code)
- `state_id=..., court_type=...` (in `_find_by_state`)
- `city_id=..., court_type=...` (in `_find_by_city` and `_find_by_partial_name`)

If every strategy is inconclusive, the existing final `raise CourtNotFoundError` runs and DRF converts to 400 with the `court_not_found` code that clients already handle.

## Tests

Two new tests in `CourtResolverTestCase`:

- `test_find_court_ambiguous_name_no_other_signal_raises` — two rows share a name with no extractable type prefix; assert `CourtNotFoundError` (not `MultipleObjectsReturned`).
- `test_find_court_ambiguous_name_resolves_via_unique_code` — ambiguous name + a unique `court_code` passed → code lookup wins (confirms the fix doesn't regress the common ambiguous-but-resolvable case).

## Test plan

- [x] `DJANGO_CONFIGURATION=TestConfiguration manage.py test oldp.apps.cases.tests.test_case_creation_api.CourtResolverTestCase` — 21/21 ✓
- [x] `DJANGO_CONFIGURATION=TestConfiguration manage.py test oldp.apps.cases` — 281/282 ✓ (one failure in `test_extract_law_refs_1` pre-exists on master, unrelated to this change)
- [x] `make lint` — clean
- [ ] CI runs to verify on a fresh environment

🤖 Generated with [Claude Code](https://claude.com/claude-code)