### PR TITLE
fix(cases): scope case detail cache by review_status to prevent leak of pending cases

### DIFF
--- a/oldp/apps/cases/cache.py
+++ b/oldp/apps/cases/cache.py
@@ -1,0 +1,27 @@
+"""Cache helpers for case detail view.
+
+The case detail view (`case_view`) caches three artefacts under slug-only
+keys. To keep `review_status` filtering honest, the cache must:
+
+- skip writes for non-accepted cases (so a staff/creator preview cannot
+  poison the cache for anonymous visitors), and
+- be invalidated whenever a case's `review_status` changes (so an
+  accepted-then-demoted case stops being served).
+"""
+
+from django.core.cache import cache
+
+CASE_DATA_KEY = "case_data_%s"
+CASE_PUBLIC_MARKERS_KEY = "case_public_markers_%s"
+CASE_CONTENT_ANON_KEY = "case_content_anon_%s"
+
+
+def invalidate_case_cache(case_slug: str) -> None:
+    """Drop every slug-keyed cache entry for ``case_slug``."""
+    cache.delete_many(
+        [
+            CASE_DATA_KEY % case_slug,
+            CASE_PUBLIC_MARKERS_KEY % case_slug,
+            CASE_CONTENT_ANON_KEY % case_slug,
+        ]
+    )

--- a/oldp/apps/cases/signals.py
+++ b/oldp/apps/cases/signals.py
@@ -1,6 +1,7 @@
-from django.db.models.signals import pre_save
+from django.db.models.signals import post_save, pre_save
 from django.dispatch import receiver
 
+from oldp.apps.cases.cache import invalidate_case_cache
 from oldp.apps.cases.models import Case
 
 
@@ -8,3 +9,17 @@ from oldp.apps.cases.models import Case
 def pre_save_case(sender, instance: Case, *args, **kwargs):
     if instance.slug is None or instance.slug == "":
         instance.set_slug()
+
+
+@receiver(post_save, sender=Case)
+def invalidate_case_detail_cache(sender, instance: Case, **kwargs):
+    """Drop slug-keyed view-cache entries whenever a case is saved.
+
+    The case detail view caches under slug-only keys. Any save (especially
+    a `review_status` transition) might change what should be served, so
+    we invalidate unconditionally — cheaper than tracking the prior value
+    and correct under demotion (accepted -> pending) as well as
+    promotion.
+    """
+    if instance.slug:
+        invalidate_case_cache(instance.slug)

--- a/oldp/apps/cases/tests/test_view_review_status.py
+++ b/oldp/apps/cases/tests/test_view_review_status.py
@@ -164,3 +164,88 @@ class CaseViewVisibilityTestCase(TestCase):
         self.client.force_login(self.staff)
         res = self.client.get(reverse("cases:case", args=("pend-99999",)))
         self.assertEqual(res.status_code, 200)
+
+
+@override_settings(
+    CACHES={
+        "default": {
+            "BACKEND": "django.core.cache.backends.locmem.LocMemCache",
+            "LOCATION": "case-detail-cache-tests",
+        }
+    }
+)
+class CaseDetailCacheReviewStatusTestCase(TestCase):
+    """Regression: the case detail view caches under slug-only keys.
+
+    Without per-role scoping, a staff/creator preview would poison the
+    cache and serve pending/rejected cases to anonymous visitors.
+    """
+
+    fixtures = [
+        "locations/countries.json",
+        "locations/states.json",
+        "locations/cities.json",
+        "courts/courts.json",
+    ]
+
+    @classmethod
+    def setUpTestData(cls):
+        cls.staff = User.objects.create_user(
+            username="staff", password="pass", is_staff=True
+        )
+        court = Court.objects.exclude(pk=Court.DEFAULT_ID).first()
+        cls.accepted = Case.objects.create(
+            court=court,
+            file_number="ACC-CACHE",
+            slug="acc-cache",
+            date=date(2026, 1, 1),
+            content="<p>accepted body</p>",
+            review_status="accepted",
+        )
+        cls.pending = Case.objects.create(
+            court=court,
+            file_number="PEND-CACHE",
+            slug="pend-cache",
+            date=date(2026, 1, 2),
+            content="<p>pending body</p>",
+            review_status="pending",
+        )
+
+    def setUp(self):
+        from django.core.cache import cache
+
+        cache.clear()
+
+    def test_pending_case_not_leaked_to_anon_after_staff_warm(self):
+        self.client.force_login(self.staff)
+        staff_res = self.client.get(reverse("cases:case", args=("pend-cache",)))
+        self.assertEqual(staff_res.status_code, 200)
+
+        self.client.logout()
+        anon_res = self.client.get(reverse("cases:case", args=("pend-cache",)))
+        self.assertEqual(anon_res.status_code, 404)
+
+    def test_no_cache_entries_written_for_pending(self):
+        from django.core.cache import cache
+
+        from oldp.apps.cases.cache import (
+            CASE_CONTENT_ANON_KEY,
+            CASE_DATA_KEY,
+            CASE_PUBLIC_MARKERS_KEY,
+        )
+
+        self.client.force_login(self.staff)
+        self.client.get(reverse("cases:case", args=("pend-cache",)))
+
+        for tpl in (CASE_DATA_KEY, CASE_PUBLIC_MARKERS_KEY, CASE_CONTENT_ANON_KEY):
+            self.assertIsNone(cache.get(tpl % "pend-cache"), tpl)
+
+    def test_accepted_case_invalidated_on_demotion(self):
+        warm = self.client.get(reverse("cases:case", args=("acc-cache",)))
+        self.assertEqual(warm.status_code, 200)
+
+        self.accepted.review_status = "pending"
+        self.accepted.save()
+
+        anon_res = self.client.get(reverse("cases:case", args=("acc-cache",)))
+        self.assertEqual(anon_res.status_code, 404)

--- a/oldp/apps/cases/views.py
+++ b/oldp/apps/cases/views.py
@@ -7,6 +7,11 @@ from django.shortcuts import get_object_or_404, redirect, render
 from django.urls import reverse
 from django.utils.translation import gettext_lazy as _
 
+from oldp.apps.cases.cache import (
+    CASE_CONTENT_ANON_KEY,
+    CASE_DATA_KEY,
+    CASE_PUBLIC_MARKERS_KEY,
+)
 from oldp.apps.cases.filters import CaseFilter
 from oldp.apps.cases.models import Case
 from oldp.apps.lib.apps import Counter
@@ -73,8 +78,12 @@ def case_view(request, case_slug):
     Layer 1: Shared case data (Case object + reference markers) cached per case slug.
     Layer 2: User-specific annotation data fetched fresh per request.
     """
-    # Layer 1: Shared case data (one cache entry per case)
-    case_cache_key = "case_data_%s" % case_slug
+    # Layer 1: Shared case data (one cache entry per case).
+    # The cache key is slug-only, so anything we store here is served to
+    # every requester regardless of role. Only accepted cases are publicly
+    # visible, so we cache only those — otherwise a staff/creator preview
+    # would poison the cache and expose pending/rejected cases to anon.
+    case_cache_key = CASE_DATA_KEY % case_slug
     cached = cache.get(case_cache_key)
     if cached is None:
         qs = Case.get_queryset(request).select_related("court", "source")
@@ -85,7 +94,8 @@ def case_view(request, case_slug):
         item.references = list(item.get_references())
         related_cases = item.get_related()
         cached = (item, ref_markers, related_cases)
-        cache.set(case_cache_key, cached, settings.CACHE_TTL)
+        if item.review_status == "accepted":
+            cache.set(case_cache_key, cached, settings.CACHE_TTL)
     else:
         item, ref_markers, related_cases = cached
 
@@ -97,17 +107,21 @@ def case_view(request, case_slug):
         content = insert_markers(item.content or "", ref_markers + user_markers)
     else:
         # Anonymous users only see public markers, so this can be shared.
-        public_markers_cache_key = "case_public_markers_%s" % case_slug
+        # Skip writes for non-accepted cases for the same reason Layer 1 does.
+        can_cache_anon = item.review_status == "accepted"
+        public_markers_cache_key = CASE_PUBLIC_MARKERS_KEY % case_slug
         user_markers = cache.get(public_markers_cache_key)
         if user_markers is None:
             user_markers = list(item.get_markers(request))
-            cache.set(public_markers_cache_key, user_markers, settings.CACHE_TTL)
+            if can_cache_anon:
+                cache.set(public_markers_cache_key, user_markers, settings.CACHE_TTL)
 
-        content_cache_key = "case_content_anon_%s" % case_slug
+        content_cache_key = CASE_CONTENT_ANON_KEY % case_slug
         content = cache.get(content_cache_key)
         if content is None:
             content = insert_markers(item.content or "", ref_markers + user_markers)
-            cache.set(content_cache_key, content, settings.CACHE_TTL)
+            if can_cache_anon:
+                cache.set(content_cache_key, content, settings.CACHE_TTL)
 
     if request.user.is_staff:
         marker_labels = (


### PR DESCRIPTION
## Summary

The case detail view (`oldp/apps/cases/views.py:case_view`) caches the case object + ref markers + related cases under a **slug-only** key (`case_data_<slug>`). `Case.get_queryset(request)` correctly filters by `review_status` for anonymous users, but that filter only runs on a cache **miss**. If a staff user or the case creator (e.g. an ingestor preview) views a pending case first, the cache stores the pending object and serves it to every subsequent anonymous visitor for the TTL window.

Concrete impact: anonymous users reaching the URL of a `pending` case could see the full case page once any privileged user had warmed the cache.

## Changes

- Move the three slug-keyed cache key templates into `oldp/apps/cases/cache.py` and add `invalidate_case_cache(slug)`.
- In `case_view`, skip `cache.set` for Layer 1 + the anon Layer 2 entries when `item.review_status != "accepted"`. Staff/creator previews are still served correctly (from the DB) but no longer poison the public cache.
- Add a `post_save` signal that calls `invalidate_case_cache(slug)` on every Case save, so `accepted ↔ pending ↔ rejected` transitions cleanly drop any stale entries.
- Add regression tests (`CaseDetailCacheReviewStatusTestCase`) under a real `LocMemCache` backend. The existing review_status tests used `DummyCache`, so this bug was invisible to them.

## Test plan

- [x] `make lint`
- [x] New tests pass: `test_pending_case_not_leaked_to_anon_after_staff_warm`, `test_no_cache_entries_written_for_pending`, `test_accepted_case_invalidated_on_demotion`
- [x] Full cases-app test suite passes (1 pre-existing refex failure on master only)
- [x] Full project suite: only pre-existing refex/MCP failures remain (same on master, unrelated)