### PR TITLE
Update CI workflow to use Python 3.12 only

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -45,7 +45,7 @@ jobs:
     strategy:
       fail-fast: true
       matrix:
-        python-version: ['3.11', '3.12']
+        python-version: ['3.12']  # deprecated: '3.11'
 
     steps:
       - name: Checkout code


### PR DESCRIPTION
Removed Python version 3.11 from CI matrix.