### PR TITLE
perf+feat(homepage): stream dump_api_data via .iterator(); atomic writes, error handling, snapshot_started_at

### DIFF
--- a/oldp/apps/homepage/management/commands/dump_api_data.py
+++ b/oldp/apps/homepage/management/commands/dump_api_data.py
@@ -18,10 +18,11 @@ class Command(BaseCommand):
     """Export data to gzipped JSONL using API serializers.
 
     Each registered API resource is written to ``<plural>.jsonl.gz``. A
-    ``manifest.json`` file is written alongside, recording the snapshot
-    date, OLDP version, applied filters, and per-file row counts so that
-    downstream consumers (e.g. ``oldp-toolkit``, citation-matching
-    benchmarks) can pin against a specific snapshot.
+    ``manifest.json`` file is written alongside, recording snapshot start
+    and completion timestamps, OLDP version, applied filters, and
+    per-file row + error counts so that downstream consumers
+    (e.g. ``oldp-toolkit``, citation-matching benchmarks) can pin
+    against a specific snapshot.
 
     Records with ``review_status`` are always filtered to ``"accepted"``
     — non-accepted records must never appear in published artifacts.
@@ -30,8 +31,14 @@ class Command(BaseCommand):
     associated ``Law`` rows) is dumped. Pass ``--include-lawbook-revisions``
     to export every historical revision instead.
 
-    Pagination iterates rows in ascending primary-key order so the same
-    prod state yields a byte-stable dump across runs.
+    Iteration is in ascending primary-key order so the same prod state
+    yields a byte-stable dump across runs.
+
+    Each output file is written to a sibling ``.partial`` path and
+    atomically renamed on success; a killed dump therefore never
+    publishes a half-written ``*.jsonl.gz`` or ``manifest.json``.
+    Per-row serialisation errors are logged and skipped (counted in
+    ``error_count``) rather than aborting the whole dump.
 
     Usage::
 
@@ -76,6 +83,7 @@ class Command(BaseCommand):
         )
 
     def handle(self, *args, **opts):
+        started_at = datetime.now(timezone.utc).isoformat()
         dir_path = os.path.join(settings.WORKING_DIR, opts["output"])
 
         if os.path.exists(dir_path):
@@ -105,6 +113,9 @@ class Command(BaseCommand):
 
             file_name = plural + ".jsonl.gz"
             file_path = os.path.join(dir_path, file_name)
+            # Write to a sibling ``.partial`` first and rename on success
+            # so a killed dump never publishes a half-written *.jsonl.gz.
+            partial_path = file_path + ".partial"
             view_set = view_set_cls()
             serializer_cls = view_set.get_serializer_class()
             qs = view_set.get_queryset()
@@ -125,7 +136,7 @@ class Command(BaseCommand):
             if opts["limit"] > 0:
                 qs = qs[: opts["limit"]]
 
-            logger.debug("Writing to %s", file_path)
+            logger.info("Writing to %s", file_path)
 
             # Stream via server-side cursor. Paginator + LIMIT/OFFSET on
             # tables like Case (424k rows accepted) becomes O(N^2) cumulative
@@ -133,18 +144,42 @@ class Command(BaseCommand):
             # by PK over a single table, ``.iterator(chunk_size=...)`` uses
             # the PK index directly and runs in O(N).
             row_count = 0
-            with gzip.open(file_path, "wt", encoding="utf-8") as fh:
+            error_count = 0
+            with gzip.open(partial_path, "wt", encoding="utf-8") as fh:
                 for item in qs.iterator(chunk_size=self.chunk_size):
-                    data = serializer_cls(instance=item).data
-                    fh.write(json.dumps(data, ensure_ascii=False) + "\n")
-                    row_count += 1
-                    if row_count % self.chunk_size == 0:
-                        logger.debug("%s - rows written: %i", plural, row_count)
-            logger.debug("%s - rows written (final): %i", plural, row_count)
+                    try:
+                        data = serializer_cls(instance=item).data
+                        fh.write(json.dumps(data, ensure_ascii=False) + "\n")
+                        row_count += 1
+                    except Exception:
+                        error_count += 1
+                        logger.exception(
+                            "Failed to serialize %s pk=%s — skipping",
+                            plural,
+                            getattr(item, "pk", "?"),
+                        )
+                    if (row_count + error_count) % self.chunk_size == 0:
+                        logger.info(
+                            "%s - rows written: %i (errors: %i)",
+                            plural,
+                            row_count,
+                            error_count,
+                        )
+            os.replace(partial_path, file_path)
+            logger.info(
+                "%s - rows written (final): %i (errors: %i)",
+                plural,
+                row_count,
+                error_count,
+            )
 
-            files_manifest[file_name] = {"row_count": row_count}
+            files_manifest[file_name] = {
+                "row_count": row_count,
+                "error_count": error_count,
+            }
 
         manifest = {
+            "snapshot_started_at": started_at,
             "snapshot_date": datetime.now(timezone.utc).isoformat(),
             "oldp_version": get_version(),
             "filters": {
@@ -154,7 +189,9 @@ class Command(BaseCommand):
             "files": files_manifest,
         }
         manifest_path = os.path.join(dir_path, "manifest.json")
-        with open(manifest_path, "w", encoding="utf-8") as fh:
+        manifest_partial = manifest_path + ".partial"
+        with open(manifest_partial, "w", encoding="utf-8") as fh:
             json.dump(manifest, fh, indent=2, ensure_ascii=False)
+        os.replace(manifest_partial, manifest_path)
 
         logger.info("Done")

--- a/oldp/apps/homepage/management/commands/dump_api_data.py
+++ b/oldp/apps/homepage/management/commands/dump_api_data.py
@@ -7,7 +7,6 @@ from datetime import datetime, timezone
 
 from django.conf import settings
 from django.core.management import BaseCommand
-from django.core.paginator import Paginator
 
 from oldp.api.urls import router
 from oldp.utils.version import get_version
@@ -128,21 +127,20 @@ class Command(BaseCommand):
 
             logger.debug("Writing to %s", file_path)
 
+            # Stream via server-side cursor. Paginator + LIMIT/OFFSET on
+            # tables like Case (424k rows accepted) becomes O(N^2) cumulative
+            # because each page re-scans the prefix being skipped; ordered
+            # by PK over a single table, ``.iterator(chunk_size=...)`` uses
+            # the PK index directly and runs in O(N).
             row_count = 0
             with gzip.open(file_path, "wt", encoding="utf-8") as fh:
-                paginator = Paginator(qs, self.chunk_size)
-                for page in range(1, paginator.num_pages + 1):
-                    logger.debug(
-                        "%s - total %i - page %i / %i",
-                        plural,
-                        paginator.count,
-                        page,
-                        paginator.num_pages,
-                    )
-                    for item in paginator.page(page).object_list:
-                        data = serializer_cls(instance=item).data
-                        fh.write(json.dumps(data, ensure_ascii=False) + "\n")
-                        row_count += 1
+                for item in qs.iterator(chunk_size=self.chunk_size):
+                    data = serializer_cls(instance=item).data
+                    fh.write(json.dumps(data, ensure_ascii=False) + "\n")
+                    row_count += 1
+                    if row_count % self.chunk_size == 0:
+                        logger.debug("%s - rows written: %i", plural, row_count)
+            logger.debug("%s - rows written (final): %i", plural, row_count)
 
             files_manifest[file_name] = {"row_count": row_count}
 


### PR DESCRIPTION
## Summary

Two layered changes to `dump_api_data`:

### 1. Streaming via `.iterator()` (perf)

`Paginator(qs, chunk_size).page(N)` issues `LIMIT N OFFSET (N-1)*chunk_size` once per page. On the Case queryset (~424k accepted rows) each subsequent page costs more than the last because MariaDB has to traverse the skipped prefix even when the PK index is used.

Observed on prod (v0.10.5): page-rate stabilises at **~3.5 minutes per 1000-row page**, extrapolating to **>25 hours** for the full cases table and growing as OFFSET deepens. Killed at page 21/424.

Replaced with `qs.iterator(chunk_size=...)`. With `.order_by("pk")` over a single table the server-side cursor uses the PK index directly and runs in O(N) total.

### 2. Durability + observability (feat)

- **Atomic file writes.** Each `*.jsonl.gz` (and `manifest.json`) is written to a sibling `.partial` and `os.replace()`'d into place on success. Killed dumps never publish half-written artifacts.
- **Per-row exception handling.** A single un-serialisable row no longer aborts the whole dump — pk + traceback are logged via `logger.exception`, and the row is skipped. Failures are counted per resource and surfaced as `error_count` in the manifest.
- **`snapshot_started_at`** added to the manifest. `snapshot_date` remains the completion timestamp; the new field records the start so multi-hour dumps can be pinned to a clearly bounded DB state.
- **Progress logging at INFO** (was DEBUG). The dump is now visible at the default log level.

## What stays

- `chunk_size = 1000` unchanged. `dump_api_data` uses the viewset's `get_queryset()` which already does `.only(...)` + `.select_related(...)`, so per-row hydration cost is bounded — no fat-field problem like #214.
- `.order_by("pk")` kept — preserves the byte-stability contract documented in the docstring.
- Skip list (`users`, `citations`, `references`) unchanged.

## Test plan

- [ ] Existing tests pass (`dump_api_data` has no dedicated test; smoke is the snapshot it produces)
- [ ] Manual: `make dump-api-data` on prod — runs to completion in <1h, produces `*.jsonl.gz` and `manifest.json` with both timestamps and `error_count: 0` (or non-zero with corresponding log entries if any row is bad).
- [ ] Kill mid-run: verify no `.partial` is renamed; previous run's artifacts remain intact

🤖 Generated with [Claude Code](https://claude.com/claude-code)