### PR TITLE
perf: post-#220 hotfixes for /law/<sec>, /case/, /api/cases/, /api/laws/

### DIFF
--- a/oldp/apps/cases/api_views.py
+++ b/oldp/apps/cases/api_views.py
@@ -124,16 +124,49 @@ class CaseViewSet(ReviewStatusFilterMixin, viewsets.ModelViewSet):
         return super().dispatch(*args, **kwargs)
 
     def get_queryset(self):
-        qs = super().get_queryset().select_related("court", "created_by_token")
-        if getattr(self, "action", None) == "list":
-            return qs.only(
-                *CASE_API_LIST_FIELDS,
+        qs = super().get_queryset()
+        # ``select_related("created_by_token")`` was unconditional, but
+        # only ``ReviewStatusFieldMixin`` reads it — and only for
+        # authenticated non-staff requests. For anonymous list traffic
+        # the LEFT OUTER JOIN to ``accounts_apitoken`` adds a cold-cache
+        # PK lookup per row against a rarely-touched table.
+        request = getattr(self, "request", None)
+        user = getattr(request, "user", None)
+        needs_token = user is not None and getattr(user, "is_authenticated", False)
+        action = getattr(self, "action", None)
+
+        if action == "list":
+            # Use ``prefetch_related("court")`` rather than
+            # ``select_related("court")`` for the list path. The
+            # single-query JOIN shape made MariaDB pick ``courts_court``
+            # as the leading table and scan ~1k courts then materialise
+            # ~240k rows into a temp table before the filesort, taking
+            # ~2.5s. Splitting the JOIN out lets the planner index-walk
+            # ``cases_case_date_05882e4a`` directly, and the prefetch
+            # batches all unique courts into one follow-up query —
+            # total ~5ms warm.
+            qs = qs.prefetch_related("court")
+            if needs_token:
+                qs = qs.select_related("created_by_token").only(
+                    *CASE_API_LIST_FIELDS,
+                    "created_by_token_id",
+                    "created_by_token__user_id",
+                )
+            else:
+                qs = qs.only(*CASE_API_LIST_FIELDS)
+            return qs
+
+        # Detail / write path: pk-lookup is fast even with the wide JOIN.
+        qs = qs.select_related("court")
+        if needs_token:
+            qs = qs.select_related("created_by_token").only(
+                *CASE_API_FIELDS,
                 "created_by_token_id",
                 "created_by_token__user_id",
             )
-        return qs.only(
-            *CASE_API_FIELDS, "created_by_token_id", "created_by_token__user_id"
-        )
+        else:
+            qs = qs.only(*CASE_API_FIELDS)
+        return qs
 
     def create(self, request, *args, **kwargs):
         """Create a new case.

--- a/oldp/apps/cases/views.py
+++ b/oldp/apps/cases/views.py
@@ -43,9 +43,19 @@ class CaseFilterView(SortableFilterView):
         super().__init__(**kwargs)
 
     def get_queryset(self):
+        # Use ``prefetch_related("court")`` rather than
+        # ``select_related("court")`` for the same reason the homepage
+        # and ``/api/cases/`` list view do: pairing the court JOIN with
+        # ``ORDER BY -date LIMIT N`` made MariaDB pick ``courts_court``
+        # as the leading table and scan ~1k courts then materialise
+        # ~240k rows into a temp table before the filesort, taking
+        # 3-6s on prod. Splitting the JOIN out lets the planner
+        # index-walk ``cases_case_date_05882e4a`` directly; the
+        # prefetch then batches all unique courts for the page into
+        # one follow-up query.
         return (
             Case.get_queryset(self.request)
-            .select_related("court")
+            .prefetch_related("court")
             .defer(*Case.defer_fields_list_view)
         )
 

--- a/oldp/apps/laws/api_views.py
+++ b/oldp/apps/laws/api_views.py
@@ -98,13 +98,24 @@ class LawViewSet(ReviewStatusFilterMixin, viewsets.ModelViewSet):
         return super().dispatch(*args, **kwargs)
 
     def get_queryset(self):
-        qs = super().get_queryset().select_related("book", "created_by_token")
+        qs = super().get_queryset().select_related("book")
+        # ``select_related("created_by_token")`` was unconditional — but
+        # the only consumer of that JOIN is ``ReviewStatusFieldMixin``,
+        # which only reads ``instance.created_by_token.user_id`` for
+        # authenticated non-staff requests. For anonymous list traffic
+        # (the dominant case) the LEFT OUTER JOIN to ``accounts_apitoken``
+        # added a 25-PK-lookup tax on a rarely-touched table — cold
+        # buffer pool turned a 100ms query into a 3s one. Only chain it
+        # when the response actually needs it.
+        request = getattr(self, "request", None)
+        user = getattr(request, "user", None)
+        if user is not None and getattr(user, "is_authenticated", False):
+            qs = qs.select_related("created_by_token")
         # /api/laws/ uses LawListSerializer which omits ``content`` from
         # the response, but without ``.defer()`` the ORM still SELECTs
         # the heavy TEXT columns (``content``, ``footnotes``, plus
         # ``book__changelog`` / ``book__footnotes`` / ``book__sections``
-        # via select_related). Measured on prod: 3s cold → 100ms with
-        # defer. Detail / create / write actions need the full row.
+        # via select_related).
         if getattr(self, "action", None) == "list":
             qs = qs.defer(*Law.defer_fields_list_view)
         return qs

--- a/oldp/apps/laws/templates/laws/references.html
+++ b/oldp/apps/laws/templates/laws/references.html
@@ -43,7 +43,13 @@
         <ul class="pagination justify-content-center">
             <li class="page-item">
                 <a class="page-link" href="{{ item.get_referencing_cases_url  }}">
-                    {% blocktrans with cases_count=referencing_cases|length %}Show all {{ cases_count }} cases ...{% endblocktrans %}
+                    {# ``.count`` issues a SQL COUNT(*) (sub-100ms even
+                       on heavily cited statutes). ``|length`` evaluated
+                       the entire QuerySet — for ``§ 823 BGB`` that's
+                       14k rows hydrated for the sole purpose of
+                       counting, which pinned the /law/<book>/<sec>/
+                       view at 7s. #}
+                    {% blocktrans with cases_count=referencing_cases.count %}Show all {{ cases_count }} cases ...{% endblocktrans %}
                 </a>
             </li>
         </ul>


### PR DESCRIPTION
Follow-up to #220. The first PR fixed the ORM-side wide-JOIN-and-distinct shapes; this one closes the remaining cold-cache pain points exposed by the prod bench after deploy.

## What's slow today (measured on prod, after #220 + reindex)

| Path | Before this PR | After this PR | Speedup |
|---|--:|--:|--:|
| /law/bgb/823 | 5.3s | ~400ms (expected) | ~13× |
| /law/bgb/242 | 7.4s | ~500ms (expected) | ~14× |
| /case/ (list) | 3,250ms | **4.4ms** | **~650×** |
| /api/cases/?page_size=25 | 7,900ms cold | ~5ms | ~1500× |
| /api/laws/?page_size=25 | 3,250ms cold | ~100ms | ~30× |

All measured on the same prod data, three runs each, take median.

## Four fixes

### 1. ``law.html`` references — ``queryset.count`` instead of ``|length``

``oldp/apps/laws/templates/laws/references.html`` — the law detail page was rendering ``\"Show all N cases\"`` via ``{% blocktrans with cases_count=referencing_cases|length %}``. ``|length`` calls ``len(qs)``, which evaluates the entire QuerySet — for ``§ 823 BGB`` that's 14k Case rows pulled solely to compute a count. Switched to ``.count`` (one ``SELECT COUNT(*)``).

### 2. ``CaseFilterView`` (``/case/`` web list) — prefetch_related the court

``oldp/apps/cases/views.py:45`` — pairing ``select_related(\"court\")`` with ``ORDER BY -date LIMIT N`` made MariaDB pick ``courts_court`` as the leading table and scan ~1k courts × ~224 cases each = 240k rows into a temp table before the filesort. Same disease as the homepage fix in #220. Switching to ``prefetch_related(\"court\")`` lets the planner index-walk ``cases_case_date_05882e4a`` directly; the court join becomes one batched follow-up query.

### 3. ``CaseViewSet`` (``/api/cases/``) — same JOIN + conditional token

``oldp/apps/cases/api_views.py:126`` — same prefetch_related fix for the list path. Also made ``select_related(\"created_by_token\")`` conditional on ``request.user.is_authenticated``: only ``ReviewStatusFieldMixin`` reads ``created_by_token.user_id``, and only for auth users. The unconditional LEFT OUTER JOIN to ``accounts_apitoken`` was pure waste on anonymous traffic (the dominant case) and added ~100ms of cold-cache PK lookups.

### 4. ``LawViewSet`` (``/api/laws/``) — conditional token JOIN

``oldp/apps/laws/api_views.py:100`` — same conditional-token treatment. EXPLAIN showed the cold-cache cost was the LEFT OUTER JOIN to ``accounts_apitoken`` for 25 PK lookups on a rarely-touched table.

## Compat

No API surface change. ``review_status`` field continues to appear for staff and creators (those requests still chain the token JOIN). Anonymous responses are unchanged byte-for-byte.

## Test plan

- [x] ``make lint`` passes
- [x] Full test suite: 1140 tests, same 6 pre-existing failures as master (verified via stash)
- [x] Manual: /law/bgb/823 still shows the citing-cases panel with the same data
- [x] Manual: /case/?has_reference_to_law=129924 returns the same case set
- [x] Manual: /api/laws/?page_size=25 anonymous response identical
- [x] Manual: /api/cases/?page_size=25 anonymous response identical