### PR TITLE
perf(references): stream dump_references via .iterator(); drop order_by("pk")

### DIFF
--- a/oldp/apps/references/management/commands/dump_references.py
+++ b/oldp/apps/references/management/commands/dump_references.py
@@ -166,21 +166,24 @@ class Command(BaseCommand):
         :param writer: CSV writer
         :return:
         """
-        # Use paginator to not load all rows at once in memory
-        paginator = Paginator(items, self.chunk_size)
-        for page in range(1, paginator.num_pages + 1):
-            logger.debug("Page %i / %i" % (page, paginator.num_pages))
+        # Stream via server-side cursor — avoids OFFSET pagination, which
+        # over a join with ``Using temporary; Using filesort`` re-evaluates
+        # the whole sort per page (O(N^2) cumulative).
+        count = 0
+        for item in items.iterator(chunk_size=self.chunk_size):
+            row = {}
+            for field in writer.fieldnames:  # Fieldnames are validated beforehand
+                try:
+                    row[field] = self.available_fields[field](item)
+                except (AttributeError, KeyError):
+                    # If field does not exist (e.g. from type is wrong), just return null
+                    row[field] = None
 
-            for item in paginator.page(page).object_list:  # type: ReferenceFromContent
-                row = {}
-                for field in writer.fieldnames:  # Fieldnames are validated beforehand
-                    try:
-                        row[field] = self.available_fields[field](item)
-                    except (AttributeError, KeyError):
-                        # If field does not exist (e.g. from type is wrong), just return null
-                        row[field] = None
-
-                writer.writerow(rowdict=row)
+            writer.writerow(rowdict=row)
+            count += 1
+            if count % self.chunk_size == 0:
+                logger.debug("Rows written: %i", count)
+        logger.debug("Rows written (final): %i", count)
 
     def handle_nodes_gephi(self, writer, limit=0, case_fields=[]):
         # Source
@@ -405,7 +408,6 @@ class Command(BaseCommand):
                         marker__referenced_by__review_status=REVIEW_STATUS_ACCEPTED,
                     )
                     .filter(target_accepted)
-                    .order_by("pk")
                 )
 
                 # Limit
@@ -430,7 +432,6 @@ class Command(BaseCommand):
                         marker__referenced_by__review_status=REVIEW_STATUS_ACCEPTED,
                     )
                     .filter(target_accepted)
-                    .order_by("pk")
                 )
 
                 # Limit


### PR DESCRIPTION
## Summary

`dump_references` stalled when invoked against the prod DB without producing any output. Root cause from EXPLAIN:

- Each `Paginator(chunk_size).page(N)` issues `LIMIT N OFFSET (N-1)*chunk_size` against a join whose plan contains `Using temporary; Using filesort` (the `.order_by("pk")` is on the M2M table but that table is not the leftmost in the join — see plan analysis below).
- Every page re-evaluates the full sort, giving O(N²) cumulative cost on the result size. On prod (~16M markers, ~424k accepted cases, ~176k accepted laws) this never finishes.

This PR:

- Replaces the `Paginator` loop in `handle_items` with `items.iterator(chunk_size=...)`. Server-side cursor, streams in constant memory, no OFFSET pagination, no upfront `COUNT(*)` for `num_pages`.
- Drops `.order_by("pk")` from both `from_case_items` and `from_law_items`. The CSV output order isn't part of any contract; removing the ordering eliminates `Using temporary; Using filesort` entirely.

Gephi paths are left unchanged — their `order_by("pk"|"law_id"|"case_id").values(...).distinct()` carries `DISTINCT` semantics where order can matter.

## Query plan (from prod EXPLAIN, before this PR)

| Variant | Lead table | Top-level cost |
|---|---|---|
| Current (with `order_by("pk")`) | `courts_court` ALL (1067 rows) | 90,280 |
| Without court joins | `references_casereferencemarker` ALL (15.98M rows) | 102,535 |

Both variants do `Using temporary; Using filesort` over the joined result — that's the load-bearing problem, not the leading-table choice.

## Test plan

- [x] Existing smoke tests in `oldp/apps/references/tests/test_commands.py` still pass (no API change)
- [x] Manual smoke against prod: `make dump-references DUMP_NAME=smoke-test` (from deployment repo) completes within minutes and produces a CSV with the expected columns
- [x] Inspect a few rows: `from_slug`, `to_slug`, `from_law_book_slug`, `to_law_book_slug` populated, all `review_status` = accepted

🤖 Generated with [Claude Code](https://claude.com/claude-code)