### PR TITLE
fix(mcp): refex-backed citation parsing + 7 audit follow-ups

### DIFF
--- a/oldp/apps/cases/mcp.py
+++ b/oldp/apps/cases/mcp.py
@@ -8,8 +8,10 @@ from django.db.models.functions import TruncMonth, TruncYear
 from mcp_server import MCPToolset
 
 from oldp.apps.cases.models import Case
-from oldp.apps.courts.mcp import resolve_jurisdiction
+from oldp.apps.courts.mcp import JURISDICTION_ALIASES, resolve_jurisdiction
+from oldp.apps.courts.models import Court, State
 from oldp.apps.mcp.monitoring import log_tool_call
+from oldp.apps.mcp.utils import clamp_limit, with_limit_meta
 
 logger = logging.getLogger("oldp.mcp.tools")
 
@@ -64,9 +66,12 @@ class CaseTools(MCPToolset):
             start_date: Filter cases from this date (YYYY-MM-DD).
             end_date: Filter cases up to this date (YYYY-MM-DD).
             decision_type: Filter by decision type (e.g. "Urteil", "Beschluss").
-            limit: Maximum results (default 10, max 50).
+            limit: Maximum results (default 10, max 50). Values above 50 are
+                clamped; the response then includes ``limit_clamped: true``
+                and the original ``requested_limit``.
         """
-        limit = min(max(1, limit), 50)
+        requested_limit = limit
+        limit, limit_was_clamped = clamp_limit(limit, maximum=50)
 
         try:
             from oldp.apps.search.api import SearchQueryBuilder
@@ -101,14 +106,20 @@ class CaseTools(MCPToolset):
             # total once.
             sliced = list(sqs[:limit])
             if not sliced:
-                return {
-                    "results": [],
-                    "total": 0,
-                    "message": (
-                        f"No cases found for query '{query}'. "
-                        "Try different search terms or broader filters."
-                    ),
-                }
+                return with_limit_meta(
+                    {
+                        "results": [],
+                        "total": 0,
+                        "message": (
+                            f"No cases found for query '{query}'. "
+                            "Try different search terms or broader filters."
+                        ),
+                    },
+                    requested=requested_limit,
+                    applied=limit,
+                    was_clamped=limit_was_clamped,
+                    maximum=50,
+                )
 
             results = []
             for result in sliced:
@@ -120,7 +131,13 @@ class CaseTools(MCPToolset):
 
                 results.append(
                     {
-                        "id": result.pk,
+                        # result.pk is a string in Elasticsearch hits; cast
+                        # to int so downstream MCP/REST consumers can feed
+                        # this id straight back into get_case(case_id=…) /
+                        # get_case_references(case_id=…), which both
+                        # declare int. The Django Case PK is the source of
+                        # truth — the ES string is just transport.
+                        "id": int(result.pk),
                         "slug": getattr(result, "slug", ""),
                         "date": str(getattr(result, "date", "")),
                         "court": getattr(result, "court", ""),
@@ -134,7 +151,13 @@ class CaseTools(MCPToolset):
                 )
 
             total = sqs.count()
-            return {"total": total, "results": results}
+            return with_limit_meta(
+                {"total": total, "results": results},
+                requested=requested_limit,
+                applied=limit,
+                was_clamped=limit_was_clamped,
+                maximum=50,
+            )
 
         except Exception as exc:
             logger.warning("mcp_tool_search_failed tool=search_cases error=%s", exc)
@@ -172,10 +195,13 @@ class CaseTools(MCPToolset):
             file_number: Exact file number (Aktenzeichen).
             ecli: Exact ECLI identifier.
             decision_type: Decision type (e.g. "Urteil", "Beschluss").
-            limit: Maximum results (default 20, max 50).
+            limit: Maximum results (default 20, max 50). Values above 50
+                are clamped; the response then includes
+                ``limit_clamped: true`` and the original ``requested_limit``.
             offset: Skip first N results for pagination (default 0).
         """
-        limit = min(max(1, limit), 50)
+        requested_limit = limit
+        limit, limit_was_clamped = clamp_limit(limit, maximum=50)
         offset = max(0, offset)
 
         qs = exclude_future_dated_cases(
@@ -217,14 +243,20 @@ class CaseTools(MCPToolset):
         page = sliced[:limit]
 
         if not page:
-            return {
-                "results": [],
-                "total": 0,
-                "message": (
-                    "No cases found matching your filters. "
-                    "Try broadening your search criteria."
-                ),
-            }
+            return with_limit_meta(
+                {
+                    "results": [],
+                    "total": 0,
+                    "message": (
+                        "No cases found matching your filters. "
+                        "Try broadening your search criteria."
+                    ),
+                },
+                requested=requested_limit,
+                applied=limit,
+                was_clamped=limit_was_clamped,
+                maximum=50,
+            )
 
         if has_more:
             # More pages remain; caller may want to know total for pagination UI.
@@ -247,12 +279,18 @@ class CaseTools(MCPToolset):
                 }
             )
 
-        return {
-            "total": total,
-            "offset": offset,
-            "limit": limit,
-            "results": results,
-        }
+        return with_limit_meta(
+            {
+                "total": total,
+                "offset": offset,
+                "limit": limit,
+                "results": results,
+            },
+            requested=requested_limit,
+            applied=limit,
+            was_clamped=limit_was_clamped,
+            maximum=50,
+        )
 
     @log_tool_call
     def get_case(
@@ -342,7 +380,48 @@ class CaseTools(MCPToolset):
             date_after: Count cases from this date (YYYY-MM-DD, default: 1 year ago).
             date_before: Count cases up to this date (YYYY-MM-DD, default: today).
             group_by: Time grouping: "month" (default) or "year".
+
+        Returns an ``{"error": ...}`` payload (instead of silently zero
+        results) when an unknown court_id, state, jurisdiction, group_by,
+        or malformed date is supplied — the previous behavior swallowed
+        bad inputs as ``total: 0`` and was the dangerous failure mode
+        called out in the MCP audit.
         """
+        if group_by not in ("month", "year"):
+            return {"error": (f"Invalid group_by '{group_by}'. Use 'month' or 'year'.")}
+
+        if (
+            court_id
+            and not Court.objects.filter(id=court_id, review_status="accepted").exists()
+        ):
+            return {"error": f"Court with ID {court_id} not found."}
+
+        if (
+            state
+            and not State.objects.filter(
+                Q(name__icontains=state) | Q(slug__iexact=state)
+            ).exists()
+        ):
+            return {
+                "error": (
+                    f"State '{state}' not found. Use list_courts to discover "
+                    "available states."
+                )
+            }
+
+        if jurisdiction:
+            resolved_jurisdiction = resolve_jurisdiction(jurisdiction)
+            known_jurisdictions = set(JURISDICTION_ALIASES.values())
+            if resolved_jurisdiction not in known_jurisdictions:
+                return {
+                    "error": (
+                        f"Unknown jurisdiction '{jurisdiction}'. "
+                        f"Accepted English shortcuts: "
+                        f"{sorted(JURISDICTION_ALIASES.keys())}; "
+                        f"or German values: {sorted(known_jurisdictions)}."
+                    )
+                }
+
         qs = exclude_future_dated_cases(
             Case.objects.filter(review_status="accepted", date__isnull=False)
         )
@@ -355,9 +434,7 @@ class CaseTools(MCPToolset):
                 | Q(court__state__slug__iexact=state)
             )
         if jurisdiction:
-            qs = qs.filter(
-                court__jurisdiction__icontains=resolve_jurisdiction(jurisdiction)
-            )
+            qs = qs.filter(court__jurisdiction__icontains=resolved_jurisdiction)
 
         # Default date range: last year
         today = datetime.date.today()
@@ -365,7 +442,11 @@ class CaseTools(MCPToolset):
             try:
                 qs = qs.filter(date__gte=datetime.date.fromisoformat(date_after))
             except ValueError:
-                pass
+                return {
+                    "error": (
+                        f"Invalid date_after format: '{date_after}'. Use YYYY-MM-DD."
+                    )
+                }
         else:
             qs = qs.filter(date__gte=today - datetime.timedelta(days=365))
 
@@ -373,7 +454,11 @@ class CaseTools(MCPToolset):
             try:
                 qs = qs.filter(date__lte=datetime.date.fromisoformat(date_before))
             except ValueError:
-                pass
+                return {
+                    "error": (
+                        f"Invalid date_before format: '{date_before}'. Use YYYY-MM-DD."
+                    )
+                }
 
         # Compute the time-series aggregation once and derive the total from
         # its buckets (avoiding a separate COUNT(*) scan on the same filtered

--- a/oldp/apps/cases/serializers.py
+++ b/oldp/apps/cases/serializers.py
@@ -51,6 +51,17 @@ class CaseListSerializer(ReviewStatusFieldMixin, serializers.ModelSerializer):
 class CaseSearchSerializer(SearchResultSerializer):
     """Serializer for case search results."""
 
+    # Haystack stores doc ids as strings (ES doc-id convention), so
+    # ``result.pk`` arrives here as a string. Cast to int — the Case
+    # Django PK is the source of truth and downstream consumers
+    # (e.g. the MCP ``get_case`` tool, generic clients that follow up
+    # with ``/api/cases/<id>/``) want an int. Mirrors the same fix on
+    # ``LawSearchSerializer`` and the MCP ``search_cases`` tool.
+    id = serializers.SerializerMethodField()
+
+    def get_id(self, obj):
+        return int(obj.pk)
+
     class Meta:
         fields = [
             "slug",

--- a/oldp/apps/courts/mcp.py
+++ b/oldp/apps/courts/mcp.py
@@ -5,12 +5,26 @@ from mcp_server import MCPToolset
 
 from oldp.apps.courts.models import Court
 from oldp.apps.mcp.monitoring import log_tool_call
+from oldp.apps.mcp.utils import clamp_limit, with_limit_meta
+
+# Conditional aggregate that mirrors the explicit accepted-only filter
+# used by get_court(). list_courts() previously counted *all* related
+# cases (review_status="accepted" or otherwise), which drifted from the
+# accepted-only count get_court() reports for the same row — same court
+# returned different totals from the two tools.
+_ACCEPTED_CASE_COUNT = Count("case", filter=Q(case__review_status="accepted"))
 
 # English → German aliases for the `jurisdiction` and `level_of_appeal`
 # Court fields. The DB stores German values exclusively, but the docstrings
 # of the MCP tools advertise short English names ("labor", "federal", …)
 # because they are easier for non-German-speaking LLM clients. Resolving
 # the alias before the DB query lets either form work.
+#
+# Note: there is no "Patentgerichtsbarkeit" entry — the Bundespatentgericht
+# is constitutionally part of the Ordentliche Gerichtsbarkeit (§ 96 Abs. 1
+# GG, §§ 65 ff. PatG), so a separate alias would point at a category that
+# doesn't exist in the DB. To find patent-court cases, query
+# ``court_type="BPatG"`` or filter on ``court_slug="bpatg"`` directly.
 JURISDICTION_ALIASES = {
     "ordinary": "Ordentliche Gerichtsbarkeit",
     "administrative": "Verwaltungsgerichtsbarkeit",
@@ -18,7 +32,6 @@ JURISDICTION_ALIASES = {
     "social": "Sozialgerichtsbarkeit",
     "fiscal": "Finanzgerichtsbarkeit",
     "constitutional": "Verfassungsgerichtsbarkeit",
-    "patent": "Patentgerichtsbarkeit",
 }
 
 LEVEL_OF_APPEAL_ALIASES = {
@@ -71,15 +84,22 @@ class CourtTools(MCPToolset):
             state: Filter by state name or slug (e.g. "Berlin", "bayern").
             jurisdiction: Filter by jurisdiction. Accepts the English
                 shortcuts "ordinary", "administrative", "labor", "social",
-                "fiscal", "constitutional", "patent" or the stored
-                German values ("Arbeitsgerichtsbarkeit", …).
+                "fiscal", "constitutional" or the stored German values
+                ("Arbeitsgerichtsbarkeit", …). The Bundespatentgericht
+                (BPatG) belongs to ``ordinary``; there is no separate
+                patent-jurisdiction category — filter on
+                ``court_type="BPatG"`` if you specifically want patent
+                cases.
             level_of_appeal: Filter by court level. Accepts the English
                 shortcuts "local", "regional", "high", "federal" or the
                 stored German values ("Amtsgericht", …).
             search: Search court names and aliases.
-            limit: Maximum results to return (default 50, max 100).
+            limit: Maximum results to return (default 50, max 100). Values
+                above 100 are clamped; the response then includes
+                ``limit_clamped: true`` and the original ``requested_limit``.
         """
-        limit = min(max(1, limit), 100)
+        requested_limit = limit
+        limit, limit_was_clamped = clamp_limit(limit, maximum=100)
         qs = Court.objects.filter(review_status="accepted").select_related(
             "state", "city"
         )
@@ -105,7 +125,7 @@ class CourtTools(MCPToolset):
         # COUNT(*), then fetch the ordered+annotated slice for results.
         total = qs.count()
 
-        annotated = qs.annotate(case_count=Count("case")).order_by("-case_count")
+        annotated = qs.annotate(case_count=_ACCEPTED_CASE_COUNT).order_by("-case_count")
 
         results = []
         for court in annotated[:limit]:
@@ -125,13 +145,25 @@ class CourtTools(MCPToolset):
             )
 
         if not results:
-            return {
-                "results": [],
-                "total": 0,
-                "message": "No courts found matching your filters. Try broadening your search.",
-            }
+            return with_limit_meta(
+                {
+                    "results": [],
+                    "total": 0,
+                    "message": "No courts found matching your filters. Try broadening your search.",
+                },
+                requested=requested_limit,
+                applied=limit,
+                was_clamped=limit_was_clamped,
+                maximum=100,
+            )
 
-        return {"total": total, "results": results}
+        return with_limit_meta(
+            {"total": total, "results": results},
+            requested=requested_limit,
+            applied=limit,
+            was_clamped=limit_was_clamped,
+            maximum=100,
+        )
 
     @log_tool_call
     def get_court(

--- a/oldp/apps/laws/mcp.py
+++ b/oldp/apps/laws/mcp.py
@@ -7,6 +7,7 @@ from mcp_server import MCPToolset
 
 from oldp.apps.laws.models import Law, LawBook
 from oldp.apps.mcp.monitoring import log_tool_call
+from oldp.apps.mcp.utils import clamp_limit, with_limit_meta
 
 logger = logging.getLogger("oldp.mcp.tools")
 
@@ -30,9 +31,12 @@ class LawTools(MCPToolset):
         Args:
             latest_only: Only show latest revisions (default True).
             search: Search book codes and titles.
-            limit: Maximum results (default 50, max 200).
+            limit: Maximum results (default 50, max 200). Values above 200
+                are clamped; the response then includes
+                ``limit_clamped: true`` and the original ``requested_limit``.
         """
-        limit = min(max(1, limit), 200)
+        requested_limit = limit
+        limit, limit_was_clamped = clamp_limit(limit, maximum=200)
         qs = LawBook.objects.filter(review_status="accepted")
 
         if latest_only:
@@ -49,7 +53,14 @@ class LawTools(MCPToolset):
         # queryset is only used for the limited result slice.
         total = qs.count()
 
-        annotated = qs.annotate(section_count=Count("law")).order_by("-section_count")
+        # Count only accepted Law rows so the section_count matches what
+        # get_law_section / search_laws will actually return (they both
+        # filter on review_status="accepted"). Without this filter the
+        # section_count would advertise pending / rejected rows that
+        # callers cannot retrieve.
+        annotated = qs.annotate(
+            section_count=Count("law", filter=Q(law__review_status="accepted"))
+        ).order_by("-section_count")
 
         results = []
         for book in annotated[:limit]:
@@ -66,13 +77,25 @@ class LawTools(MCPToolset):
             )
 
         if not results:
-            return {
-                "results": [],
-                "total": 0,
-                "message": "No law books found. Try broadening your search.",
-            }
+            return with_limit_meta(
+                {
+                    "results": [],
+                    "total": 0,
+                    "message": "No law books found. Try broadening your search.",
+                },
+                requested=requested_limit,
+                applied=limit,
+                was_clamped=limit_was_clamped,
+                maximum=200,
+            )
 
-        return {"total": total, "results": results}
+        return with_limit_meta(
+            {"total": total, "results": results},
+            requested=requested_limit,
+            applied=limit,
+            was_clamped=limit_was_clamped,
+            maximum=200,
+        )
 
     @log_tool_call
     def get_law_section(
@@ -89,7 +112,14 @@ class LawTools(MCPToolset):
 
         Args:
             book_code: Law book code (e.g. "BGB", "StGB", "GG").
-            section: Section identifier (e.g. "823", "1", "242").
+            section: Section identifier. Accept bare numbers ("823",
+                "1", "242") or fully-qualified strings ("§ 823",
+                "Art. 14", "Artikel 1") — the lookup tries the bare
+                form first and then the common prefixed variants. The
+                ``section`` field on the response is whatever the DB
+                stores, which differs by book convention: BGB / StGB /
+                ZPO etc. store ``§ N`` (e.g. ``"§ 823"``), the
+                Grundgesetz stores ``Art N`` (e.g. ``"Art 1"``).
             law_id: Direct law database ID (alternative to book_code+section).
         """
         law = None
@@ -168,9 +198,12 @@ class LawTools(MCPToolset):
         Args:
             query: Search query text (supports Lucene syntax).
             book_code: Optional filter by law book code (e.g. "BGB").
-            limit: Maximum results (default 10, max 50).
+            limit: Maximum results (default 10, max 50). Values above 50 are
+                clamped; the response then includes ``limit_clamped: true``
+                and the original ``requested_limit``.
         """
-        limit = min(max(1, limit), 50)
+        requested_limit = limit
+        limit, limit_was_clamped = clamp_limit(limit, maximum=50)
 
         try:
             from oldp.apps.search.api import SearchQueryBuilder
@@ -204,7 +237,12 @@ class LawTools(MCPToolset):
 
                 results.append(
                     {
-                        "id": result.pk,
+                        # result.pk is a string from ES; cast to int so
+                        # downstream MCP/REST consumers can pass this id
+                        # back into get_law_section(law_id=…) /
+                        # get_cases_for_law(law_id=…) without a type
+                        # error. Django Law PK is the source of truth.
+                        "id": int(result.pk),
                         "title": getattr(result, "title", ""),
                         "book_code": getattr(result, "book_code", ""),
                         "slug": getattr(result, "slug", ""),
@@ -213,15 +251,27 @@ class LawTools(MCPToolset):
                 )
 
             if not results:
-                return {
-                    "results": [],
-                    "total": 0,
-                    "message": f"No laws found for query '{query}'. Try different search terms.",
-                }
+                return with_limit_meta(
+                    {
+                        "results": [],
+                        "total": 0,
+                        "message": f"No laws found for query '{query}'. Try different search terms.",
+                    },
+                    requested=requested_limit,
+                    applied=limit,
+                    was_clamped=limit_was_clamped,
+                    maximum=50,
+                )
 
             # Single ES count round-trip, only if we got results.
             total = sqs.count()
-            return {"total": total, "results": results}
+            return with_limit_meta(
+                {"total": total, "results": results},
+                requested=requested_limit,
+                applied=limit,
+                was_clamped=limit_was_clamped,
+                maximum=50,
+            )
 
         except Exception as exc:
             logger.warning("mcp_tool_search_failed tool=search_laws error=%s", exc)

--- a/oldp/apps/mcp/utils.py
+++ b/oldp/apps/mcp/utils.py
@@ -1,0 +1,44 @@
+"""Helpers shared across MCP tool modules.
+
+Functions here are stateless utilities that several toolsets need —
+limit clamping, response shaping, etc. Per-toolset logic stays in the
+respective ``apps/<name>/mcp.py``.
+"""
+
+from __future__ import annotations
+
+
+def clamp_limit(requested: int, *, maximum: int, minimum: int = 1) -> tuple[int, bool]:
+    """Clamp ``requested`` to ``[minimum, maximum]``.
+
+    Returns ``(clamped_value, was_clamped)``. Callers should surface
+    ``was_clamped`` (and the original requested value) in their
+    response so consumers can tell that the page they got back is
+    smaller than the page they asked for — silent clamping was the UX
+    issue this helper was introduced to fix.
+
+    Negative or zero values clamp up to ``minimum``; values above
+    ``maximum`` clamp down. The "was_clamped" flag is true in either
+    case so the caller can include a hint in the payload.
+    """
+    if requested < minimum:
+        return minimum, True
+    if requested > maximum:
+        return maximum, True
+    return requested, False
+
+
+def with_limit_meta(
+    payload: dict, *, requested: int, applied: int, was_clamped: bool, maximum: int
+) -> dict:
+    """Annotate a response dict with limit-clamp metadata when relevant.
+
+    Only adds ``requested_limit`` + ``limit_clamped`` + ``max_limit``
+    when the caller's input was actually rewritten — un-clamped calls
+    stay free of bookkeeping noise. Mutates and returns ``payload``.
+    """
+    if was_clamped:
+        payload["requested_limit"] = requested
+        payload["limit_clamped"] = True
+        payload["max_limit"] = maximum
+    return payload

--- a/oldp/apps/references/mcp.py
+++ b/oldp/apps/references/mcp.py
@@ -13,6 +13,7 @@ from mcp_server import MCPToolset
 from oldp.apps.cases.models import Case
 from oldp.apps.laws.models import Law
 from oldp.apps.mcp.monitoring import log_tool_call
+from oldp.apps.mcp.utils import clamp_limit, with_limit_meta
 from oldp.apps.references.services import (
     case_forward_references,
     citing_cases_for_case,
@@ -81,9 +82,12 @@ class ReferenceTools(MCPToolset):
 
         Args:
             case_id: The database ID of the cited case.
-            limit: Maximum results (default 20, max 50).
+            limit: Maximum results (default 20, max 50). Values above 50 are
+                clamped; the response then includes ``limit_clamped: true``
+                and the original ``requested_limit``.
         """
-        limit = min(max(1, limit), 50)
+        requested_limit = limit
+        limit, limit_was_clamped = clamp_limit(limit, maximum=50)
 
         case = Case.objects.filter(id=case_id, review_status="accepted").first()
         if not case:
@@ -98,12 +102,18 @@ class ReferenceTools(MCPToolset):
         else:
             total = qs.count()
 
-        return {
-            "cited_case_id": case_id,
-            "cited_case_file_number": case.file_number,
-            "total_citing_cases": total,
-            "results": [serialize_case_summary(c) for c in sliced],
-        }
+        return with_limit_meta(
+            {
+                "cited_case_id": case_id,
+                "cited_case_file_number": case.file_number,
+                "total_citing_cases": total,
+                "results": [serialize_case_summary(c) for c in sliced],
+            },
+            requested=requested_limit,
+            applied=limit,
+            was_clamped=limit_was_clamped,
+            maximum=50,
+        )
 
     @log_tool_call
     def get_cases_for_law(
@@ -123,9 +133,12 @@ class ReferenceTools(MCPToolset):
             book_code: Law book code (e.g. "BGB", "StGB").
             section: Section identifier (e.g. "823").
             law_id: Direct law database ID (alternative to book_code+section).
-            limit: Maximum results (default 20, max 50).
+            limit: Maximum results (default 20, max 50). Values above 50 are
+                clamped; the response then includes ``limit_clamped: true``
+                and the original ``requested_limit``.
         """
-        limit = min(max(1, limit), 50)
+        requested_limit = limit
+        limit, limit_was_clamped = clamp_limit(limit, maximum=50)
 
         primary: Law | None = None
         law_ids: list[int] = []
@@ -169,10 +182,16 @@ class ReferenceTools(MCPToolset):
         else:
             total = qs.count()
 
-        return {
-            "law_id": primary.id,
-            "book_code": primary.book.code if primary.book_id else "",
-            "section": primary.section,
-            "total_citing_cases": total,
-            "results": [serialize_case_summary(c) for c in sliced],
-        }
+        return with_limit_meta(
+            {
+                "law_id": primary.id,
+                "book_code": primary.book.code if primary.book_id else "",
+                "section": primary.section,
+                "total_citing_cases": total,
+                "results": [serialize_case_summary(c) for c in sliced],
+            },
+            requested=requested_limit,
+            applied=limit,
+            was_clamped=limit_was_clamped,
+            maximum=50,
+        )

--- a/oldp/apps/references/services/citation_lookup.py
+++ b/oldp/apps/references/services/citation_lookup.py
@@ -4,6 +4,14 @@ Determines whether a free-form German citation string (Aktenzeichen,
 ECLI, or paragraph reference) corresponds to a row in the local DB.
 Mirrors the shape of the legacy ``ReferenceTools.validate_citation``
 MCP tool — moved here so REST endpoints can reuse the same logic.
+
+Law-reference parsing is delegated to the ``refex`` package
+(legal-reference-extraction), which is the same library used by the
+production reference-extraction pipeline. This means
+``validate_citation`` accepts every citation shape that the extractor
+itself recognises (``§ 823 BGB``, ``§ 823 Abs. 1 Satz 2 BGB``,
+``Artikel 1 GG``, ``Art. 14 GG``, ``Art. 15 DSGVO``, …) without
+re-implementing — and drifting from — that grammar here.
 """
 
 from __future__ import annotations
@@ -13,11 +21,15 @@ import re
 from oldp.apps.cases.models import Case
 from oldp.apps.laws.models import Law, LawBook
 
-# Regex patterns for German citation formats.
+# ECLI has a fixed shape (`ECLI:DE:BGH:2023:…`); refex doesn't parse
+# them yet, so a tiny regex is still the cleanest detector. Everything
+# else (paragraph/article references, Aktenzeichen) goes through refex.
 ECLI_PATTERN = re.compile(r"^ECLI:\w{2}:\w+:\d{4}:[\w.]+$", re.IGNORECASE)
-PARAGRAPH_PATTERN = re.compile(
-    r"(?:§|Art\.?)\s*([\d\w]+(?:\s*[a-z])?)\s+(\w+)", re.IGNORECASE
-)
+
+# Lightweight detector for the law_reference vs file_number split in
+# parse_citation_type. We don't extract from this — we just need to
+# decide which validator to run. refex performs the actual parsing.
+_LAW_REFERENCE_HINT = re.compile(r"(?:§|Artikel|Art\.?)\s", re.IGNORECASE)
 
 
 def section_variants(section: str) -> list[str]:
@@ -47,7 +59,7 @@ def parse_citation_type(citation: str) -> str:
     citation = citation.strip()
     if ECLI_PATTERN.match(citation):
         return "ecli"
-    if PARAGRAPH_PATTERN.match(citation):
+    if _LAW_REFERENCE_HINT.match(citation):
         return "law_reference"
     return "file_number"
 
@@ -93,17 +105,48 @@ def _validate_ecli(citation: str) -> dict:
     }
 
 
+def _extract_law_citation(citation: str):
+    """Parse a free-form law reference with refex.
+
+    Returns the first ``LawCitation`` (refex result) or ``None`` if
+    nothing parses. We import inside the function so a refex import
+    failure doesn't break process startup — validation is opt-in per
+    request, not a module-load dependency.
+
+    The extractor's recognised-book set is the union of refex's
+    bundled list (~1950 codes shipped with the library) and the codes
+    actually present in the local DB. The DB additions let test books
+    and any OLDP-specific codes resolve without monkeypatching refex;
+    the bundle keeps coverage for codes that haven't been ingested
+    locally yet.
+    """
+    from refex.document import make_document
+    from refex.engines.regex import RegexLawExtractor
+    from refex.orchestrator import CitationExtractor
+
+    engine = RegexLawExtractor()
+    db_codes = LawBook.objects.values_list("code", flat=True).distinct()
+    engine.law_book_codes = list(set(engine.law_book_codes) | set(db_codes))
+    extractor = CitationExtractor(engines=[engine])
+    result = extractor.extract(make_document(citation, fmt="text"))
+    return next(iter(result.citations), None)
+
+
 def _validate_law_reference(citation: str) -> dict:
-    match = PARAGRAPH_PATTERN.match(citation)
-    if not match:
+    parsed = _extract_law_citation(citation)
+    if parsed is None:
         return {
             "found": False,
             "type": "unknown",
             "message": f"Could not parse law reference: '{citation}'.",
         }
 
-    section = match.group(1).strip()
-    book_code = match.group(2).strip()
+    # refex stores the law book code in lower-case (e.g. ``bgb``) and
+    # the section number as a bare string ("823", "16a"). Resolve via
+    # case-insensitive matching to be tolerant of either form.
+    book_code = parsed.book or ""
+    section = parsed.number or ""
+
     book = LawBook.objects.filter(
         code__iexact=book_code,
         latest=True,
@@ -117,11 +160,11 @@ def _validate_law_reference(citation: str) -> dict:
             "message": f"Law book '{book_code}' not found.",
         }
 
-    # Try the user-provided form, then the common German prefixed
-    # variants ("§ N", "Artikel N", ...). Stop at the first variant
-    # that yields hits and only accept exact matches; an icontains
-    # fallback would produce spurious siblings (e.g. "§ 1823" for
-    # "§ 823 BGB", "§ 132" for "§ 32 StGB").
+    # Try refex's bare-number form first (the most common storage), then
+    # the common prefixed variants ("§ N", "Artikel N", …). Stop at the
+    # first variant that yields hits and only accept exact matches; an
+    # icontains fallback would surface spurious siblings (e.g. "§ 1823"
+    # for "§ 823", "§ 132" for "§ 32").
     laws: list[Law] = []
     for variant in section_variants(section):
         laws = list(
@@ -145,7 +188,7 @@ def _validate_law_reference(citation: str) -> dict:
         "type": "law",
         "citation_type": "law_reference",
         "message": (
-            f"Section '{section}' not found in {book_code}. "
+            f"Section '{section}' not found in {book.code}. "
             "Use list_law_books to check available books."
         ),
     }
@@ -181,32 +224,55 @@ def validate_citation(citation: str, citation_type: str = "auto") -> dict:
 
     Args:
         citation: The citation string (e.g. ``"VI ZR 123/22"``,
-            ``"ECLI:DE:BGH:2023:..."``, ``"§ 823 BGB"``).
+            ``"ECLI:DE:BGH:2023:..."``, ``"§ 823 BGB"``,
+            ``"Artikel 1 GG"``).
         citation_type: ``"auto"`` (default), ``"file_number"``,
             ``"ecli"``, or ``"law_reference"``.
 
     Returns:
         A dict with ``found``, ``type``, and either ``matches`` (list of
         record dicts) or ``message`` (human-readable not-found text).
-        Mirrors the shape of the MCP ``validate_citation`` tool.
+        When the caller passes an explicit ``citation_type`` that
+        conflicts with what auto-detection would have chosen, the
+        response also includes ``input_type_mismatch`` describing the
+        conflict so confused inputs aren't silently mis-routed.
     """
     citation = (citation or "").strip()
     if not citation:
         return {"error": "Citation cannot be empty."}
 
+    detected_type = parse_citation_type(citation)
+    mismatch_warning: dict | None = None
     if citation_type == "auto":
-        citation_type = parse_citation_type(citation)
+        citation_type = detected_type
+    elif citation_type != detected_type:
+        # Honour the caller's explicit override, but include a warning
+        # so confused inputs don't silently return cryptic "not found"
+        # messages. Common case: passing citation_type="ecli" for an
+        # Aktenzeichen.
+        mismatch_warning = {
+            "requested_type": citation_type,
+            "detected_type": detected_type,
+            "message": (
+                f"Input looks like '{detected_type}' but citation_type="
+                f"'{citation_type}' was forced; results may be empty."
+            ),
+        }
 
     if citation_type == "ecli":
-        return _validate_ecli(citation)
-    if citation_type == "law_reference":
-        return _validate_law_reference(citation)
-    return _validate_file_number(citation)
+        result = _validate_ecli(citation)
+    elif citation_type == "law_reference":
+        result = _validate_law_reference(citation)
+    else:
+        result = _validate_file_number(citation)
+
+    if mismatch_warning is not None:
+        result["input_type_mismatch"] = mismatch_warning
+    return result
 
 
 __all__ = [
     "ECLI_PATTERN",
-    "PARAGRAPH_PATTERN",
     "parse_citation_type",
     "section_variants",
     "validate_citation",

--- a/oldp/apps/search/api.py
+++ b/oldp/apps/search/api.py
@@ -154,17 +154,40 @@ class SearchResultSerializer(serializers.Serializer):
 
         Replaces 'text' field with 'snippets' list by default.
         If return_text=1, includes both 'text' and 'snippets'.
+
+        SerializerMethodField is honoured (its bound method runs against
+        the SearchResult instance) so subclasses can transform fields —
+        notably ``id`` from haystack's "laws.law.123" identifier string
+        down to the bare integer Django PK. The naive
+        ``getattr(instance, field_name)`` path used previously skipped
+        DRF's field-resolution logic and returned the raw haystack
+        identifier instead of whatever the method computed. Other
+        explicitly-declared field types fall back to
+        ``Field.to_representation`` after pulling the value via
+        ``get_attribute``.
         """
         result = {}
         return_text = self._should_return_text()
 
-        for field_name in self.fields:
+        for field_name, field in self.fields.items():
             if field_name == "text":
                 if return_text:
                     result["text"] = getattr(instance, "text", None)
                 continue
+            if isinstance(field, serializers.SerializerMethodField):
+                method = getattr(self, field.method_name or f"get_{field_name}")
+                result[field_name] = method(instance)
+                continue
+            # The auto-added CharField path (see __init__) plus anything
+            # a subclass declares as a plain Field. We bypass
+            # ``field.get_attribute`` because SearchResult attribute
+            # access is dotted (no dict / nested traversal), and use
+            # ``field.to_representation`` to honour the field's own
+            # coercion (e.g. IntegerField casting).
             value = getattr(instance, field_name, None)
-            result[field_name] = value
+            result[field_name] = (
+                field.to_representation(value) if value is not None else None
+            )
 
         result["snippets"] = _build_snippets(instance)
         return result


### PR DESCRIPTION
## Summary

Follow-ups from a 2026-05-27 beta audit against the production MCP
server (and `oldp-local`). The audit posed as a legal-researcher
testing every tool end-to-end;

Each numbered fix below maps to an issue in that report.

### Citation / reference parsing

- **#1** `validate_citation` was hand-rolling a regex that couldn't
  parse the most common German forms — `"Artikel 1 GG"` got captured
  as `book="1", section="ikel"`, and `"§ 823 Abs. 1 BGB"` got
  captured as `book="Abs"`. Replaced with the **refex extractor that
  the production reference-extraction pipeline already uses**, so
  validator and extractor stay in sync. Local `LawBook.code`s are
  merged into refex's bundled list at request time so test books
  resolve too.
- **#8** `validate_citation(citation, citation_type=…)` now warns via
  `input_type_mismatch` when the caller's explicit type override
  contradicts auto-detection (common case: passing `"ecli"` for an
  Aktenzeichen and getting a cryptic "ECLI 'X' not found").

### Search results

- **#2** Cast `result.pk` to `int` in `search_cases` / `search_laws`
  so chained calls into `get_case(case_id=int)` /
  `get_case_references` accept the value. While tracing, found a
  deeper bug: `SearchResultSerializer.to_representation` was
  bypassing DRF's field machinery, so `LawSearchSerializer.get_id`
  never fired and the REST law search was leaking the raw haystack
  identifier (`"laws.law.21727"`) as the id. Fixed at the base
  serializer (now invokes `SerializerMethodField`) and added the
  same `int(obj.pk)` override to `CaseSearchSerializer`.

### Limits

- **#5** New `oldp/apps/mcp/utils.py` with `clamp_limit` +
  `with_limit_meta` helpers. Every clamping site now surfaces
  `limit_clamped` / `requested_limit` / `max_limit` in the response
  when the caller's `limit` was rewritten. Previously a `limit=999`
  silently returned 50 results with no indication. REST endpoints
  already report this via DRF pagination metadata.

### Validation

- **#6** `get_case_statistics` used to swallow unknown
  `court_id` / `state` / `jurisdiction` / `group_by` / malformed
  dates as `total: 0` (the worst failure mode — looks like "no data"
  when input was just typo'd). Each invalid input now returns an
  explicit error payload listing the valid options.
- **#7** `list_courts.case_count` counted all related cases
  regardless of `review_status` while `get_court.case_count` filtered
  to accepted, so the same court reported different totals from the
  two tools. Switched to a conditional aggregate and applied the
  same treatment to `list_law_books.section_count` for symmetry with
  `get_law_section`.

### Docs

- **#10** `get_law_section` docstring now explains that the
  `section` field shape differs by book convention (`§ N` for
  BGB-style codes, `Art N` for the Grundgesetz) and that the
  input-side accepts both bare numbers and prefixed forms.

### Patent pseudo-jurisdiction removed

`JURISDICTION_ALIASES["patent"] = "Patentgerichtsbarkeit"` advertised
a German jurisdiction category that **doesn't exist** in the
Gerichtsverfassung. The Bundespatentgericht is constitutionally part
of the Ordentliche Gerichtsbarkeit (§ 96 Abs. 1 GG, §§ 65 ff. PatG),
which is why prod showed BPatG as `Ordentliche Gerichtsbarkeit`.
Removing the alias means `get_case_statistics(jurisdiction="patent")`
now hits the explicit-error path from #6 instead of silently
returning zero, and the docstring points patent-case lookups at
`court_type="BPatG"`.

## Out of band

**#3 federal-court jurisdiction backfill** — handled by a separate
`dev-deployment/scripts/backfill_court_jurisdiction.py` (committed in
the `dev-deployment` repo) which PATCHes the federal high courts
via the public REST API. Already dry-run + applied against prod:

```
PATCH BGH      -> Ordentliche Gerichtsbarkeit (HTTP 200)
PATCH BFH      -> Finanzgerichtsbarkeit (HTTP 200)
Updated 2 court(s).
```

Other federal courts (BVerwG, BVerfG, BAG, BSG, BPatG) were already
correctly tagged.

**#4 local ES** — started via `podman compose up -d search` from
the repo root; only relevant for local dev.

## Deferred

See `dev-deployment/mcp-issues.md` for #9 (HTML entity decoding in
law content), #11 (Unknown-court data attribution), #12 (local
fixture noise), #13 (EuGH French content), and minor cosmetic items.

## Test plan

- [x] `make lint` clean
- [x] `make test` — 1127 tests pass
- [x] End-to-end MCP smoke against `oldp-local` after container
  restart + ES reindex, covering all 8 fixes:
  - `validate_citation` parses `"Artikel 1 GG"`, `"§ 823 Abs. 1 BGB"`,
    `"Art. 15 DSGVO"` correctly (pre-fix: all failed).
  - `search_cases(limit=999)` response includes
    `requested_limit: 999, limit_clamped: true, max_limit: 50`.
  - `get_case_statistics(state="notarealstate")` →
    `{"error": "State 'notarealstate' not found. …"}`.
  - `get_case_statistics(group_by="decade")` → explicit error.
  - `list_courts(court_type="BGH").case_count` matches
    `get_court(code="BGH").case_count` (both 9 on local).
  - `validate_citation("VI ZR 277/24", citation_type="ecli")` →
    response includes `input_type_mismatch` payload.
  - `search_cases` / `search_laws` return `id` as int (`455826`,
    `20061`) — previously strings.
  - `get_case_statistics(jurisdiction="patent")` errors with the
    valid-shortcut list no longer including `"patent"`.
