### PR TITLE
fix(references): OOM-proof dump_references via .defer() + chunk_size; fix court.jurisdiction typo + N+1

### DIFF
--- a/oldp/apps/references/management/commands/dump_references.py
+++ b/oldp/apps/references/management/commands/dump_references.py
@@ -59,13 +59,23 @@ class Command(BaseCommand):
     """
 
     help = "Export reference data as CSV"
-    # Smaller chunk size because the select_related chain on this command
-    # pulls fat text columns (Case.content/raw/abstract, Law.content) for
-    # every row. With chunk_size=1000 the per-batch hydration exceeded the
-    # container's available memory on prod (OOM-killed; oom_kill counter
-    # incremented in cgroup memory.events). 100 keeps per-batch memory
-    # within hundreds of MB.
     chunk_size = 100
+
+    # Fat text columns deferred from select_related joins below. None of
+    # the lambdas in ``available_fields`` read these — the API serialiser
+    # does, but this command writes CSV from explicit field accessors.
+    # Pulling Case.content/raw/abstract and Law.content for every row of
+    # a multi-million-row join exhausted prod memory (OOM-killed) before
+    # this list existed.
+    CASE_FAT_FIELDS = (
+        "content",
+        "raw",
+        "abstract",
+        "preceding_cases_raw",
+        "following_cases_raw",
+    )
+    LAW_FAT_FIELDS = ("content", "footnotes")
+    LAWBOOK_FAT_FIELDS = ("changelog", "footnotes", "sections")
     default_fields = [
         "from_id",
         "from_type",
@@ -114,7 +124,7 @@ class Command(BaseCommand):
         "to_law_title": lambda item: item.reference.law.title,
         "to_case_court_name": lambda item: item.reference.case.court.name,
         "to_case_court_jurisdiction": lambda item: (
-            item.reference.case.court.jurisidction
+            item.reference.case.court.jurisdiction
         ),
         "to_case_court_level_of_appeal": lambda item: (
             item.reference.case.court.level_of_appeal
@@ -398,6 +408,26 @@ class Command(BaseCommand):
                     reference__law__review_status=REVIEW_STATUS_ACCEPTED
                 ) | Q(reference__case__review_status=REVIEW_STATUS_ACCEPTED)
 
+                # Defer paths grouped by side. The two querysets share the
+                # `reference__case` / `reference__law` / `reference__law__book`
+                # joins; only the `marker__referenced_by` model differs
+                # (Case for from-case, Law for from-law).
+                defer_target = [
+                    *(f"reference__case__{f}" for f in self.CASE_FAT_FIELDS),
+                    *(f"reference__law__{f}" for f in self.LAW_FAT_FIELDS),
+                    *(f"reference__law__book__{f}" for f in self.LAWBOOK_FAT_FIELDS),
+                ]
+                defer_from_case = [
+                    *(f"marker__referenced_by__{f}" for f in self.CASE_FAT_FIELDS),
+                ]
+                defer_from_law = [
+                    *(f"marker__referenced_by__{f}" for f in self.LAW_FAT_FIELDS),
+                    *(
+                        f"marker__referenced_by__book__{f}"
+                        for f in self.LAWBOOK_FAT_FIELDS
+                    ),
+                ]
+
                 # Case -> Law + Case
                 from_case_items = (
                     ReferenceFromCase.objects.select_related(
@@ -408,7 +438,10 @@ class Command(BaseCommand):
                         "marker",
                         "marker__referenced_by",
                         "marker__referenced_by__court",
+                        "marker__referenced_by__court__city",
+                        "marker__referenced_by__court__state",
                     )
+                    .defer(*defer_target, *defer_from_case)
                     .exclude(reference__law__isnull=True, reference__case__isnull=True)
                     .filter(
                         marker__referenced_by__review_status=REVIEW_STATUS_ACCEPTED,
@@ -433,6 +466,7 @@ class Command(BaseCommand):
                         "marker__referenced_by",
                         "marker__referenced_by__book",
                     )
+                    .defer(*defer_target, *defer_from_law)
                     .exclude(reference__law__isnull=True, reference__case__isnull=True)
                     .filter(
                         marker__referenced_by__review_status=REVIEW_STATUS_ACCEPTED,

--- a/oldp/apps/references/management/commands/dump_references.py
+++ b/oldp/apps/references/management/commands/dump_references.py
@@ -59,7 +59,13 @@ class Command(BaseCommand):
     """
 
     help = "Export reference data as CSV"
-    chunk_size = 1000
+    # Smaller chunk size because the select_related chain on this command
+    # pulls fat text columns (Case.content/raw/abstract, Law.content) for
+    # every row. With chunk_size=1000 the per-batch hydration exceeded the
+    # container's available memory on prod (OOM-killed; oom_kill counter
+    # incremented in cgroup memory.events). 100 keeps per-batch memory
+    # within hundreds of MB.
+    chunk_size = 100
     default_fields = [
         "from_id",
         "from_type",


### PR DESCRIPTION
## Summary

Multiple improvements to `dump_references` discovered while investigating the prod OOM that happened with `make dump-references --fields all`:

### 1. `.defer()` the fat text columns (main fix)

The `select_related` chain pulls `Case.content/raw/abstract/preceding_cases_raw/following_cases_raw`, `Law.content/footnotes`, and `LawBook.changelog/footnotes/sections` — large `TextField` columns that **no lambda in `available_fields` reads**. With the streaming iterator from #213 hydrating 1000 rows per batch, those columns blew per-batch memory past the container limit on prod (`oom_kill` counter incremented in cgroup `memory.events`; SIGKILL at ~110 s of runtime).

This PR defers them in both `from_case_items` and `from_law_items` querysets. The deferred set is declared as class constants (`CASE_FAT_FIELDS`, `LAW_FAT_FIELDS`, `LAWBOOK_FAT_FIELDS`) so the two querysets share definitions.

### 2. Smaller `chunk_size` (defence-in-depth)

Lowered `chunk_size: 1000 → 100`. With `.defer()` in place the OOM should be impossible anyway; this is belt-and-suspenders.

### 3. Fix `court.jurisidction` typo

Line 117 read `item.reference.case.court.jurisidction` (note the transposition). The `try/except AttributeError` in `handle_items` swallowed the error, so the `to_case_court_jurisdiction` column always emitted `null`. Now spelled correctly.

### 4. Add `court__city` / `court__state` to `select_related`

`from_case_court_city` and `from_case_court_state` dereference `court.city.name` / `court.state.name`. Those FKs were not in `select_related`, so the lambda triggered an extra `SELECT` for each row when `--fields all` was requested — N+1 over hundreds of thousands of rows.

## Test plan

- [ ] Existing smoke tests in `oldp/apps/references/tests/test_commands.py` still pass
- [ ] Manual: `make dump-references` on prod completes without OOM and produces a non-empty `references.csv`
- [ ] `to_case_court_jurisdiction` column has non-null values for rows where the target case has a court with a jurisdiction set

🤖 Generated with [Claude Code](https://claude.com/claude-code)