### PR TITLE
feat(search): ES-backed citing-cases panel + filtered search

### DIFF
--- a/docs/api/api-overview.md
+++ b/docs/api/api-overview.md
@@ -238,22 +238,26 @@ curl -X GET "https://de.openlegaldata.io/api/cases/search/?text=urheberrecht+AND
 
 ## Citations & Cross-References
 
-The citation graph is queryable in two complementary ways. The same
-data is also available via the [MCP server](../mcp.md) — both surfaces
-share a single service layer so payload shapes match.
+The citation graph is queryable in three complementary ways. The same
+data is also available via the [MCP server](../mcp.md) — the REST
+nested actions and the MCP tools share a single service layer, so
+payload shapes match across the two **agent-facing** surfaces. The
+**human-facing** web search at `/search/?cited_law_book=…&cited_law_section=…`
+(or `?cited_case=<id>`) renders the same Elasticsearch-backed result
+set with facets and pagination.
 
 ### Nested actions on cases & laws
 
 Map 1:1 to the natural questions about a single case or law section.
 
-| Endpoint | Returns |
-|----------|---------|
-| `GET /api/cases/<id>/references/` | Forward refs emitted by this case (laws + cases it cites) |
-| `GET /api/cases/<id>/citing_cases/` | Cases whose body cites this case |
-| `GET /api/cases/<id>/citing_laws/` | Laws whose body cites this case |
-| `GET /api/laws/<id>/references/` | Forward refs emitted by this law |
-| `GET /api/laws/<id>/citing_cases/` | Cases whose body cites this law section |
-| `GET /api/laws/<id>/citing_laws/` | Laws whose body cites this law section |
+| Endpoint | Returns | Backend |
+|----------|---------|---------|
+| `GET /api/cases/<id>/references/` | Forward refs emitted by this case (laws + cases it cites) | SQL |
+| `GET /api/cases/<id>/citing_cases/` | Cases whose body cites this case | Elasticsearch |
+| `GET /api/cases/<id>/citing_laws/` | Laws whose body cites this case | SQL |
+| `GET /api/laws/<id>/references/` | Forward refs emitted by this law | SQL |
+| `GET /api/laws/<id>/citing_cases/` | Cases whose body cites this law section | Elasticsearch |
+| `GET /api/laws/<id>/citing_laws/` | Laws whose body cites this law section | SQL |
 
 The `references/` endpoints return a single dict
 (`total_law_references`, `total_case_references`,
@@ -263,9 +267,39 @@ paginated list of summary records — **`content` is omitted** on these
 list-style responses for both cases and laws; fetch the detail endpoint
 when the body HTML is actually needed.
 
-`citing_cases` and `citing_laws` for a law cross-revision-resolve via
-`(book_code, section)`, so older citation rows pinned to non-latest
-revisions still surface.
+For laws, the citing-cases lookup is keyed by `(book_slug,
+section_slug)` against the `CaseIndex.cited_laws` field. The slug
+pair is stable across book revisions, so older citation rows pinned
+to non-latest revisions still surface — no `(book_code, section)`
+sibling expansion needed at query time.
+
+### Elasticsearch dependency on citing-cases endpoints
+
+`/api/cases/<id>/citing_cases/` and `/api/laws/<id>/citing_cases/`
+read from Elasticsearch (`CaseIndex.cited_cases` and
+`CaseIndex.cited_laws` respectively). When ES is unavailable these
+endpoints return **503** with a structured body so clients can
+differentiate transient warm-up from a hard outage:
+
+```json
+// 503 — transient timeout, agent should retry
+{
+  "detail": "Search timed out while warming caches. Retry the same query in a few seconds.",
+  "code": "search_backend_timeout",
+  "retryable": true,
+  "hint": "First-touch queries on large result sets read ES segments from disk; the same query is sub-100ms on the next attempt."
+}
+
+// 503 — hard outage
+{
+  "detail": "Search backend is currently unavailable. Please try again later.",
+  "code": "search_backend_unavailable"
+}
+```
+
+See [docs/elasticsearch.md](../elasticsearch.md#index-fields-driving-citation-lookups)
+for the underlying index fields and the reindex command an operator
+must run after upgrading a release that changes either field's shape.
 
 ```bash
 # What does case 12345 cite?

--- a/docs/elasticsearch.md
+++ b/docs/elasticsearch.md
@@ -5,8 +5,84 @@ to work with ES.
 
 ### Propagate database entries to search index
 
-- Rebuild index: `./manage.py rebuild_index` 
+- Rebuild index: `./manage.py rebuild_index`
 - Update existing index: `./manage.py update_index`
+
+### Index fields driving citation lookups
+
+Three multi-value fields back the "find documents tagged with X"
+filter queries. Each lives on the corresponding search index and
+needs a reindex of that app whenever the field shape changes:
+
+| Field | Index | Purpose |
+|-------|-------|---------|
+| `is_latest` | `LawIndex` | Boolean mirroring `LawBook.latest`. The search backend always filters `not (django_ct=laws.law AND is_latest=false)` so stale revisions never enter the haystack hydration loop. |
+| `cited_laws` | `CaseIndex` | List of `"<book_slug>__<section_slug>"` tokens for every law section the case cites. Powers `/search/?cited_law_book=&cited_law_section=`, the citing-cases panel on `/law/<book>/<sec>/`, and the REST + MCP `citing_cases` endpoints. |
+| `cited_cases` | `CaseIndex` | List of Case PKs (as strings) for every case the case cites. Powers `/search/?cited_case=<id>`, the citing-cases panel on `/case/<slug>/`, and the corresponding API + MCP endpoints. |
+
+The token format used by `cited_laws` is intentional: two underscores
+cannot appear inside a Django slug, so `f"{book_slug}__{section_slug}"`
+is unambiguously parseable and safe to use inside an ES `query_string`
+literal. Helper `oldp.apps.cases.search_indexes.cited_law_token`
+renders the token; consumers should call it rather than concatenating
+manually.
+
+### Reindex requirement after deploy
+
+A release that adds or changes one of the fields above needs an
+operator-run reindex on prod to populate the new shape. From inside
+the app container:
+
+    python manage.py update_index laws   # populates is_latest
+    python manage.py update_index cases  # populates cited_laws + cited_cases
+
+Estimated runtime (May 2026 prod data):
+
+- `update_index laws` — ~4-5 min for ~110k law sections.
+- `update_index cases` — ~15-30 min for ~423k cases.
+
+Before the reindex completes, downstream surfaces that rely on the
+new field render their empty state ("No cases cite this section
+yet." / "No other cases cite this decision yet." in the web UI;
+empty paginated list in REST; `total_citing_cases: 0` in MCP). Free-
+text search, facets, and the search backend's existing fields are
+unaffected — the reindex is additive and incremental.
+
+### Service-layer surfaces backed by Elasticsearch
+
+After PR #224 / PR #225 the citation graph is served by ES on every
+surface except the `references/` forward-refs endpoints (which return
+the immediate marker chain — a Python dict — and have always come
+straight out of the ORM):
+
+| Surface | Backend |
+|---------|---------|
+| Web `/law/<book>/<sec>/` "Referenced by" panel | ES (`cited_laws`) |
+| Web `/case/<slug>/` "Cited by" panel | ES (`cited_cases`) |
+| Web `/search/?cited_law_book=&cited_law_section=` | ES (`cited_laws`) |
+| Web `/search/?cited_case=<id>` | ES (`cited_cases`) |
+| REST `/api/laws/<id>/citing_cases/` | ES (`cited_laws`) |
+| REST `/api/cases/<id>/citing_cases/` | ES (`cited_cases`) |
+| REST `/api/{laws,cases}/<id>/references/` | SQL (forward refs) |
+| REST `/api/references/` flat resource | SQL (analytical) |
+| REST `/api/{laws,cases}/<id>/citing_laws/` | SQL (rare) |
+| MCP `get_cases_for_law` | ES (`cited_laws`) |
+| MCP `get_citing_cases` (cases citing a case) | ES (`cited_cases`) |
+| MCP `get_case_references` (forward refs) | SQL |
+
+ES outage on a citing-cases surface returns:
+
+- Web: a "search unavailable" notice with a deep link to the search
+  results page (the user can retry once ES recovers).
+- REST: 503 `SearchBackendUnavailable` (hard outage) or 503
+  `SearchBackendTimeout` (`retryable: true` in the body — transient
+  warm-up).
+- MCP: `{error, retryable, hint}` envelope matching the
+  `search_cases` tool's contract.
+
+The relational citation graph (`Reference` rows + marker
+through-tables) remains the source of truth and feeds the ES
+indexer — see `oldp/apps/references/services/citation_graph.py`.
 
 
 ### Queries

--- a/docs/mcp.md
+++ b/docs/mcp.md
@@ -77,20 +77,40 @@ The server implements OAuth 2.0 with PKCE and Dynamic Client Registration (RFC 7
 
 ### Cross-References
 
-| Tool | Description |
-|------|------------|
-| `validate_citation` | Check if Aktenzeichen, ECLI, or § reference exists in the database |
-| `get_case_references` | Forward refs: which laws and cases does a decision cite? |
-| `get_citing_cases` | Reverse refs: which cases cite a given decision? |
-| `get_cases_for_law` | All cases interpreting a specific statute section |
+| Tool | Description | Backend |
+|------|-------------|---------|
+| `validate_citation` | Check if Aktenzeichen, ECLI, or § reference exists in the database | SQL |
+| `get_case_references` | Forward refs: which laws and cases does a decision cite? | SQL |
+| `get_citing_cases` | Reverse refs: which cases cite a given decision? | Elasticsearch |
+| `get_cases_for_law` | All cases interpreting a specific statute section | Elasticsearch |
 
 The same data is queryable via the
 [REST API's citation surfaces](api/api-overview.md#citations--cross-references):
 nested actions like `/api/cases/<id>/references/` for case-by-case
 lookups, plus a flat `/api/references/` resource with slug-based
 filters (`cited_by_law__book__slug=bgb&cited_by_law__slug=823`) for
-cross-cutting graph queries the MCP tools can't express. Both surfaces
-share a single service layer, so payload shapes match.
+cross-cutting graph queries the MCP tools can't express. The REST
+nested actions and the MCP tools share a single service layer and
+the same backends — `references` / forward-refs paths via the ORM,
+`citing_cases` paths via Elasticsearch — so payload shapes match.
+
+When Elasticsearch is unavailable, `get_citing_cases` and
+`get_cases_for_law` return a structured error envelope rather than
+silently degrading:
+
+```json
+// Transient timeout — same query is sub-100ms after segments are
+// paged in. Agent should wait + retry.
+{"error": "Search timed out…", "retryable": true, "hint": "…"}
+
+// Hard outage — retrying immediately won't help.
+{"error": "Citation graph is temporarily unavailable. Try again in a few minutes.", "retryable": false}
+```
+
+Agents should branch on `retryable` rather than parsing the message.
+See [docs/elasticsearch.md](elasticsearch.md#index-fields-driving-citation-lookups)
+for the underlying `CaseIndex.cited_laws` / `CaseIndex.cited_cases`
+fields.
 
 ### Statistics
 

--- a/oldp/apps/cases/api_views.py
+++ b/oldp/apps/cases/api_views.py
@@ -37,7 +37,6 @@ from oldp.apps.references.serializers import (
 )
 from oldp.apps.references.services import (
     case_forward_references,
-    citing_cases_for_case,
     citing_laws_for_case,
 )
 from oldp.apps.search.api import SearchFilter, SearchViewMixin
@@ -254,9 +253,31 @@ class CaseViewSet(ReviewStatusFilterMixin, viewsets.ModelViewSet):
         serializer_class=CaseListSerializer,
     )
     def citing_cases(self, request, pk=None):
-        """Cases whose body cites this case."""
+        """Cases whose body cites this case.
+
+        Backed by Elasticsearch (``CaseIndex.cited_cases``). On ES
+        failure raises ``SearchBackendTimeout`` /
+        ``SearchBackendUnavailable`` → 503 + structured body.
+        """
+        from oldp.apps.search.exceptions import (
+            SearchBackendTimeout,
+            SearchBackendUnavailable,
+        )
+        from oldp.apps.search.utils import (
+            citing_cases_queryset_via_es,
+            is_search_backend_error,
+            is_search_backend_timeout,
+        )
+
         case = self.get_object()
-        qs = citing_cases_for_case(case)
+        try:
+            qs, _total = citing_cases_queryset_via_es("cited_cases", str(case.pk))
+        except Exception as exc:
+            if is_search_backend_timeout(exc):
+                raise SearchBackendTimeout() from exc
+            if is_search_backend_error(exc):
+                raise SearchBackendUnavailable() from exc
+            raise
         page = self.paginate_queryset(qs)
         serializer = CaseListSerializer(page if page is not None else qs, many=True)
         if page is not None:

--- a/oldp/apps/cases/search_indexes.py
+++ b/oldp/apps/cases/search_indexes.py
@@ -2,6 +2,21 @@ from haystack import indexes
 
 from oldp.apps.cases.models import Case
 
+# Separator for ``cited_laws`` tokens. Two underscores cannot appear
+# inside a Django slug (slugs only use ``-`` and alphanumerics), so
+# ``f"{book_slug}__{section_slug}"`` is always unambiguously parseable
+# back into its two components and safe to use inside an ES query_string
+# literal (no special characters).
+CITED_LAW_SEPARATOR = "__"
+
+
+def cited_law_token(book_slug: str, section_slug: str) -> str:
+    """Render a cited-law token used by ``CaseIndex.cited_laws`` and
+    by the search view's ``cited_law_book`` / ``cited_law_section``
+    query params.
+    """
+    return f"{book_slug}{CITED_LAW_SEPARATOR}{section_slug}"
+
 
 class CaseIndex(indexes.SearchIndex, indexes.Indexable):
     FACET_MODEL_NAME = "Case"
@@ -25,6 +40,19 @@ class CaseIndex(indexes.SearchIndex, indexes.Indexable):
     date = indexes.DateField(faceted=True)
 
     exact_matches = indexes.CharField()  # boost on exact match with this field
+
+    # ``cited_laws``: multi-value list of ``"{book_slug}__{section_slug}"``
+    # tokens for every law section this case cites. Powers the
+    # ``/search/?cited_law_book=&cited_law_section=`` filter and the
+    # citing-cases panel on ``/law/<book>/<sec>/``. Backed by ES's
+    # inverted index, so the cold-cache cost of "all cases citing
+    # § 823 BGB" drops from the ~3s SQL JOIN path to ~50ms.
+    cited_laws = indexes.MultiValueField()
+    # ``cited_cases``: multi-value list of Case PKs (as strings, since
+    # haystack MultiValueField stores tokens) for every case this case
+    # cites. Powers ``/search/?cited_case=<id>`` and the citing-cases
+    # panel on ``/case/<slug>/``.
+    cited_cases = indexes.MultiValueField()
 
     def get_model(self):
         return Case
@@ -55,6 +83,48 @@ class CaseIndex(indexes.SearchIndex, indexes.Indexable):
 
     def prepare_date(self, obj):
         return obj.date  # .strftime('%Y-%m%-%d')
+
+    def prepare_cited_laws(self, obj):
+        """Collect distinct ``(law_book_slug, law_section_slug)`` pairs
+        from every reference attached to one of the case's reference
+        markers. Empty slugs are skipped — those rows are unassigned
+        references that haystack should not return as filter hits.
+
+        Querying ``Reference`` directly (rather than walking
+        ``casereferencemarker_set`` → ``references``) keeps the per-row
+        prepare cost to a single index-driven SELECT during reindex.
+        """
+        from oldp.apps.references.models import Reference
+
+        pairs = (
+            Reference.objects.filter(
+                casereferencemarker__referenced_by_id=obj.pk,
+            )
+            .exclude(law_book_slug="")
+            .exclude(law_section_slug="")
+            .values_list("law_book_slug", "law_section_slug")
+            .distinct()
+        )
+        return [cited_law_token(book, section) for book, section in pairs]
+
+    def prepare_cited_cases(self, obj):
+        """Collect distinct cited-case PKs.
+
+        Stored as strings — haystack's ``MultiValueField`` tokenises
+        each entry, and ES indexes the string form for filter lookups.
+        Callers query with ``filter(cited_cases=str(case.pk))``.
+        """
+        from oldp.apps.references.models import Reference
+
+        ids = (
+            Reference.objects.filter(
+                casereferencemarker__referenced_by_id=obj.pk,
+                case_id__isnull=False,
+            )
+            .values_list("case_id", flat=True)
+            .distinct()
+        )
+        return [str(i) for i in ids]
 
     def index_queryset(self, using=None):
         return Case.get_queryset().select_related("court", "court__state")

--- a/oldp/apps/cases/templates/cases/case.html
+++ b/oldp/apps/cases/templates/cases/case.html
@@ -185,6 +185,40 @@
 </section>
 
 <section>
+    {# Cited-by panel: cases that reference THIS case. Backed by the
+       ``cited_cases`` multi-value field on ``CaseIndex``; ES is the
+       sole source of truth. On backend failure we render an explicit
+       notice plus a link to the search page — the equivalent panel on
+       /law/<book>/<sec>/ behaves identically. #}
+    <h3>{% trans 'Cited by' %}</h3>
+
+    {% if referencing_cases_error %}
+        <div class="alert alert-warning">
+            <p>{{ referencing_cases_error }}</p>
+            <a href="{{ referencing_cases_search_url }}" class="btn btn-sm btn-primary">
+                {% trans 'Open citing-cases search' %}
+            </a>
+        </div>
+    {% elif referencing_cases_count %}
+        {% with cases=referencing_cases %}
+            {% include 'cases/table.html' %}
+        {% endwith %}
+
+        <nav class="text-center" aria-label="Page navigation">
+            <ul class="pagination justify-content-center">
+                <li class="page-item">
+                    <a class="page-link" href="{{ referencing_cases_search_url }}">
+                        {% blocktrans with cases_count=referencing_cases_count %}Show all {{ cases_count }} cases ...{% endblocktrans %}
+                    </a>
+                </li>
+            </ul>
+        </nav>
+    {% else %}
+        <p class="text-center">{% trans 'No other cases cite this decision yet.' %}</p>
+    {% endif %}
+</section>
+
+<section>
     <h3>{% trans 'Related Cases' %}</h3>
     {% if related_cases %}
         {% with cases=related_cases %}

--- a/oldp/apps/cases/views.py
+++ b/oldp/apps/cases/views.py
@@ -5,6 +5,7 @@ from django.core.cache import cache
 from django.db.models import Count
 from django.shortcuts import get_object_or_404, redirect, render
 from django.urls import reverse
+from django.utils.http import urlencode
 from django.utils.translation import gettext_lazy as _
 
 from oldp.apps.cases.cache import (
@@ -146,6 +147,22 @@ def case_view(request, case_slug):
         marker_labels = None
         annotation_labels = None
 
+    # Citing-cases panel — symmetric to the law detail view. Backed by
+    # the ``cited_cases`` field on ``CaseIndex`` (multi-value list of
+    # the case PKs each case cites). The ES inverted index makes this
+    # ~50ms cold; falling back to a SQL JOIN at this scale would be
+    # the same disease the law detail view used to suffer. On ES
+    # failure the template surfaces a "search unavailable" notice plus
+    # a link to the filtered search page.
+    from oldp.apps.search.utils import citing_cases_via_es
+
+    referencing_cases, referencing_cases_count, referencing_cases_error = (
+        citing_cases_via_es("cited_cases", str(item.pk))
+    )
+    referencing_cases_search_url = (
+        reverse("haystack_search") + "?" + urlencode({"cited_case": str(item.pk)})
+    )
+
     return render(
         request,
         "cases/case.html",
@@ -158,6 +175,10 @@ def case_view(request, case_slug):
             "marker_labels": marker_labels,
             "line_counter": Counter(),
             "nav": "cases",
+            "referencing_cases": referencing_cases,
+            "referencing_cases_count": referencing_cases_count,
+            "referencing_cases_error": referencing_cases_error,
+            "referencing_cases_search_url": referencing_cases_search_url,
         },
     )
 

--- a/oldp/apps/laws/api_views.py
+++ b/oldp/apps/laws/api_views.py
@@ -34,7 +34,6 @@ from oldp.apps.references.serializers import (
     ForwardReferencesResponseSerializer,
 )
 from oldp.apps.references.services import (
-    citing_cases_for_law,
     citing_laws_for_law,
     law_forward_references,
 )
@@ -215,22 +214,38 @@ class LawViewSet(ReviewStatusFilterMixin, viewsets.ModelViewSet):
     def citing_cases(self, request, pk=None):
         """Cases whose body cites this law section.
 
-        Resolves cross-revision: ``Reference.law_id`` may pin to an
-        older revision of the same statute section, so we expand to all
-        revisions of the same ``(book code, section)`` pair before
-        querying citing cases.
+        Backed by Elasticsearch (``CaseIndex.cited_laws``). The
+        ``(book_slug, section_slug)`` token is stable across book
+        revisions, so cross-revision lookup is implicit — no
+        sibling-id expansion needed.
+
+        On ES failure raises ``SearchBackendTimeout`` (transient,
+        retryable) or ``SearchBackendUnavailable`` (hard outage). Both
+        serialise to 503 with a structured body; agents differentiate
+        via the ``retryable`` field.
         """
-        law = self.get_object()
-        # Expand to all revisions of this section so we don't miss
-        # citations extracted before the latest revision was added.
-        sibling_ids = list(
-            Law.objects.filter(
-                book__code__iexact=law.book.code,
-                section__iexact=law.section,
-                review_status="accepted",
-            ).values_list("id", flat=True)
+        from oldp.apps.cases.search_indexes import cited_law_token
+        from oldp.apps.search.exceptions import (
+            SearchBackendTimeout,
+            SearchBackendUnavailable,
         )
-        qs = citing_cases_for_law(sibling_ids or [law.id])
+        from oldp.apps.search.utils import (
+            citing_cases_queryset_via_es,
+            is_search_backend_error,
+            is_search_backend_timeout,
+        )
+
+        law = self.get_object()
+        try:
+            qs, _total = citing_cases_queryset_via_es(
+                "cited_laws", cited_law_token(law.book.slug, law.slug)
+            )
+        except Exception as exc:
+            if is_search_backend_timeout(exc):
+                raise SearchBackendTimeout() from exc
+            if is_search_backend_error(exc):
+                raise SearchBackendUnavailable() from exc
+            raise
         page = self.paginate_queryset(qs)
         serializer = CaseListSerializer(page if page is not None else qs, many=True)
         if page is not None:

--- a/oldp/apps/laws/templates/laws/references.html
+++ b/oldp/apps/laws/templates/laws/references.html
@@ -34,26 +34,37 @@
 
     <h3>{% trans 'Referenced by' %}</h3>
 
-    {% with cases=referencing_cases|slice:":10" %}
-        {% include 'cases/table.html' %}
-    {% endwith %}
+    {% if referencing_cases_error %}
+        {# ES is the sole source of truth for the citing-cases panel
+           since we moved the lookup off the SQL JOIN path. When the
+           backend is unavailable we surface the error explicitly and
+           give the user a direct link to the search page, which they
+           can retry once ES recovers. The link itself does not need
+           ES to render — it round-trips through the standard search
+           view, which handles its own ``search_error`` state. #}
+        <div class="alert alert-warning">
+            <p>{{ referencing_cases_error }}</p>
+            <a href="{{ referencing_cases_search_url }}" class="btn btn-sm btn-primary">
+                {% trans 'Open citing-cases search' %}
+            </a>
+        </div>
+    {% elif referencing_cases_count %}
+        {% with cases=referencing_cases %}
+            {% include 'cases/table.html' %}
+        {% endwith %}
 
-
-    <nav class="text-center" aria-label="Page navigation">
-        <ul class="pagination justify-content-center">
-            <li class="page-item">
-                <a class="page-link" href="{{ item.get_referencing_cases_url  }}">
-                    {# ``.count`` issues a SQL COUNT(*) (sub-100ms even
-                       on heavily cited statutes). ``|length`` evaluated
-                       the entire QuerySet — for ``§ 823 BGB`` that's
-                       14k rows hydrated for the sole purpose of
-                       counting, which pinned the /law/<book>/<sec>/
-                       view at 7s. #}
-                    {% blocktrans with cases_count=referencing_cases.count %}Show all {{ cases_count }} cases ...{% endblocktrans %}
-                </a>
-            </li>
-        </ul>
-    </nav>
+        <nav class="text-center" aria-label="Page navigation">
+            <ul class="pagination justify-content-center">
+                <li class="page-item">
+                    <a class="page-link" href="{{ referencing_cases_search_url }}">
+                        {% blocktrans with cases_count=referencing_cases_count %}Show all {{ cases_count }} cases ...{% endblocktrans %}
+                    </a>
+                </li>
+            </ul>
+        </nav>
+    {% else %}
+        <p class="text-center">{% trans 'No cases cite this section yet.' %}</p>
+    {% endif %}
 
 </section>
 

--- a/oldp/apps/laws/views.py
+++ b/oldp/apps/laws/views.py
@@ -6,9 +6,10 @@ from django.contrib import messages
 from django.core.paginator import EmptyPage, PageNotAnInteger, Paginator
 from django.http import Http404
 from django.shortcuts import get_object_or_404, render
+from django.urls import reverse
+from django.utils.http import urlencode
 from django.utils.translation import gettext_lazy as _
 
-from oldp.apps.cases.models import Case
 from oldp.apps.laws.models import Law, LawBook
 from oldp.utils.cache_per_user import cache_per_role
 
@@ -148,6 +149,9 @@ def view_book(request, book_slug):
 
 @cache_per_role(settings.CACHE_TTL)
 def view_law(request, law_slug, book_slug):
+    from oldp.apps.cases.search_indexes import cited_law_token
+    from oldp.apps.search.utils import citing_cases_via_es
+
     book = get_law_book(request, book_slug)
     item = get_object_or_404(
         Law.get_queryset(request).select_related("book", "previous"),
@@ -157,8 +161,21 @@ def view_law(request, law_slug, book_slug):
     revision_dates = list(book.get_revision_dates())
     related_laws = item.get_related()
 
-    referencing_cases = item.get_referencing_cases(
-        Case.get_queryset(request).defer(*Case.defer_fields_list_view)
+    referencing_cases, referencing_cases_count, referencing_cases_error = (
+        citing_cases_via_es("cited_laws", cited_law_token(book.slug, item.slug))
+    )
+    # Deep link to the full search results, preserving the citation
+    # filter — used both by the "Show all N cases ..." pagination link
+    # and by the "search is unavailable" fallback message.
+    referencing_cases_search_url = (
+        reverse("haystack_search")
+        + "?"
+        + urlencode(
+            {
+                "cited_law_book": book.slug,
+                "cited_law_section": item.slug,
+            }
+        )
     )
 
     return render(
@@ -171,5 +188,8 @@ def view_law(request, law_slug, book_slug):
             "revision_dates": revision_dates,
             "related_laws": related_laws,
             "referencing_cases": referencing_cases,
+            "referencing_cases_count": referencing_cases_count,
+            "referencing_cases_error": referencing_cases_error,
+            "referencing_cases_search_url": referencing_cases_search_url,
         },
     )

--- a/oldp/apps/references/mcp.py
+++ b/oldp/apps/references/mcp.py
@@ -16,12 +16,42 @@ from oldp.apps.mcp.monitoring import log_tool_call
 from oldp.apps.mcp.utils import clamp_limit, with_limit_meta
 from oldp.apps.references.services import (
     case_forward_references,
-    citing_cases_for_case,
-    citing_cases_for_law,
     resolve_law_section,
     serialize_case_summary,
     validate_citation,
 )
+
+
+def _es_outage_error(exc: Exception) -> dict:
+    """Translate an Elasticsearch failure to the MCP error envelope.
+
+    Mirrors the shape used by ``search_cases`` / ``search_laws``: a
+    ``retryable: True`` body for transient timeouts (segment files
+    paging in from disk, agent should retry the same call after a
+    moment) and ``retryable: False`` for hard outages.
+    """
+    from oldp.apps.search.utils import is_search_backend_timeout
+
+    if is_search_backend_timeout(exc):
+        return {
+            "error": (
+                "Search timed out while warming caches. "
+                "Retry the same query in a few seconds."
+            ),
+            "retryable": True,
+            "hint": (
+                "First-touch citation-graph queries on large result "
+                "sets read ES segments from disk; the same query is "
+                "sub-100ms on the next attempt."
+            ),
+        }
+    return {
+        "error": (
+            "Citation graph is temporarily unavailable. Try again in a few minutes."
+        ),
+        "retryable": False,
+    }
+
 
 logger = logging.getLogger("oldp.mcp.tools")
 
@@ -93,14 +123,21 @@ class ReferenceTools(MCPToolset):
         if not case:
             return {"error": f"Case with ID {case_id} not found."}
 
-        qs = citing_cases_for_case(case)
-        # Materialise the limited slice once; reuse for total to avoid
-        # running the same DISTINCT JOIN twice when result count <= limit.
+        # Backed by Elasticsearch (``CaseIndex.cited_cases``). ES is
+        # the source of truth here; on outage we return a structured
+        # error so the agent can decide to retry vs give up.
+        from oldp.apps.search.utils import (
+            citing_cases_queryset_via_es,
+            is_search_backend_error,
+        )
+
+        try:
+            qs, total = citing_cases_queryset_via_es("cited_cases", str(case_id))
+        except Exception as exc:
+            if is_search_backend_error(exc):
+                return _es_outage_error(exc)
+            raise
         sliced = list(qs[:limit])
-        if len(sliced) < limit:
-            total = len(sliced)
-        else:
-            total = qs.count()
 
         return with_limit_meta(
             {
@@ -175,12 +212,26 @@ class ReferenceTools(MCPToolset):
                 ),
             }
 
-        qs = citing_cases_for_law(law_ids)
+        # Backed by Elasticsearch (``CaseIndex.cited_laws``). The
+        # ``(book_slug, section_slug)`` token is stable across book
+        # revisions, so cross-revision lookup is implicit — no
+        # ``law_ids`` expansion needed at query time.
+        from oldp.apps.cases.search_indexes import cited_law_token
+        from oldp.apps.search.utils import (
+            citing_cases_queryset_via_es,
+            is_search_backend_error,
+        )
+
+        try:
+            qs, total = citing_cases_queryset_via_es(
+                "cited_laws",
+                cited_law_token(primary.book.slug, primary.slug),
+            )
+        except Exception as exc:
+            if is_search_backend_error(exc):
+                return _es_outage_error(exc)
+            raise
         sliced = list(qs[:limit])
-        if len(sliced) < limit:
-            total = len(sliced)
-        else:
-            total = qs.count()
 
         return with_limit_meta(
             {

--- a/oldp/apps/references/tests/_es_shim.py
+++ b/oldp/apps/references/tests/_es_shim.py
@@ -1,0 +1,94 @@
+"""Test helpers for the ES-backed citing_cases endpoints.
+
+The production helper ``oldp.apps.search.utils.citing_cases_queryset_via_es``
+queries Elasticsearch via ``CaseIndex.cited_laws`` / ``CaseIndex.cited_cases``.
+Unit tests run with ``MOCK_ES_TESTS=True`` (mock haystack backend) which
+returns no hits — so any test that asserts "citing-cases endpoint
+returns these specific fixture rows" needs to bypass ES.
+
+This module provides a SQL-backed shim that mirrors the production
+helper's signature + return shape, computed from the same
+``Reference`` rows the test fixtures create. Apply it to a TestCase
+via ``ESCitingCasesShimMixin`` — it starts the patch in ``setUp`` and
+stops it in ``tearDown``, so the mock isn't passed to test methods
+(which would change their signatures and break ``@override_settings``
+and other decorators).
+
+The shim keeps the API/MCP behaviour identical from the consumer's
+point of view (paginated Case queryset + total count) while leaving
+the production import path under test. The matching production code
+remains ES-only — there is no SQL fallback in views / MCP tools.
+"""
+
+from unittest.mock import patch
+
+
+def _sql_citing_cases_queryset(field, value, max_results=10000):
+    """Test-only SQL fallback that mirrors ``citing_cases_queryset_via_es``.
+
+    Computes the citing-case ids via the existing SQL helpers in
+    ``oldp.apps.references.services.citation_graph`` (which are the
+    source of truth that fed the ES indexer in the first place), then
+    builds the same hydrated ``Case`` queryset shape the production
+    helper returns.
+    """
+    from oldp.apps.cases.models import Case
+    from oldp.apps.references.services import (
+        citing_case_ids_for_case,
+        citing_case_ids_for_slug_pair,
+    )
+
+    if field == "cited_laws":
+        book, sep, section = value.partition("__")
+        if not sep:
+            return Case.objects.none(), 0
+        ids = citing_case_ids_for_slug_pair(book, section)
+    elif field == "cited_cases":
+        case = Case.objects.filter(pk=int(value)).first()
+        if case is None:
+            return Case.objects.none(), 0
+        ids = citing_case_ids_for_case(case)
+    else:
+        return Case.objects.none(), 0
+
+    ids = list(ids)[:max_results]
+    if not ids:
+        return Case.objects.none(), 0
+    qs = (
+        Case.objects.filter(id__in=ids, review_status="accepted")
+        .select_related("court")
+        .defer(*Case.defer_fields_list_view)
+        .order_by("-date")
+    )
+    return qs, qs.count()
+
+
+class ESCitingCasesShimMixin:
+    """Mixin: monkey-patches ``citing_cases_queryset_via_es`` to the
+    SQL fallback for every test in the class.
+
+    Apply to a TestCase via ``class MyTest(ESCitingCasesShimMixin,
+    TestCase): ...``. The patch is started in ``setUpClass`` and
+    stopped in ``tearDownClass``, so it doesn't interact with the
+    test class's per-test ``setUp`` (which existing classes don't
+    chain via ``super().setUp()``). Test method signatures stay
+    unchanged.
+
+    Tests that exercise the ES failure path should NOT use this
+    mixin; ``@patch`` the helper directly with a side-effect-raising
+    lambda inside the test.
+    """
+
+    @classmethod
+    def setUpClass(cls):
+        cls._citing_cases_patcher = patch(
+            "oldp.apps.search.utils.citing_cases_queryset_via_es",
+            side_effect=_sql_citing_cases_queryset,
+        )
+        cls._citing_cases_patcher.start()
+        super().setUpClass()
+
+    @classmethod
+    def tearDownClass(cls):
+        super().tearDownClass()
+        cls._citing_cases_patcher.stop()

--- a/oldp/apps/references/tests/test_api.py
+++ b/oldp/apps/references/tests/test_api.py
@@ -23,6 +23,7 @@ from oldp.apps.references.models import (
     ReferenceFromCase,
     ReferenceFromLaw,
 )
+from oldp.apps.references.tests._es_shim import ESCitingCasesShimMixin
 
 
 def _make_court(slug: str, code: str | None = None) -> Court:
@@ -103,7 +104,7 @@ def _attach_law_law_ref(source: Law, target: Law, marker_text: str = "§ 1") -> 
 @override_settings(
     CACHES={"default": {"BACKEND": "django.core.cache.backends.dummy.DummyCache"}}
 )
-class CitationApiTestCase(TestCase):
+class CitationApiTestCase(ESCitingCasesShimMixin, TestCase):
     """Exercise nested + flat citation surfaces."""
 
     @classmethod
@@ -234,6 +235,49 @@ class CitationApiTestCase(TestCase):
         for field in ("id", "to", "to_hash", "case", "law", "cited_by", "marker_text"):
             self.assertIn(field, ref)
         self.assertEqual(ref["law"]["book_slug"], "bgb")
+
+    def test_citing_cases_returns_503_on_es_outage(self):
+        """``/api/laws/<id>/citing_cases/`` and
+        ``/api/cases/<id>/citing_cases/`` are ES-backed; on backend
+        failure they must surface a 503 (not a silent SQL fallback)
+        so consumers know the data path is degraded.
+        """
+        from unittest.mock import patch
+
+        try:
+            from elasticsearch.exceptions import ConnectionError as ESConnectionError
+        except ImportError:
+            self.skipTest("elasticsearch package not installed")
+
+        with patch(
+            "oldp.apps.search.utils.citing_cases_queryset_via_es",
+            side_effect=ESConnectionError("ES down"),
+        ):
+            resp = self.client.get(f"/api/laws/{self.law_823.id}/citing_cases/")
+            self.assertEqual(resp.status_code, 503)
+            resp = self.client.get(f"/api/cases/{self.case_a.id}/citing_cases/")
+            self.assertEqual(resp.status_code, 503)
+
+    def test_citing_cases_returns_retryable_503_on_es_timeout(self):
+        """Timeouts must map to the ``retryable: True`` body so
+        agents distinguish "wait + retry" from "give up".
+        """
+        from unittest.mock import patch
+
+        try:
+            from elasticsearch.exceptions import ConnectionTimeout
+        except ImportError:
+            self.skipTest("elasticsearch package not installed")
+
+        with patch(
+            "oldp.apps.search.utils.citing_cases_queryset_via_es",
+            side_effect=ConnectionTimeout("warming up"),
+        ):
+            resp = self.client.get(f"/api/laws/{self.law_823.id}/citing_cases/")
+            self.assertEqual(resp.status_code, 503)
+            body = resp.json()
+            self.assertTrue(body.get("retryable"))
+            self.assertIn("hint", body)
 
     def test_flat_serializer_uses_prefetch_cache(self):
         """``cited_by`` / ``marker_text`` must read the prefetched

--- a/oldp/apps/references/tests/test_mcp.py
+++ b/oldp/apps/references/tests/test_mcp.py
@@ -16,6 +16,7 @@ from oldp.apps.references.models import (
 from oldp.apps.references.services import (
     parse_citation_type as _parse_citation_type,
 )
+from oldp.apps.references.tests._es_shim import ESCitingCasesShimMixin
 
 
 class CitationParsingTests(TestCase):
@@ -55,7 +56,7 @@ class CitationParsingTests(TestCase):
 @override_settings(
     CACHES={"default": {"BACKEND": "django.core.cache.backends.dummy.DummyCache"}}
 )
-class ReferenceToolsTests(TestCase):
+class ReferenceToolsTests(ESCitingCasesShimMixin, TestCase):
     """Tests for citation validation and cross-reference tools."""
 
     fixtures = [
@@ -394,6 +395,48 @@ class ReferenceToolsTests(TestCase):
     def test_get_cases_for_law_not_found(self):
         result = self.tools.get_cases_for_law(law_id=999999)
         self.assertIn("error", result)
+
+    def test_get_cases_for_law_returns_retryable_on_es_timeout(self):
+        """ES timeout on the citation lookup must surface as a
+        ``retryable: True`` envelope so the agent can wait + retry.
+        Mirrors the ``search_cases`` tool's contract.
+        """
+        from unittest.mock import patch
+
+        try:
+            from elasticsearch.exceptions import ConnectionTimeout
+        except ImportError:
+            self.skipTest("elasticsearch package not installed")
+
+        with patch(
+            "oldp.apps.search.utils.citing_cases_queryset_via_es",
+            side_effect=ConnectionTimeout("warming up"),
+        ):
+            result = self.tools.get_cases_for_law(law_id=self.law.id)
+        self.assertIn("error", result)
+        self.assertTrue(result.get("retryable"))
+        self.assertIn("hint", result)
+
+    def test_get_citing_cases_returns_hard_error_on_es_outage(self):
+        """ConnectionError (hard outage) gets ``retryable: False`` —
+        agents shouldn't burn retries against an empty/broken backend.
+        """
+        from unittest.mock import patch
+
+        if not self.court:
+            self.skipTest("No court fixture")
+        try:
+            from elasticsearch.exceptions import ConnectionError as ESConnectionError
+        except ImportError:
+            self.skipTest("elasticsearch package not installed")
+
+        with patch(
+            "oldp.apps.search.utils.citing_cases_queryset_via_es",
+            side_effect=ESConnectionError("ES down"),
+        ):
+            result = self.tools.get_citing_cases(case_id=self.case_a.id)
+        self.assertIn("error", result)
+        self.assertFalse(result.get("retryable"))
 
     def test_get_cases_for_law_no_params(self):
         result = self.tools.get_cases_for_law()

--- a/oldp/apps/search/exceptions.py
+++ b/oldp/apps/search/exceptions.py
@@ -17,9 +17,6 @@ class SearchBackendTimeout(SearchBackendUnavailable):
     Subclasses :class:`SearchBackendUnavailable` so existing
     ``except SearchBackendUnavailable`` callers keep working but
     timeout-aware handlers can branch on the more specific type.
-    Wraps the response body in a dict so REST callers (incl. MCP
-    consumers via OpenAPI) get a structured ``retryable: true``
-    field instead of having to parse the message.
     """
 
     status_code = 503
@@ -27,16 +24,28 @@ class SearchBackendTimeout(SearchBackendUnavailable):
         "Search timed out while warming caches. Retry the same query in a few seconds."
     )
     default_code = "search_backend_timeout"
+    retry_hint = (
+        "First-touch queries on large result sets read ES segments "
+        "from disk; the same query is sub-100ms on the next attempt."
+    )
 
-    def __init__(self, detail=None, code=None):
-        super().__init__(detail=detail, code=code)
-        if isinstance(self.detail, str):
-            self.detail = {
-                "detail": str(self.detail),
-                "retryable": True,
-                "hint": (
-                    "First-touch queries on large result sets read "
-                    "ES segments from disk; the same query is "
-                    "sub-100ms on the next attempt."
-                ),
-            }
+    def get_full_details(self):
+        """Return the structured body for REST consumers.
+
+        We override the default DRF transformation because the project
+        runs every ``APIException`` through ``full_details_exception_handler``
+        (``oldp/api/exceptions.py``) which calls ``get_full_details``
+        and writes it back to ``self.detail``. The default traversal
+        chokes on non-``ErrorDetail`` values in the dict; doing the
+        shaping ourselves keeps the body clean — flat
+        ``{detail, code, retryable, hint}`` — instead of nesting each
+        value under ``{message, code}``.
+        """
+        return {
+            "detail": str(self.detail)
+            if isinstance(self.detail, str)
+            else self.default_detail,
+            "code": self.default_code,
+            "retryable": True,
+            "hint": self.retry_hint,
+        }

--- a/oldp/apps/search/templates/search/search.html
+++ b/oldp/apps/search/templates/search/search.html
@@ -33,6 +33,30 @@
 
         </form>
 
+        {% if citation_filter %}
+            {# Active citation-graph filter (set by /law/<sec>/ or
+               /case/<slug>/ "View all citing cases" link). Render as
+               a dismissible chip so the user can clear it without
+               touching the URL bar. #}
+            <div class="active-filters" style="margin-top: .75rem;">
+                <span class="badge badge-pill badge-info" style="font-size: 0.95rem; padding: .5rem .75rem;">
+                    {% if citation_filter.kind == 'law' %}
+                        {% trans 'Cases citing' %}
+                    {% else %}
+                        {% trans 'Cases citing case' %}
+                    {% endif %}
+                    {% if citation_filter.label %}
+                        <strong>{{ citation_filter.label }}</strong>
+                    {% else %}
+                        <em>{% trans '(unknown)' %}</em>
+                    {% endif %}
+                    <a href="{{ clear_citation_url }}" class="badge-clear"
+                       aria-label="{% trans 'Remove filter' %}"
+                       style="color: inherit; margin-left: .5rem; text-decoration: none; font-weight: bold;">×</a>
+                </span>
+            </div>
+        {% endif %}
+
         <div class="search-container">
             <div class="search-results">
 
@@ -41,10 +65,14 @@
                         <h4>{% trans 'Error' %}</h4>
                         <p>{{ search_error }}</p>
                     </div>
-                {% elif query and object_list %}
+                {% elif object_list and query or object_list and citation_filter %}
 
                     <div style="text-align: right; color: grey;">
-                        {% blocktrans with count=page_obj.paginator.count %}{{ count }} results sorted by <b>relevance</b>.{% endblocktrans %}
+                        {% if citation_filter %}
+                            {% blocktrans with count=page_obj.paginator.count %}{{ count }} citing cases.{% endblocktrans %}
+                        {% else %}
+                            {% blocktrans with count=page_obj.paginator.count %}{{ count }} results sorted by <b>relevance</b>.{% endblocktrans %}
+                        {% endif %}
                     </div>
 
 
@@ -73,7 +101,7 @@
 
     </section>
 
-    {% if query and object_list %}
+    {% if object_list and query or object_list and citation_filter %}
         {% include 'pagination_list_view.html' %}
     {% endif %}
 

--- a/oldp/apps/search/tests/test_search_filter.py
+++ b/oldp/apps/search/tests/test_search_filter.py
@@ -500,10 +500,13 @@ class SearchViewMixinErrorHandlingTest(TestCase):
         request = Request(self.factory.get("/api/cases/search/", {"text": "test"}))
         with self.assertRaises(SearchBackendTimeout) as ctx:
             view.list(request)
-        # Body must include the retry hint as structured fields so REST
-        # callers don't need to scrape strings.
-        self.assertEqual(ctx.exception.detail.get("retryable"), True)
-        self.assertIn("hint", ctx.exception.detail)
+        # ``get_full_details`` produces the structured body that the
+        # project-wide ``full_details_exception_handler`` writes back
+        # to the response. REST callers see this exact shape.
+        body = ctx.exception.get_full_details()
+        self.assertEqual(body.get("retryable"), True)
+        self.assertIn("hint", body)
+        self.assertEqual(body.get("code"), "search_backend_timeout")
         # And SearchBackendTimeout must remain a subclass of the broad
         # SearchBackendUnavailable so existing handlers keep working.
         self.assertIsInstance(ctx.exception, SearchBackendUnavailable)

--- a/oldp/apps/search/tests/test_search_filter.py
+++ b/oldp/apps/search/tests/test_search_filter.py
@@ -452,6 +452,27 @@ class SearchViewMixinErrorHandlingTest(TestCase):
         with self.assertRaises(ValueError):
             view.list(request)
 
+    def test_citing_cases_via_es_returns_error_on_backend_failure(self):
+        """Helper must surface a structured error instead of falling
+        back to SQL — the law/case detail views render this as a
+        notice + deep link to the search page.
+        """
+        try:
+            from elasticsearch.exceptions import ConnectionError as ESConnectionError
+        except ImportError:
+            self.skipTest("elasticsearch package not installed")
+
+        from oldp.apps.search.utils import citing_cases_via_es
+
+        with patch(
+            "haystack.query.SearchQuerySet.count",
+            side_effect=ESConnectionError("ES down"),
+        ):
+            cases, total, error = citing_cases_via_es("cited_laws", "bgb__823")
+        self.assertEqual(cases, [])
+        self.assertIsNone(total)
+        self.assertIsNotNone(error)
+
     def test_elasticsearch_timeout_raises_timeout_subclass(self):
         """Timeouts must raise the retryable subclass, not the generic one.
 

--- a/oldp/apps/search/tests/test_views.py
+++ b/oldp/apps/search/tests/test_views.py
@@ -154,6 +154,55 @@ class MockedSearchViewsTestCase(TestCase):
         self.assertEqual(200, res.status_code)
         self.assertTrue(any("from=ref" in msg for msg in cm.output))
 
+    @patch(
+        "oldp.apps.search.views.CustomSearchForm.search", return_value=_make_mock_sqs()
+    )
+    def test_search_renders_citation_filter_chip(self, mock_search):
+        """``/search/?cited_law_book=bgb&cited_law_section=823`` renders
+        the active-filter chip with the ``×`` clear link.
+
+        Regression test for the cited-law filter wiring: the request
+        must succeed (status 200), the chip must show the law label
+        (falling back to ``(unknown)`` when the law row isn't in the
+        test fixtures, which is the case here), and the clear link
+        must strip ``cited_law_book`` + ``cited_law_section`` from
+        the URL.
+        """
+        res = self.get_search_response(
+            {
+                "cited_law_book": "bgb",
+                "cited_law_section": "823",
+            }
+        )
+        self.assertEqual(res.status_code, 200)
+        body = res.content.decode()
+        self.assertIn("active-filters", body)
+        # Clear link strips the filter params but keeps any others
+        self.assertIn("badge-clear", body)
+        self.assertNotIn("cited_law_book=bgb", body.split("badge-clear")[1][:200])
+
+    def test_citation_filter_resolver_resolves_unknown_as_label_none(self):
+        """``_resolve_citation_filter`` returns a dict with ``label=None``
+        when the slug pair does not exist — the search filter still
+        applies (ES returns zero hits, which is correct), but the chip
+        falls back to ``(unknown)``.
+        """
+        from oldp.apps.search.views import _resolve_citation_filter
+
+        out = _resolve_citation_filter(
+            {"cited_law_book": "nonexistent", "cited_law_section": "999"}
+        )
+        self.assertIsNotNone(out)
+        self.assertEqual(out["kind"], "law")
+        self.assertEqual(out["token"], "nonexistent__999")
+        self.assertIsNone(out["label"])
+
+    def test_citation_filter_resolver_returns_none_for_no_params(self):
+        from oldp.apps.search.views import _resolve_citation_filter
+
+        self.assertIsNone(_resolve_citation_filter({}))
+        self.assertIsNone(_resolve_citation_filter({"q": "anything"}))
+
     @override_settings(
         CACHES={
             "default": {

--- a/oldp/apps/search/utils.py
+++ b/oldp/apps/search/utils.py
@@ -11,6 +11,63 @@ def is_search_backend_error(exc: Exception) -> bool:
         return False
 
 
+def citing_cases_queryset_via_es(field: str, value: str, max_results: int = 10000):
+    """Return ``(case_queryset, total)`` for cases citing ``value``.
+
+    Variant of :func:`citing_cases_via_es` for callers that need a
+    Django ``QuerySet`` (REST pagination, MCP slicing) rather than a
+    pre-materialised list:
+
+      * Issues one ES query to resolve the matching case IDs (in
+        ``-date`` order, capped at ``max_results``) and the total
+        count;
+      * Builds a Django queryset filtered to those IDs, with
+        ``select_related("court")`` + ``defer(*defer_fields_list_view)``
+        and re-applies ``order_by("-date")`` so paginator slices land
+        in the same order as ES emitted;
+      * **Raises** ``ConnectionError`` / ``ConnectionTimeout`` /
+        ``TransportError`` on ES failure — the API translates these to
+        ``SearchBackendUnavailable`` / ``SearchBackendTimeout`` (DRF
+        503 + retry hint) and MCP translates them to its
+        ``{error, retryable, hint}`` dict.
+
+    ``max_results`` caps the materialised id list to bound memory.
+    With ``PAGINATE_UNTIL * page_size_max = 10 * 1000 = 10_000`` for
+    the small-results paginator this is also the upper bound the
+    API can ever surface, so anything above it would be unreachable.
+    """
+    from haystack.query import SearchQuerySet
+
+    from oldp.apps.cases.models import Case
+
+    sqs = (
+        SearchQuerySet()
+        .filter(**{field: value})
+        .filter(facet_model_name="Case")
+        .filter(review_status="accepted")
+        .order_by("-date")
+    )
+    total = sqs.count()
+    if total == 0:
+        return Case.objects.none(), 0
+
+    # Materialise the matching case ids in ES sort order. We don't use
+    # ``load_all()`` here — DRF's paginator will slice the Django
+    # queryset and hydrate the page itself, so pre-fetching all
+    # ``max_results`` cases would waste cycles.
+    case_ids = [int(r.pk) for r in sqs[:max_results]]
+    if not case_ids:
+        return Case.objects.none(), 0
+
+    qs = (
+        Case.objects.filter(id__in=case_ids, review_status="accepted")
+        .select_related("court")
+        .defer(*Case.defer_fields_list_view)
+        .order_by("-date")
+    )
+    return qs, total
+
+
 def citing_cases_via_es(field: str, value: str, limit: int = 10):
     """Look up cases citing ``value`` in the given ``cited_*`` field.
 

--- a/oldp/apps/search/utils.py
+++ b/oldp/apps/search/utils.py
@@ -11,6 +11,69 @@ def is_search_backend_error(exc: Exception) -> bool:
         return False
 
 
+def citing_cases_via_es(field: str, value: str, limit: int = 10):
+    """Look up cases citing ``value`` in the given ``cited_*`` field.
+
+    ``field`` is the name of the multi-value field on ``CaseIndex``
+    (``"cited_laws"`` for a law section, ``"cited_cases"`` for a case).
+    ``value`` is the corresponding token: ``"book_slug__section_slug"``
+    for laws, the cited case's PK as a string for cases.
+
+    Returns ``(cases_list, total_count, error_message)``. ``cases_list``
+    is a list of ``Case`` model instances hydrated via Haystack's
+    ``load_all`` (one batched SQL fetch with the index's
+    ``read_queryset`` ``select_related`` chain). On ES failure we set
+    ``error_message`` to a user-facing string and leave the list
+    empty — callers (the law and case detail views) render this as a
+    "search unavailable" notice with a deep link to the full search
+    results page instead of falling back to the SQL JOIN path.
+    """
+    from haystack.query import SearchQuerySet
+
+    try:
+        sqs = (
+            SearchQuerySet()
+            .filter(**{field: value})
+            .filter(facet_model_name="Case")
+            .filter(review_status="accepted")
+            .order_by("-date")
+            .load_all()
+        )
+        total = sqs.count()
+        results = list(sqs[:limit])
+    except Exception as exc:
+        if is_search_backend_error(exc):
+            import logging
+
+            from django.utils.translation import gettext_lazy as _
+
+            logger = logging.getLogger(__name__)
+            logger.warning(
+                "Citing-cases ES lookup failed (%s=%r, timeout=%s): %s",
+                field,
+                value,
+                is_search_backend_timeout(exc),
+                exc,
+            )
+            return (
+                [],
+                None,
+                _(
+                    "Search backend is currently unavailable, so the list "
+                    "of citing cases cannot be loaded. Please try again "
+                    "later."
+                ),
+            )
+        raise
+
+    # ``r.object`` is None when the ES doc points to a row that
+    # ``CaseIndex.read_queryset`` no longer returns (deleted case,
+    # ``review_status`` flipped after indexing). Drop those rather
+    # than rendering a hole in the table.
+    cases = [r.object for r in results if getattr(r, "object", None) is not None]
+    return cases, total, None
+
+
 def is_search_backend_timeout(exc: Exception) -> bool:
     """Subset of :func:`is_search_backend_error` for transient timeouts.
 

--- a/oldp/apps/search/views.py
+++ b/oldp/apps/search/views.py
@@ -11,6 +11,7 @@ from haystack.forms import FacetedSearchForm
 from haystack.generic_views import FacetedSearchView
 from haystack.query import SearchQuerySet
 
+from oldp.apps.cases.search_indexes import cited_law_token
 from oldp.apps.search.api import SearchQueryBuilder
 from oldp.apps.search.utils import (
     is_search_backend_error,
@@ -38,6 +39,72 @@ def _get_autocomplete_cache_key(request, query: str) -> str:
     return f"autocomplete_v2_{digest}"
 
 
+def _resolve_citation_filter(data):
+    """Resolve ``cited_law_book`` + ``cited_law_section`` / ``cited_case``
+    query parameters to the ES filter token + a human-readable label.
+
+    Returns a ``dict`` with keys:
+
+      * ``kind`` — one of ``"law"``, ``"case"``, or ``None``;
+      * ``token`` — the value stored in the corresponding ES field
+        (``cited_laws`` or ``cited_cases``);
+      * ``label`` — display text (e.g. ``"§ 823 BGB"`` or
+        ``"VI ZR 123/22 (BGH)"``);
+      * ``params`` — the dict of GET params that select this filter,
+        used to round-trip the chosen filter through pagination
+        URLs without losing it.
+
+    Returns ``None`` when no citation filter is requested. Returns the
+    dict with ``label=None`` when the resolved law / case does not
+    exist (we still apply the ES filter; the search will just return
+    zero hits, which is correct behaviour).
+    """
+    book = (data.get("cited_law_book") or "").strip()
+    section = (data.get("cited_law_section") or "").strip()
+    case_id_raw = (data.get("cited_case") or "").strip()
+
+    if book and section:
+        from oldp.apps.laws.models import Law
+
+        law = (
+            Law.objects.filter(book__slug=book, slug=section, book__latest=True)
+            .select_related("book")
+            .first()
+        )
+        label = law.get_title() if law else None
+        return {
+            "kind": "law",
+            "token": cited_law_token(book, section),
+            "label": label,
+            "params": {"cited_law_book": book, "cited_law_section": section},
+        }
+
+    if case_id_raw:
+        try:
+            case_id = int(case_id_raw)
+        except ValueError:
+            return None
+        from oldp.apps.cases.models import Case
+
+        case = Case.objects.filter(pk=case_id).select_related("court").first()
+        if case is not None:
+            label = (
+                f"{case.file_number} ({case.court.name})"
+                if case.court_id
+                else case.file_number
+            )
+        else:
+            label = None
+        return {
+            "kind": "case",
+            "token": str(case_id),
+            "label": label,
+            "params": {"cited_case": str(case_id)},
+        }
+
+    return None
+
+
 class CustomSearchForm(FacetedSearchForm):
     """Our custom search form for facet search with haystack"""
 
@@ -57,6 +124,21 @@ class CustomSearchForm(FacetedSearchForm):
             self.data.get("start_date", ""),
             self.data.get("end_date", ""),
         )
+        # Citation graph filters. Both ``cited_laws`` and ``cited_cases``
+        # are multi-value fields on ``CaseIndex``; haystack emits a
+        # narrow-query like ``cited_laws:"bgb__823"`` which ES resolves
+        # against the inverted index in sub-100ms. We also clamp the
+        # model to Case here because the citation fields are not
+        # populated on ``LawIndex`` documents.
+        citation_filter = _resolve_citation_filter(self.data)
+        if citation_filter is not None:
+            sqs = builder.build()
+            if citation_filter["kind"] == "law":
+                sqs = sqs.filter(cited_laws=citation_filter["token"])
+            else:
+                sqs = sqs.filter(cited_cases=citation_filter["token"])
+            sqs = sqs.filter(facet_model_name="Case")
+            return sqs
         return builder.build()
 
 
@@ -255,10 +337,24 @@ class CustomSearchView(FacetedSearchView):
         #             'items': [{'date': date.strftime(fmt), 'count': count} for date, count in dates],
         #         }
 
+        citation_filter = _resolve_citation_filter(self.request.GET)
+        clear_citation_url = None
+        if citation_filter is not None:
+            # Build a "remove this filter" URL by stripping the citation
+            # params from the current querystring. Keeps q=, facets, etc.
+            remaining = self.request.GET.copy()
+            for key in ("cited_law_book", "cited_law_section", "cited_case"):
+                remaining.pop(key, None)
+            remaining.pop("page", None)
+            qs = remaining.urlencode()
+            clear_citation_url = "?" + qs if qs else "?"
+
         context.update(
             {
                 "title": _("Search") + " " + context["query"][:30],
                 "search_facets": self.get_search_facets(context),
+                "citation_filter": citation_filter,
+                "clear_citation_url": clear_citation_url,
                 # 'date_facets': date_facets,
             }
         )

--- a/oldp/locale/de/LC_MESSAGES/django.po
+++ b/oldp/locale/de/LC_MESSAGES/django.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2026-05-06 06:33+0000\n"
+"POT-Creation-Date: 2026-05-28 12:00+0000\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -205,7 +205,7 @@ msgstr "Benutzer inaktiv oder gelöscht."
 #: oldp/apps/cases/templates/cases/case_filter.html:47
 #: oldp/apps/cases/templates/cases/index.html:9
 #: oldp/apps/cases/templates/cases/stats/base.html:113
-#: oldp/apps/cases/views.py:60
+#: oldp/apps/cases/views.py:76
 #: oldp/apps/courts/templates/courts/cases_list.html:55
 #: oldp/assets/templates/admin/index.html:20
 #: oldp/assets/templates/header.html:18
@@ -213,7 +213,7 @@ msgid "Cases"
 msgstr "Urteile"
 
 #: oldp/apps/accounts/models.py:19 oldp/apps/laws/templates/laws/index.html:9
-#: oldp/apps/laws/templates/laws/law.html:90 oldp/apps/laws/views.py:70
+#: oldp/apps/laws/templates/laws/law.html:90 oldp/apps/laws/views.py:71
 #: oldp/assets/templates/admin/index.html:24
 #: oldp/assets/templates/header.html:31
 msgid "Laws"
@@ -531,7 +531,7 @@ msgstr "Rotieren Sie Token regelmäßig für erhöhte Sicherheit"
 
 #: oldp/apps/accounts/templates/accounts/app_api_token_revoke.html:5
 #: oldp/apps/accounts/templates/accounts/app_api_token_revoke.html:13
-#: oldp/apps/accounts/views.py:118
+#: oldp/apps/accounts/views.py:127
 msgid "Revoke API Token"
 msgstr "API-Token widerrufen"
 
@@ -791,7 +791,7 @@ msgstr "Ihr API-Zugriffstoken wurde erfolgreich erneuert."
 msgid "Token name is required."
 msgstr "Token-Name ist erforderlich."
 
-#: oldp/apps/accounts/views.py:84
+#: oldp/apps/accounts/views.py:93
 msgid ""
 "API token '{}' has been created successfully. Make sure to copy it now - you "
 "won't be able to see it again!"
@@ -799,21 +799,21 @@ msgstr ""
 "API-Token '{}' wurde erfolgreich erstellt. Kopieren Sie es jetzt - Sie "
 "können es später nicht mehr sehen!"
 
-#: oldp/apps/accounts/views.py:95
+#: oldp/apps/accounts/views.py:104
 msgid "Create API Token"
 msgstr "API-Token erstellen"
 
-#: oldp/apps/accounts/views.py:110
+#: oldp/apps/accounts/views.py:119
 msgid "API token '{}' has been revoked successfully."
 msgstr "API-Token '{}' wurde erfolgreich widerrufen."
 
-#: oldp/apps/cases/filters.py:27 oldp/apps/cases/filters.py:125
+#: oldp/apps/cases/filters.py:27 oldp/apps/cases/filters.py:145
 #: oldp/apps/cases/templates/cases/case.html:18
 #: oldp/apps/search/templates/search/facets.html:66
 msgid "Court"
 msgstr "Gericht"
 
-#: oldp/apps/cases/filters.py:34 oldp/apps/cases/filters.py:131
+#: oldp/apps/cases/filters.py:34 oldp/apps/cases/filters.py:151
 #: oldp/apps/cases/templates/cases/stats/base.html:80
 #: oldp/apps/courts/filters.py:16 oldp/apps/courts/filters.py:20
 #: oldp/apps/courts/filters.py:43 oldp/apps/courts/views.py:27
@@ -839,78 +839,78 @@ msgstr "Sachliche Zuständigkeit"
 msgid "Published on"
 msgstr "Erschienen am"
 
-#: oldp/apps/cases/filters.py:87 oldp/apps/cases/views.py:33
+#: oldp/apps/cases/filters.py:107 oldp/apps/cases/views.py:39
 #: oldp/apps/search/templates/search/facets.html:107
 msgid "Publication date"
 msgstr "Erscheinungsdatum"
 
-#: oldp/apps/cases/filters.py:88
+#: oldp/apps/cases/filters.py:108
 msgid "Last modified date"
 msgstr "Letzte Änderung"
 
-#: oldp/apps/cases/filters.py:89 oldp/apps/cases/templates/cases/case.html:39
-#: oldp/apps/cases/views.py:30
+#: oldp/apps/cases/filters.py:109 oldp/apps/cases/templates/cases/case.html:39
+#: oldp/apps/cases/views.py:36
 msgid "File number"
 msgstr "Aktenzeichen"
 
-#: oldp/apps/cases/models.py:198
+#: oldp/apps/cases/models.py:208
 msgid "Unknown topic"
 msgstr "Unbekanntes Thema"
 
-#: oldp/apps/cases/serializers.py:142
+#: oldp/apps/cases/serializers.py:153
 msgid "Court name cannot be empty."
 msgstr "Der Gerichtsname darf nicht leer sein."
 
-#: oldp/apps/cases/serializers.py:146
+#: oldp/apps/cases/serializers.py:157
 #, python-format
 msgid "Court name must not exceed %(max_length)s characters."
 msgstr "Der Gerichtsname darf %(max_length)s Zeichen nicht überschreiten."
 
-#: oldp/apps/cases/serializers.py:159
+#: oldp/apps/cases/serializers.py:170
 msgid "File number cannot be empty."
 msgstr "Das Aktenzeichen darf nicht leer sein."
 
-#: oldp/apps/cases/serializers.py:164
+#: oldp/apps/cases/serializers.py:175
 #, python-format
 msgid "File number must be at least %(min_length)s characters."
 msgstr "Das Aktenzeichen muss mindestens %(min_length)s Zeichen haben."
 
-#: oldp/apps/cases/serializers.py:169
+#: oldp/apps/cases/serializers.py:180
 #, python-format
 msgid "File number must not exceed %(max_length)s characters."
 msgstr "Das Aktenzeichen darf %(max_length)s Zeichen nicht überschreiten."
 
-#: oldp/apps/cases/serializers.py:182
+#: oldp/apps/cases/serializers.py:193
 msgid "Content cannot be empty."
 msgstr "Der Inhalt darf nicht leer sein."
 
-#: oldp/apps/cases/serializers.py:186 oldp/apps/laws/serializers.py:200
+#: oldp/apps/cases/serializers.py:197 oldp/apps/laws/serializers.py:223
 #, python-format
 msgid "Content must be at least %(min_length)s characters."
 msgstr "Der Inhalt muss mindestens %(min_length)s Zeichen haben."
 
-#: oldp/apps/cases/serializers.py:191 oldp/apps/laws/serializers.py:205
+#: oldp/apps/cases/serializers.py:202 oldp/apps/laws/serializers.py:228
 #, python-format
 msgid "Content must not exceed %(max_length)s characters."
 msgstr "Der Inhalt darf %(max_length)s Zeichen nicht überschreiten."
 
-#: oldp/apps/cases/serializers.py:207
+#: oldp/apps/cases/serializers.py:218
 #, python-format
 msgid "Title must not exceed %(max_length)s characters."
 msgstr "Der Titel darf %(max_length)s Zeichen nicht überschreiten."
 
-#: oldp/apps/cases/serializers.py:223
+#: oldp/apps/cases/serializers.py:234
 #, python-format
 msgid "Abstract must not exceed %(max_length)s characters."
 msgstr "Die Zusammenfassung darf %(max_length)s Zeichen nicht überschreiten."
 
-#: oldp/apps/cases/serializers.py:237
+#: oldp/apps/cases/serializers.py:248
 #, fuzzy
 #| msgid "Court name cannot be empty."
 msgid "Source name cannot be empty."
 msgstr "Der Gerichtsname darf nicht leer sein."
 
-#: oldp/apps/cases/serializers.py:242
+#: oldp/apps/cases/serializers.py:253
 #, fuzzy
 #| msgid "Court name must not exceed %(max_length)s characters."
 msgid "Source name must not exceed 100 characters."
@@ -996,11 +996,31 @@ msgstr "Dieser Inhalt sollte im Produktivbetrieb nicht sichtbar sein."
 msgid "btn_show_full_text"
 msgstr "Volltext anzeigen"
 
-#: oldp/apps/cases/templates/cases/case.html:188
+#: oldp/apps/cases/templates/cases/case.html:193
+msgid "Cited by"
+msgstr "Zitiert von"
+
+#: oldp/apps/cases/templates/cases/case.html:199
+#: oldp/apps/laws/templates/laws/references.html:48
+msgid "Open citing-cases search"
+msgstr "Suche nach zitierenden Entscheidungen öffnen"
+
+#: oldp/apps/cases/templates/cases/case.html:211
+#: oldp/apps/courts/templates/courts/cases_list.html:65
+#: oldp/apps/laws/templates/laws/references.html:60
+#, python-format
+msgid "Show all %(cases_count)s cases ..."
+msgstr "Alle %(cases_count)s Gerichtsentscheidungen anzeigen ..."
+
+#: oldp/apps/cases/templates/cases/case.html:217
+msgid "No other cases cite this decision yet."
+msgstr "Bislang zitiert keine andere Entscheidung dieses Urteil."
+
+#: oldp/apps/cases/templates/cases/case.html:222
 msgid "Related Cases"
 msgstr "Verwandte Urteile"
 
-#: oldp/apps/cases/templates/cases/case.html:195
+#: oldp/apps/cases/templates/cases/case.html:229
 #: oldp/apps/laws/templates/laws/law.html:53
 msgid "empty_related_content"
 msgstr "Keine verwandten Inhalte vorhanden."
@@ -1239,7 +1259,7 @@ msgstr "Einzelne Gerichte innerhalb eines Bundeslandes aufschlüsseln."
 msgid "See which data sources contribute the most cases."
 msgstr "Sehen Sie, welche Datenquellen die meisten Urteile beitragen."
 
-#: oldp/apps/cases/views.py:28
+#: oldp/apps/cases/views.py:34
 msgid "Case"
 msgstr "Urteil"
 
@@ -1349,24 +1369,18 @@ msgstr "ECLI-Code"
 msgid "View case statistics for courts in"
 msgstr "Urteilsstatistiken für Gerichte anzeigen in"
 
-#: oldp/apps/courts/templates/courts/cases_list.html:65
-#: oldp/apps/laws/templates/laws/references.html:46
-#, python-format
-msgid "Show all %(cases_count)s cases ..."
-msgstr "Alle %(cases_count)s Gerichtsentscheidungen anzeigen ..."
-
 #: oldp/apps/homepage/templates/errors/404.html:9
 #: oldp/apps/homepage/templates/errors/500.html:9
 #: oldp/apps/homepage/templates/errors/bad_request.html:9
 #: oldp/apps/homepage/templates/errors/permission_denied.html:9
-#: oldp/apps/homepage/views.py:62 oldp/apps/homepage/views.py:71
-#: oldp/apps/homepage/views.py:81 oldp/apps/homepage/views.py:92
-#: oldp/apps/search/templates/search/search.html:41
+#: oldp/apps/homepage/views.py:79 oldp/apps/homepage/views.py:88
+#: oldp/apps/homepage/views.py:98 oldp/apps/homepage/views.py:109
+#: oldp/apps/search/templates/search/search.html:65
 msgid "Error"
 msgstr "Fehler"
 
 #: oldp/apps/homepage/templates/errors/404.html:9
-#: oldp/apps/homepage/views.py:71
+#: oldp/apps/homepage/views.py:88
 msgid "Not found"
 msgstr "Nicht gefunden"
 
@@ -1390,7 +1404,7 @@ msgstr ""
 "benachrichtigt, um ihn wieder online zu bringen."
 
 #: oldp/apps/homepage/templates/errors/bad_request.html:9
-#: oldp/apps/homepage/views.py:92
+#: oldp/apps/homepage/views.py:109
 msgid "Bad request"
 msgstr "Ungültige Anfrage"
 
@@ -1399,7 +1413,7 @@ msgid "You sent an invalid request."
 msgstr "Sie haben eine ungültige Anfrage gesendet."
 
 #: oldp/apps/homepage/templates/errors/permission_denied.html:9
-#: oldp/apps/homepage/views.py:81
+#: oldp/apps/homepage/views.py:98
 msgid "Permission denied"
 msgstr "Zugriff verweigert"
 
@@ -1657,15 +1671,15 @@ msgstr "Blog"
 msgid "View all laws"
 msgstr "Alle Gesetze anzeigen"
 
-#: oldp/apps/homepage/views.py:50
+#: oldp/apps/homepage/views.py:67
 msgid "Free Access to Legal Data"
 msgstr "Freier Zugang zu juristischen Daten"
 
-#: oldp/apps/laws/models.py:25
+#: oldp/apps/laws/models.py:26
 msgid "Revision date cannot be in the future."
 msgstr "Das Revisionsdatum darf nicht in der Zukunft liegen."
 
-#: oldp/apps/laws/models.py:28
+#: oldp/apps/laws/models.py:29
 msgid "Revision date cannot be before 1800 (unreasonably old for German laws)."
 msgstr ""
 "Das Revisionsdatum darf nicht vor 1800 liegen (ungewöhnlich alt für deutsche "
@@ -1675,15 +1689,15 @@ msgstr ""
 msgid "Law"
 msgstr "Gesetz"
 
-#: oldp/apps/laws/serializers.py:104 oldp/apps/laws/serializers.py:183
+#: oldp/apps/laws/serializers.py:127 oldp/apps/laws/serializers.py:206
 msgid "Book code cannot be empty."
 msgstr "Der Buchcode darf nicht leer sein."
 
-#: oldp/apps/laws/serializers.py:110
+#: oldp/apps/laws/serializers.py:133
 msgid "Book title cannot be empty."
 msgstr "Der Buchtitel darf nicht leer sein."
 
-#: oldp/apps/laws/serializers.py:189
+#: oldp/apps/laws/serializers.py:212
 msgid "Section cannot be empty."
 msgstr "Der Abschnitt darf nicht leer sein."
 
@@ -1752,7 +1766,11 @@ msgstr "Dieses Dokument enthält keine Referenzen."
 msgid "Referenced by"
 msgstr "Zitiert von"
 
-#: oldp/apps/laws/views.py:110
+#: oldp/apps/laws/templates/laws/references.html:66
+msgid "No cases cite this section yet."
+msgstr "Bislang zitiert keine Entscheidung diese Vorschrift."
+
+#: oldp/apps/laws/views.py:111
 #, python-format
 msgid ""
 "The requested revision (%s) was not found. Showing instead the latest "
@@ -1827,16 +1845,52 @@ msgid "Law book"
 msgstr "Gesetzbuch"
 
 #: oldp/apps/search/templates/search/search.html:29
-#: oldp/apps/search/views.py:204 oldp/apps/search/views.py:244
+#: oldp/apps/search/views.py:303 oldp/apps/search/views.py:354
 msgid "Search"
 msgstr "Suche"
 
-#: oldp/apps/search/templates/search/search.html:47
+#: oldp/apps/search/templates/search/search.html:44
+msgid "Cases citing"
+msgstr "Entscheidungen, die folgendes zitieren:"
+
+#: oldp/apps/search/templates/search/search.html:46
+msgid "Cases citing case"
+msgstr "Entscheidungen, die folgendes Urteil zitieren:"
+
+#: oldp/apps/search/templates/search/search.html:51
+msgid "(unknown)"
+msgstr "(unbekannt)"
+
+#: oldp/apps/search/templates/search/search.html:54
+msgid "Remove filter"
+msgstr "Filter entfernen"
+
+#: oldp/apps/search/templates/search/search.html:72
+#, python-format
+msgid "%(count)s citing cases."
+msgstr "%(count)s zitierende Entscheidungen."
+
+#: oldp/apps/search/templates/search/search.html:74
 #, python-format
 msgid "%(count)s results sorted by <b>relevance</b>."
 msgstr "%(count)s Dokumente sortiert nach <b>Relevanz</b>."
 
-#: oldp/apps/search/views.py:206
+#: oldp/apps/search/utils.py:62
+msgid ""
+"Search backend is currently unavailable, so the list of citing cases cannot "
+"be loaded. Please try again later."
+msgstr ""
+"Die Suche ist derzeit nicht verfügbar; die Liste der zitierenden "
+"Entscheidungen kann momentan nicht geladen werden. Bitte versuchen Sie es "
+"später erneut."
+
+#: oldp/apps/search/views.py:293
+msgid ""
+"Search timed out. The first request after a cold start can be slow — please "
+"try again."
+msgstr ""
+
+#: oldp/apps/search/views.py:298
 #, fuzzy
 #| msgid "Search service is currently not available."
 msgid "Search is currently unavailable. Please try again later."
@@ -2179,75 +2233,10 @@ msgstr "%(start)s-%(end)s von > %(max_count)s Einträgen"
 msgid "%(start)s-%(end)s of %(count)s items"
 msgstr "%(start)s-%(end)s von %(count)s Einträgen"
 
-#: oldp/settings.py:243
+#: oldp/settings.py:258
 msgid "English"
 msgstr "Englisch"
 
-#: oldp/settings.py:244
+#: oldp/settings.py:259
 msgid "German"
 msgstr "Deutsch"
-
-#, python-format
-#~ msgid "Show all %(laws_count)s laws ..."
-#~ msgstr "Alle %(laws_count)s Gesetzestexte anzeigen ..."
-
-#~ msgid "You can access our API with the following access token:"
-#~ msgstr "Unsere API kann mit folgendem Schlüssel genutzt werden:"
-
-#~ msgid "You have a freshly created API access token."
-#~ msgstr "Ein neuer API-Schlüssel wurde erstellt."
-
-#~ msgid "or"
-#~ msgstr "oder"
-
-#~ msgid "Connected Accounts"
-#~ msgstr "Verbundene Konten"
-
-#~ msgid "Relevant Laws"
-#~ msgstr "Relevante Gesetze"
-
-#~ msgid "empty_references"
-#~ msgstr "Keine Referenzen gefunden"
-
-#, fuzzy
-#~| msgid "State"
-#~ msgid "States"
-#~ msgstr "Bundesland"
-
-#~ msgid "do_search"
-#~ msgstr "Suchen"
-
-#~ msgid "Recently Updated Laws"
-#~ msgstr "Zuletzt geänderte Gesetze"
-
-#~ msgid "All results"
-#~ msgstr "Alle Ergebnisse"
-
-#~ msgid "No related cases found."
-#~ msgstr "Keine verwandten Urteile gefunden."
-
-#, fuzzy
-#~| msgid "No related cases found."
-#~ msgid "No related laws found."
-#~ msgstr "Keine verwandten Urteile gefunden."
-
-#~ msgid "Topics"
-#~ msgstr "Themen"
-
-#~ msgid "Disclaimer"
-#~ msgstr "Haftungsausschluss"
-
-#~ msgid "About The Project"
-#~ msgstr "Über das Projekt"
-
-#~ msgid "Open Legal Data Platform"
-#~ msgstr "Open Legal Data Plattform"
-
-#~ msgid "Law, Keyword, ..."
-#~ msgstr "Paragraph, Suchbegriff, ..."
-
-#~ msgid "Legal Search Engine"
-#~ msgstr "Juristische Suchmaschine"
-
-#~ msgid "This law does not contain any references."
-#~ msgstr "Dieses Gesetz enthält keine Referenzen."

--- a/oldp/locale/de/LC_MESSAGES/django.po
+++ b/oldp/locale/de/LC_MESSAGES/django.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2026-05-28 12:00+0000\n"
+"POT-Creation-Date: 2026-05-28 13:41+0000\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -1875,7 +1875,7 @@ msgstr "%(count)s zitierende Entscheidungen."
 msgid "%(count)s results sorted by <b>relevance</b>."
 msgstr "%(count)s Dokumente sortiert nach <b>Relevanz</b>."
 
-#: oldp/apps/search/utils.py:62
+#: oldp/apps/search/utils.py:119
 msgid ""
 "Search backend is currently unavailable, so the list of citing cases cannot "
 "be loaded. Please try again later."

--- a/oldp/locale/en/LC_MESSAGES/django.po
+++ b/oldp/locale/en/LC_MESSAGES/django.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2026-05-28 12:03+0000\n"
+"POT-Creation-Date: 2026-05-28 13:41+0000\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -1717,7 +1717,7 @@ msgstr ""
 msgid "%(count)s results sorted by <b>relevance</b>."
 msgstr ""
 
-#: oldp/apps/search/utils.py:62
+#: oldp/apps/search/utils.py:119
 msgid ""
 "Search backend is currently unavailable, so the list of citing cases cannot "
 "be loaded. Please try again later."

--- a/oldp/locale/en/LC_MESSAGES/django.po
+++ b/oldp/locale/en/LC_MESSAGES/django.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2019-03-18 19:39+0000\n"
+"POT-Creation-Date: 2026-05-28 12:03+0000\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -16,66 +16,841 @@ msgstr ""
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
 
-#: oldp/apps/accounts/templates/accounts/api.html:6
-#: oldp/assets/templates/account/base.html:17
-#: oldp/assets/templates/header.html:50
-msgid "API Keys"
+#: oldp/apps/accounts/admin.py:29
+msgid "Permission Details"
 msgstr ""
 
-#: oldp/apps/accounts/templates/accounts/api.html:12
-msgid "You can access our API with the following access token:"
+#: oldp/apps/accounts/admin.py:36
+msgid "Permission"
+msgstr ""
+
+#: oldp/apps/accounts/admin.py:49 oldp/apps/accounts/models.py:45
+#: oldp/apps/accounts/models.py:78
+msgid "Description"
+msgstr ""
+
+#: oldp/apps/accounts/admin.py:56
+msgid "Used in {} permission group(s)"
+msgstr ""
+
+#: oldp/apps/accounts/admin.py:60
+msgid "Usage"
+msgstr ""
+
+#: oldp/apps/accounts/admin.py:81
+msgid "Group Information"
+msgstr ""
+
+#: oldp/apps/accounts/admin.py:83 oldp/apps/accounts/admin.py:106
+#: oldp/apps/accounts/admin.py:223 oldp/apps/accounts/models.py:85
+msgid "Permissions"
+msgstr ""
+
+#: oldp/apps/accounts/admin.py:87
+msgid "Select the permissions that tokens in this group will have access to."
+msgstr ""
+
+#: oldp/apps/accounts/admin.py:91 oldp/apps/accounts/admin.py:233
+msgid "Timestamps"
+msgstr ""
+
+#: oldp/apps/accounts/admin.py:102
+msgid "No permissions"
+msgstr ""
+
+#: oldp/apps/accounts/admin.py:117
+msgid "Tokens"
+msgstr ""
+
+#: oldp/apps/accounts/admin.py:147 oldp/apps/accounts/admin.py:242
+#: oldp/apps/accounts/models.py:201
+msgid "API Token"
+msgstr ""
+
+#: oldp/apps/accounts/admin.py:160 oldp/apps/accounts/admin.py:255
+#: oldp/apps/accounts/models.py:139
+msgid "User"
+msgstr ""
+
+#: oldp/apps/accounts/admin.py:167
+msgid "Are you sure you want to revoke this token?"
+msgstr ""
+
+#: oldp/apps/accounts/admin.py:168
+#: oldp/apps/accounts/templates/accounts/app_api_tokens.html:125
+msgid "Revoke"
+msgstr ""
+
+#: oldp/apps/accounts/admin.py:171
+msgid "Actions"
+msgstr ""
+
+#: oldp/apps/accounts/admin.py:180 oldp/apps/accounts/admin.py:299
+msgid "{} token(s) were successfully revoked."
+msgstr ""
+
+#: oldp/apps/accounts/admin.py:183 oldp/apps/accounts/admin.py:302
+msgid "Revoke selected tokens"
+msgstr ""
+
+#: oldp/apps/accounts/admin.py:185 oldp/apps/accounts/admin.py:221
+msgid "Token Information"
+msgstr ""
+
+#: oldp/apps/accounts/admin.py:227
+msgid ""
+"Permission group defines what resources this token can access. Legacy scopes "
+"field is deprecated."
+msgstr ""
+
+#: oldp/apps/accounts/admin.py:232 oldp/assets/templates/account/email.html:25
+msgid "Status"
+msgstr ""
+
+#: oldp/apps/accounts/admin.py:267
+msgid "No group (legacy)"
+msgstr ""
+
+#: oldp/apps/accounts/admin.py:270 oldp/apps/accounts/models.py:177
+msgid "Permission Group"
+msgstr ""
+
+#: oldp/apps/accounts/admin.py:277
+msgid "Default"
+msgstr ""
+
+#: oldp/apps/accounts/admin.py:279 oldp/apps/accounts/models.py:191
+msgid "Rate Limit"
+msgstr ""
+
+#: oldp/apps/accounts/admin.py:285
+#: oldp/apps/accounts/templates/accounts/app_api_token_revoke.html:43
+#: oldp/apps/accounts/templates/accounts/app_api_tokens.html:116
+msgid "Expired"
+msgstr ""
+
+#: oldp/apps/accounts/admin.py:287
+msgid "Valid"
+msgstr ""
+
+#: oldp/apps/accounts/admin.py:288
+#: oldp/apps/accounts/templates/accounts/app_api_tokens.html:109
+#: oldp/apps/accounts/templates/accounts/personal_api_tokens.html:60
+msgid "Never"
+msgstr ""
+
+#: oldp/apps/accounts/admin.py:290
+msgid "Expiration Status"
+msgstr ""
+
+#: oldp/apps/accounts/admin.py:308
+msgid "{} token(s) were successfully activated."
+msgstr ""
+
+#: oldp/apps/accounts/admin.py:311
+msgid "Activate selected tokens"
+msgstr ""
+
+#: oldp/apps/accounts/admin.py:317
+msgid "{} token(s) were successfully deactivated."
+msgstr ""
+
+#: oldp/apps/accounts/admin.py:320
+msgid "Deactivate selected tokens"
+msgstr ""
+
+#: oldp/apps/accounts/authentication.py:50
+msgid "Invalid token."
+msgstr ""
+
+#: oldp/apps/accounts/authentication.py:53
+msgid "Token is inactive."
+msgstr ""
+
+#: oldp/apps/accounts/authentication.py:56
+msgid "Token has expired."
+msgstr ""
+
+#: oldp/apps/accounts/authentication.py:59
+msgid "User inactive or deleted."
+msgstr ""
+
+#: oldp/apps/accounts/models.py:18
+#: oldp/apps/cases/templates/cases/case.html:140
+#: oldp/apps/cases/templates/cases/case_filter.html:47
+#: oldp/apps/cases/templates/cases/index.html:9
+#: oldp/apps/cases/templates/cases/stats/base.html:113
+#: oldp/apps/cases/views.py:76
+#: oldp/apps/courts/templates/courts/cases_list.html:55
+#: oldp/assets/templates/admin/index.html:20
+#: oldp/assets/templates/header.html:18
+msgid "Cases"
+msgstr ""
+
+#: oldp/apps/accounts/models.py:19 oldp/apps/laws/templates/laws/index.html:9
+#: oldp/apps/laws/templates/laws/law.html:90 oldp/apps/laws/views.py:71
+#: oldp/assets/templates/admin/index.html:24
+#: oldp/assets/templates/header.html:31
+msgid "Laws"
+msgstr ""
+
+#: oldp/apps/accounts/models.py:20
+#: oldp/apps/courts/templates/courts/cases_list.html:13
+#: oldp/apps/courts/templates/courts/court_filter.html:41
+#: oldp/apps/courts/views.py:48 oldp/assets/templates/admin/index.html:32
+#: oldp/assets/templates/header.html:24
+msgid "Courts"
+msgstr ""
+
+#: oldp/apps/accounts/models.py:21 oldp/assets/templates/admin/index.html:28
+msgid "Law Books"
+msgstr ""
+
+#: oldp/apps/accounts/models.py:22
+#: oldp/apps/laws/templates/laws/references.html:5
+#: oldp/apps/references/templates/references.html:5
+msgid "References"
+msgstr ""
+
+#: oldp/apps/accounts/models.py:23
+msgid "Annotations"
+msgstr ""
+
+#: oldp/apps/accounts/models.py:27
+msgid "Read"
+msgstr ""
+
+#: oldp/apps/accounts/models.py:28
+msgid "Write"
+msgstr ""
+
+#: oldp/apps/accounts/models.py:29
+msgid "Delete"
+msgstr ""
+
+#: oldp/apps/accounts/models.py:33
+msgid "Resource"
+msgstr ""
+
+#: oldp/apps/accounts/models.py:36
+msgid "The resource this permission applies to"
+msgstr ""
+
+#: oldp/apps/accounts/models.py:39
+msgid "Action"
+msgstr ""
+
+#: oldp/apps/accounts/models.py:42
+msgid "The action allowed on this resource"
+msgstr ""
+
+#: oldp/apps/accounts/models.py:47
+msgid "Optional description of what this permission allows"
+msgstr ""
+
+#: oldp/apps/accounts/models.py:51
+msgid "API Token Permission"
+msgstr ""
+
+#: oldp/apps/accounts/models.py:52
+msgid "API Token Permissions"
+msgstr ""
+
+#: oldp/apps/accounts/models.py:72 oldp/apps/accounts/models.py:143
+#: oldp/apps/cases/templates/cases/stats/base.html:171
+#: oldp/apps/lib/tests/test_filters.py:77
+msgid "Name"
+msgstr ""
+
+#: oldp/apps/accounts/models.py:75
+msgid "Unique name for this permission group"
+msgstr ""
+
+#: oldp/apps/accounts/models.py:80
+msgid "Description of what this permission group allows"
+msgstr ""
+
+#: oldp/apps/accounts/models.py:87
+msgid "Permissions included in this group"
+msgstr ""
+
+#: oldp/apps/accounts/models.py:90
+msgid "Is Default"
+msgstr ""
+
+#: oldp/apps/accounts/models.py:92
+msgid "Whether this is the default permission group for new tokens"
+msgstr ""
+
+#: oldp/apps/accounts/models.py:94 oldp/apps/accounts/models.py:152
+msgid "Created"
+msgstr ""
+
+#: oldp/apps/accounts/models.py:95
+msgid "Updated"
+msgstr ""
+
+#: oldp/apps/accounts/models.py:98
+msgid "API Token Permission Group"
+msgstr ""
+
+#: oldp/apps/accounts/models.py:99
+msgid "API Token Permission Groups"
+msgstr ""
+
+#: oldp/apps/accounts/models.py:129
+msgid "Key"
+msgstr ""
+
+#: oldp/apps/accounts/models.py:133
+msgid "The API token key"
+msgstr ""
+
+#: oldp/apps/accounts/models.py:140
+msgid "The user this token belongs to"
+msgstr ""
+
+#: oldp/apps/accounts/models.py:146
+msgid ""
+"A descriptive name for this token (e.g., 'Production Server', 'CI/CD "
+"Pipeline')"
+msgstr ""
+
+#: oldp/apps/accounts/models.py:152
+msgid "When this token was created"
+msgstr ""
+
+#: oldp/apps/accounts/models.py:155
+msgid "Last used"
+msgstr ""
+
+#: oldp/apps/accounts/models.py:158
+msgid "When this token was last used"
+msgstr ""
+
+#: oldp/apps/accounts/models.py:161
+msgid "Expires at"
+msgstr ""
+
+#: oldp/apps/accounts/models.py:164
+msgid "When this token expires (null = never expires)"
+msgstr ""
+
+#: oldp/apps/accounts/models.py:169
+#: oldp/apps/accounts/templates/accounts/app_api_token_revoke.html:45
+#: oldp/apps/accounts/templates/accounts/app_api_tokens.html:118
+msgid "Active"
+msgstr ""
+
+#: oldp/apps/accounts/models.py:169
+msgid "Whether this token is currently active"
+msgstr ""
+
+#: oldp/apps/accounts/models.py:179
+msgid ""
+"The permission group assigned to this token (defines what resources it can "
+"access)"
+msgstr ""
+
+#: oldp/apps/accounts/models.py:183
+msgid "Scopes"
+msgstr ""
+
+#: oldp/apps/accounts/models.py:187
+msgid ""
+"Deprecated: Use permission_group instead. List of scopes this token has "
+"access to"
+msgstr ""
+
+#: oldp/apps/accounts/models.py:195
+msgid ""
+"Custom rate limit in requests per hour for this token. Leave blank to use "
+"the default rate."
+msgstr ""
+
+#: oldp/apps/accounts/models.py:202 oldp/apps/accounts/views.py:53
+msgid "API Tokens"
+msgstr ""
+
+#: oldp/apps/accounts/templates/accounts/app_api_token_create.html:5
+msgid "Create Application API Token"
+msgstr ""
+
+#: oldp/apps/accounts/templates/accounts/app_api_token_create.html:12
+msgid "Create New API Token"
+msgstr ""
+
+#: oldp/apps/accounts/templates/accounts/app_api_token_create.html:13
+msgid "Create a new API token for accessing the API from your applications."
+msgstr ""
+
+#: oldp/apps/accounts/templates/accounts/app_api_token_create.html:19
+#: oldp/apps/accounts/templates/accounts/app_api_tokens.html:47
+msgid "Close"
+msgstr ""
+
+#: oldp/apps/accounts/templates/accounts/app_api_token_create.html:31
+msgid "Token Name"
+msgstr ""
+
+#: oldp/apps/accounts/templates/accounts/app_api_token_create.html:39
+msgid "e.g., Production Server, CI/CD Pipeline, Development"
+msgstr ""
+
+#: oldp/apps/accounts/templates/accounts/app_api_token_create.html:43
+msgid "Give your token a descriptive name to remember what it's used for."
+msgstr ""
+
+#: oldp/apps/accounts/templates/accounts/app_api_token_create.html:49
+msgid "Expiration"
+msgstr ""
+
+#: oldp/apps/accounts/templates/accounts/app_api_token_create.html:52
+msgid "30 days"
+msgstr ""
+
+#: oldp/apps/accounts/templates/accounts/app_api_token_create.html:53
+msgid "90 days"
+msgstr ""
+
+#: oldp/apps/accounts/templates/accounts/app_api_token_create.html:54
+msgid "6 months"
+msgstr ""
+
+#: oldp/apps/accounts/templates/accounts/app_api_token_create.html:55
+msgid "1 year"
+msgstr ""
+
+#: oldp/apps/accounts/templates/accounts/app_api_token_create.html:56
+msgid "2 years"
+msgstr ""
+
+#: oldp/apps/accounts/templates/accounts/app_api_token_create.html:57
+msgid "Never expires"
+msgstr ""
+
+#: oldp/apps/accounts/templates/accounts/app_api_token_create.html:60
+msgid ""
+"Choose when this token should expire. Tokens that expire improve security."
+msgstr ""
+
+#: oldp/apps/accounts/templates/accounts/app_api_token_create.html:65
+msgid "Important:"
+msgstr ""
+
+#: oldp/apps/accounts/templates/accounts/app_api_token_create.html:66
+msgid ""
+"The token will be shown only once after creation. Make sure to copy it and "
+"store it securely!"
+msgstr ""
+
+#: oldp/apps/accounts/templates/accounts/app_api_token_create.html:71
+#: oldp/apps/accounts/templates/accounts/app_api_token_revoke.html:68
+msgid "Cancel"
+msgstr ""
+
+#: oldp/apps/accounts/templates/accounts/app_api_token_create.html:75
+msgid "Create Token"
+msgstr ""
+
+#: oldp/apps/accounts/templates/accounts/app_api_token_create.html:84
+msgid "Best Practices"
+msgstr ""
+
+#: oldp/apps/accounts/templates/accounts/app_api_token_create.html:88
+msgid "Use descriptive names for easy identification"
+msgstr ""
+
+#: oldp/apps/accounts/templates/accounts/app_api_token_create.html:89
+msgid "Create separate tokens for different applications or environments"
+msgstr ""
+
+#: oldp/apps/accounts/templates/accounts/app_api_token_create.html:90
+msgid "Set an expiration date for better security"
+msgstr ""
+
+#: oldp/apps/accounts/templates/accounts/app_api_token_create.html:91
+msgid "Revoke tokens immediately if they are compromised"
+msgstr ""
+
+#: oldp/apps/accounts/templates/accounts/app_api_token_create.html:92
+msgid "Never share tokens publicly or commit them to version control"
+msgstr ""
+
+#: oldp/apps/accounts/templates/accounts/app_api_token_create.html:93
+msgid "Rotate tokens periodically for enhanced security"
+msgstr ""
+
+#: oldp/apps/accounts/templates/accounts/app_api_token_revoke.html:5
+#: oldp/apps/accounts/templates/accounts/app_api_token_revoke.html:13
+#: oldp/apps/accounts/views.py:127
+msgid "Revoke API Token"
+msgstr ""
+
+#: oldp/apps/accounts/templates/accounts/app_api_token_revoke.html:14
+msgid "Are you sure you want to revoke this API token?"
+msgstr ""
+
+#: oldp/apps/accounts/templates/accounts/app_api_token_revoke.html:19
+msgid "Warning: This action cannot be undone"
+msgstr ""
+
+#: oldp/apps/accounts/templates/accounts/app_api_token_revoke.html:23
+msgid "Token Name:"
+msgstr ""
+
+#: oldp/apps/accounts/templates/accounts/app_api_token_revoke.html:26
+msgid "Token Key:"
+msgstr ""
+
+#: oldp/apps/accounts/templates/accounts/app_api_token_revoke.html:31
+#: oldp/apps/accounts/templates/accounts/app_api_tokens.html:99
+#: oldp/apps/accounts/templates/accounts/personal_api_tokens.html:57
+msgid "Created:"
+msgstr ""
+
+#: oldp/apps/accounts/templates/accounts/app_api_token_revoke.html:35
+#: oldp/apps/accounts/templates/accounts/app_api_tokens.html:105
+msgid "Last Used:"
+msgstr ""
+
+#: oldp/apps/accounts/templates/accounts/app_api_token_revoke.html:39
+msgid "Status:"
+msgstr ""
+
+#: oldp/apps/accounts/templates/accounts/app_api_token_revoke.html:48
+#: oldp/apps/accounts/templates/accounts/app_api_tokens.html:121
+msgid "Inactive"
+msgstr ""
+
+#: oldp/apps/accounts/templates/accounts/app_api_token_revoke.html:54
+msgid "What happens when you revoke this token?"
+msgstr ""
+
+#: oldp/apps/accounts/templates/accounts/app_api_token_revoke.html:56
+msgid "This token will be permanently deleted"
+msgstr ""
+
+#: oldp/apps/accounts/templates/accounts/app_api_token_revoke.html:57
+msgid "Any applications using this token will lose API access"
+msgstr ""
+
+#: oldp/apps/accounts/templates/accounts/app_api_token_revoke.html:58
+msgid "You will need to create a new token and update your applications"
+msgstr ""
+
+#: oldp/apps/accounts/templates/accounts/app_api_token_revoke.html:59
+msgid "This action cannot be undone"
+msgstr ""
+
+#: oldp/apps/accounts/templates/accounts/app_api_token_revoke.html:71
+msgid "Yes, Revoke This Token"
+msgstr ""
+
+#: oldp/apps/accounts/templates/accounts/app_api_token_revoke.html:80
+msgid "Alternative Actions"
+msgstr ""
+
+#: oldp/apps/accounts/templates/accounts/app_api_token_revoke.html:83
+msgid "If you\\"
+msgstr ""
+
+#: oldp/apps/accounts/templates/accounts/app_api_token_revoke.html:85
+msgid "Temporarily deactivate the token instead of deleting it (contact admin)"
+msgstr ""
+
+#: oldp/apps/accounts/templates/accounts/app_api_token_revoke.html:86
+msgid "Check when this token was last used to determine if it\\"
+msgstr ""
+
+#: oldp/apps/accounts/templates/accounts/app_api_token_revoke.html:87
+msgid ""
+"Update your applications to use a different token before revoking this one"
+msgstr ""
+
+#: oldp/apps/accounts/templates/accounts/app_api_token_revoke.html:88
+msgid "Create a new token with a different name if you need to reorganize"
+msgstr ""
+
+#: oldp/apps/accounts/templates/accounts/app_api_tokens.html:5
+msgid "Application API Tokens"
+msgstr ""
+
+#: oldp/apps/accounts/templates/accounts/app_api_tokens.html:12
+msgid "Manage Application API Tokens"
+msgstr ""
+
+#: oldp/apps/accounts/templates/accounts/app_api_tokens.html:13
+msgid ""
+"Create and manage multiple API tokens for different applications and "
+"services."
+msgstr ""
+
+#: oldp/apps/accounts/templates/accounts/app_api_tokens.html:27
+msgid "New Token Created!"
+msgstr ""
+
+#: oldp/apps/accounts/templates/accounts/app_api_tokens.html:28
+msgid "Make sure to copy your new API token now. You won\\"
+msgstr ""
+
+#: oldp/apps/accounts/templates/accounts/app_api_tokens.html:44
+#: oldp/apps/accounts/templates/accounts/app_api_tokens.html:60
+#: oldp/apps/accounts/templates/accounts/app_api_tokens.html:68
+#: oldp/apps/accounts/templates/accounts/personal_api_tokens.html:47
+#: oldp/apps/accounts/templates/accounts/personal_api_tokens.html:163
+msgid "Copy"
+msgstr ""
+
+#: oldp/apps/accounts/templates/accounts/app_api_tokens.html:58
+#: oldp/apps/accounts/templates/accounts/app_api_tokens.html:66
+#: oldp/apps/accounts/templates/accounts/personal_api_tokens.html:159
+msgid "Copied!"
+msgstr ""
+
+#: oldp/apps/accounts/templates/accounts/app_api_tokens.html:77
+msgid "Create New Token"
+msgstr ""
+
+#: oldp/apps/accounts/templates/accounts/app_api_tokens.html:80
+msgid "Back to Personal Tokens"
+msgstr ""
+
+#: oldp/apps/accounts/templates/accounts/app_api_tokens.html:87
+msgid "Your API Tokens"
+msgstr ""
+
+#: oldp/apps/accounts/templates/accounts/app_api_tokens.html:133
+#: oldp/apps/accounts/templates/accounts/personal_api_tokens.html:60
+msgid "Expires:"
+msgstr ""
+
+#: oldp/apps/accounts/templates/accounts/app_api_tokens.html:144
+msgid "You don\\"
+msgstr ""
+
+#: oldp/apps/accounts/templates/accounts/app_api_tokens.html:149
+#: oldp/apps/accounts/templates/accounts/personal_api_tokens.html:67
+msgid "Usage Example:"
+msgstr ""
+
+#: oldp/apps/accounts/templates/accounts/personal_api_tokens.html:5
+#: oldp/apps/accounts/templates/accounts/personal_api_tokens.html:12
+msgid "Personal API Tokens"
+msgstr ""
+
+#: oldp/apps/accounts/templates/accounts/personal_api_tokens.html:13
+msgid ""
+"Use this token to authenticate API requests. Keep it secure and never share "
+"it publicly."
+msgstr ""
+
+#: oldp/apps/accounts/templates/accounts/personal_api_tokens.html:19
+msgid "Your API Token:"
+msgstr ""
+
+#: oldp/apps/accounts/templates/accounts/personal_api_tokens.html:35
+msgid "Show/Hide Token"
+msgstr ""
+
+#: oldp/apps/accounts/templates/accounts/personal_api_tokens.html:38
+#: oldp/apps/accounts/templates/accounts/personal_api_tokens.html:100
+msgid "Show"
+msgstr ""
+
+#: oldp/apps/accounts/templates/accounts/personal_api_tokens.html:45
+msgid "Copy to Clipboard"
+msgstr ""
+
+#: oldp/apps/accounts/templates/accounts/personal_api_tokens.html:51
+msgid "Token copied to clipboard!"
+msgstr ""
+
+#: oldp/apps/accounts/templates/accounts/personal_api_tokens.html:57
+msgid "When you registered"
+msgstr ""
+
+#: oldp/apps/accounts/templates/accounts/personal_api_tokens.html:72
+msgid ""
+"Are you sure you want to renew your token? Your old token will stop working "
+"immediately."
+msgstr ""
+
+#: oldp/apps/accounts/templates/accounts/personal_api_tokens.html:73
+msgid "Renew Token"
+msgstr ""
+
+#: oldp/apps/accounts/templates/accounts/personal_api_tokens.html:76
+msgid "API Documentation"
+msgstr ""
+
+#: oldp/apps/accounts/templates/accounts/personal_api_tokens.html:81
+msgid "Security Warning:"
+msgstr ""
+
+#: oldp/apps/accounts/templates/accounts/personal_api_tokens.html:81
+msgid ""
+"Renewing your token will invalidate your current token immediately. Make "
+"sure to update all applications using the old token."
+msgstr ""
+
+#: oldp/apps/accounts/templates/accounts/personal_api_tokens.html:107
+msgid "Hide"
+msgstr ""
+
+#: oldp/apps/accounts/templates/accounts/personal_api_tokens.html:147
+msgid "Failed to copy token. Please copy it manually."
+msgstr ""
+
+#: oldp/apps/accounts/templates/accounts/profile.html:9
+msgid "Profile"
 msgstr ""
 
 #: oldp/apps/accounts/views.py:31
-msgid "You have a freshly created API access token."
+msgid "Your API access token has been renewed successfully."
 msgstr ""
 
-#: oldp/apps/cases/filters.py:25 oldp/apps/cases/filters.py:131
+#: oldp/apps/accounts/views.py:67
+msgid "Token name is required."
+msgstr ""
+
+#: oldp/apps/accounts/views.py:93
+msgid ""
+"API token '{}' has been created successfully. Make sure to copy it now - you "
+"won't be able to see it again!"
+msgstr ""
+
+#: oldp/apps/accounts/views.py:104
+msgid "Create API Token"
+msgstr ""
+
+#: oldp/apps/accounts/views.py:119
+msgid "API token '{}' has been revoked successfully."
+msgstr ""
+
+#: oldp/apps/cases/filters.py:27 oldp/apps/cases/filters.py:145
 #: oldp/apps/cases/templates/cases/case.html:18
-#: oldp/apps/search/templates/search/facets.html:74
+#: oldp/apps/search/templates/search/facets.html:66
 msgid "Court"
 msgstr ""
 
-#: oldp/apps/cases/filters.py:32 oldp/apps/cases/filters.py:138
-#: oldp/apps/courts/filters.py:16 oldp/apps/courts/filters.py:21
-#: oldp/apps/courts/filters.py:52 oldp/apps/courts/views.py:31
+#: oldp/apps/cases/filters.py:34 oldp/apps/cases/filters.py:151
+#: oldp/apps/cases/templates/cases/stats/base.html:80
+#: oldp/apps/courts/filters.py:16 oldp/apps/courts/filters.py:20
+#: oldp/apps/courts/filters.py:43 oldp/apps/courts/views.py:27
 msgid "State"
 msgstr ""
 
-#: oldp/apps/cases/filters.py:38 oldp/apps/cases/filters.py:40
+#: oldp/apps/cases/filters.py:40 oldp/apps/cases/filters.py:45
 msgid "Has reference to"
 msgstr ""
 
-#: oldp/apps/cases/filters.py:46 oldp/apps/courts/filters.py:27
-#: oldp/apps/search/templates/search/facets.html:87
+#: oldp/apps/cases/filters.py:52 oldp/apps/courts/filters.py:26
+#: oldp/apps/search/templates/search/facets.html:79
 msgid "Jurisdiction"
 msgstr ""
 
-#: oldp/apps/cases/filters.py:55 oldp/apps/courts/filters.py:37
-#: oldp/apps/search/templates/search/facets.html:100
+#: oldp/apps/cases/filters.py:57 oldp/apps/courts/filters.py:32
+#: oldp/apps/search/templates/search/facets.html:92
 msgid "Level of Appeal"
 msgstr ""
 
-#: oldp/apps/cases/filters.py:65 oldp/apps/cases/templates/cases/case.html:35
+#: oldp/apps/cases/filters.py:63 oldp/apps/cases/templates/cases/case.html:35
+#: oldp/apps/homepage/templates/homepage/landing_page.html:103
 msgid "Published on"
 msgstr ""
 
-#: oldp/apps/cases/filters.py:92 oldp/apps/cases/views.py:25
-#: oldp/apps/search/templates/search/facets.html:112
+#: oldp/apps/cases/filters.py:107 oldp/apps/cases/views.py:39
+#: oldp/apps/search/templates/search/facets.html:107
 msgid "Publication date"
 msgstr ""
 
-#: oldp/apps/cases/filters.py:93
+#: oldp/apps/cases/filters.py:108
 msgid "Last modified date"
 msgstr ""
 
-#: oldp/apps/cases/filters.py:94 oldp/apps/cases/templates/cases/case.html:39
-#: oldp/apps/cases/views.py:24
+#: oldp/apps/cases/filters.py:109 oldp/apps/cases/templates/cases/case.html:39
+#: oldp/apps/cases/views.py:36
 msgid "File number"
 msgstr ""
 
-#: oldp/apps/cases/models.py:186
+#: oldp/apps/cases/models.py:208
 msgid "Unknown topic"
+msgstr ""
+
+#: oldp/apps/cases/serializers.py:153
+msgid "Court name cannot be empty."
+msgstr ""
+
+#: oldp/apps/cases/serializers.py:157
+#, python-format
+msgid "Court name must not exceed %(max_length)s characters."
+msgstr ""
+
+#: oldp/apps/cases/serializers.py:170
+msgid "File number cannot be empty."
+msgstr ""
+
+#: oldp/apps/cases/serializers.py:175
+#, python-format
+msgid "File number must be at least %(min_length)s characters."
+msgstr ""
+
+#: oldp/apps/cases/serializers.py:180
+#, python-format
+msgid "File number must not exceed %(max_length)s characters."
+msgstr ""
+
+#: oldp/apps/cases/serializers.py:193
+msgid "Content cannot be empty."
+msgstr ""
+
+#: oldp/apps/cases/serializers.py:197 oldp/apps/laws/serializers.py:223
+#, python-format
+msgid "Content must be at least %(min_length)s characters."
+msgstr ""
+
+#: oldp/apps/cases/serializers.py:202 oldp/apps/laws/serializers.py:228
+#, python-format
+msgid "Content must not exceed %(max_length)s characters."
+msgstr ""
+
+#: oldp/apps/cases/serializers.py:218
+#, python-format
+msgid "Title must not exceed %(max_length)s characters."
+msgstr ""
+
+#: oldp/apps/cases/serializers.py:234
+#, python-format
+msgid "Abstract must not exceed %(max_length)s characters."
+msgstr ""
+
+#: oldp/apps/cases/serializers.py:248
+msgid "Source name cannot be empty."
+msgstr ""
+
+#: oldp/apps/cases/serializers.py:253
+msgid "Source name must not exceed 100 characters."
+msgstr ""
+
+#: oldp/apps/cases/stats_views.py:40
+msgid "Case Statistics"
+msgstr ""
+
+#: oldp/apps/cases/stats_views.py:49
+msgid "Cases by Country"
+msgstr ""
+
+#: oldp/apps/cases/stats_views.py:58
+msgid "Cases by State"
+msgstr ""
+
+#: oldp/apps/cases/stats_views.py:67
+msgid "Cases by Court"
+msgstr ""
+
+#: oldp/apps/cases/stats_views.py:86
+msgid "Cases by Source"
 msgstr ""
 
 #: oldp/apps/cases/templates/cases/case.html:24
@@ -83,7 +858,7 @@ msgid "Court chamber"
 msgstr ""
 
 #: oldp/apps/cases/templates/cases/case.html:30
-#: oldp/apps/search/templates/search/facets.html:61
+#: oldp/apps/search/templates/search/facets.html:53
 msgid "Decision type"
 msgstr ""
 
@@ -103,7 +878,12 @@ msgstr ""
 msgid "PDF"
 msgstr ""
 
+#: oldp/apps/cases/templates/cases/case.html:57
+msgid "Download"
+msgstr ""
+
 #: oldp/apps/cases/templates/cases/case.html:63
+#: oldp/apps/laws/templates/laws/law.html:72
 msgid "API"
 msgstr ""
 
@@ -116,17 +896,11 @@ msgid "Short-URL"
 msgstr ""
 
 #: oldp/apps/cases/templates/cases/case.html:137
+#: oldp/apps/cases/templates/cases/stats/base.html:110
 #: oldp/apps/courts/templates/courts/cases_list.html:10
-#: oldp/apps/laws/templates/laws/law.html:80
+#: oldp/apps/laws/templates/laws/law.html:87
+#: oldp/apps/processing/templates/admin/processing/dashboard.html:8
 msgid "Home"
-msgstr ""
-
-#: oldp/apps/cases/templates/cases/case.html:140
-#: oldp/apps/cases/templates/cases/case_filter.html:71
-#: oldp/apps/cases/templates/cases/index.html:9 oldp/apps/cases/views.py:46
-#: oldp/apps/courts/templates/courts/cases_list.html:49
-#: oldp/assets/templates/header.html:25
-msgid "Cases"
 msgstr ""
 
 #: oldp/apps/cases/templates/cases/case.html:158
@@ -137,96 +911,325 @@ msgstr "This content should not be accessible in production mode."
 msgid "btn_show_full_text"
 msgstr "Show full text"
 
-#: oldp/apps/cases/templates/cases/case.html:188
+#: oldp/apps/cases/templates/cases/case.html:193
+msgid "Cited by"
+msgstr ""
+
+#: oldp/apps/cases/templates/cases/case.html:199
+#: oldp/apps/laws/templates/laws/references.html:48
+msgid "Open citing-cases search"
+msgstr ""
+
+#: oldp/apps/cases/templates/cases/case.html:211
+#: oldp/apps/courts/templates/courts/cases_list.html:65
+#: oldp/apps/laws/templates/laws/references.html:60
+#, python-format
+msgid "Show all %(cases_count)s cases ..."
+msgstr ""
+
+#: oldp/apps/cases/templates/cases/case.html:217
+msgid "No other cases cite this decision yet."
+msgstr ""
+
+#: oldp/apps/cases/templates/cases/case.html:222
 msgid "Related Cases"
 msgstr ""
 
-#: oldp/apps/cases/templates/cases/case.html:195
+#: oldp/apps/cases/templates/cases/case.html:229
 #: oldp/apps/laws/templates/laws/law.html:53
 msgid "empty_related_content"
 msgstr "No related content found."
 
-#: oldp/apps/cases/templates/cases/case_filter.html:45
-#: oldp/apps/courts/templates/courts/court_filter.html:41
+#: oldp/apps/cases/templates/cases/case_filter.html:21
+#: oldp/apps/courts/templates/courts/court_filter.html:23
 msgid "Apply filters"
 msgstr ""
 
-#: oldp/apps/cases/templates/cases/case_filter.html:50
-#: oldp/apps/courts/templates/courts/court_filter.html:46
+#: oldp/apps/cases/templates/cases/case_filter.html:26
+#: oldp/apps/courts/templates/courts/court_filter.html:28
 msgid "Reset"
 msgstr ""
 
-#: oldp/apps/cases/templates/cases/case_filter.html:57
+#: oldp/apps/cases/templates/cases/case_filter.html:33
 #, python-format
 msgid ""
 "\n"
-"You can download the search results over our <a href=\"%(api_info_url)s"
-"\">REST-API</a>\n"
-"as <a href=\"%(api_url)s&format=json\">JSON</a> or <a href="
-"\"%(api_url)s&format=xml\">XML</a> files.\n"
+"You can download the search results over our <a "
+"href=\"%(api_info_url)s\">REST-API</a>\n"
+"as <a href=\"%(api_url)s&format=json\">JSON</a> or <a "
+"href=\"%(api_url)s&format=xml\">XML</a> files.\n"
 msgstr ""
 
-#: oldp/apps/cases/views.py:23
-msgid "Case"
+#: oldp/apps/cases/templates/cases/stats/base.html:17
+#: oldp/apps/cases/templates/cases/stats/base.html:116
+#: oldp/apps/cases/templates/cases/stats/base.html:119
+#: oldp/apps/sources/views.py:83 oldp/assets/templates/footer.html:19
+msgid "Statistics"
 msgstr ""
 
-#: oldp/apps/contact/forms.py:7 oldp/apps/contact/forms.py:54
-msgid "Full name"
+#: oldp/apps/cases/templates/cases/stats/base.html:21
+msgid "Overview"
 msgstr ""
 
-#: oldp/apps/contact/forms.py:12 oldp/apps/contact/forms.py:58
-msgid "Email address"
+#: oldp/apps/cases/templates/cases/stats/base.html:24
+#: oldp/apps/cases/templates/cases/stats/overview.html:17
+msgid "By Country"
 msgstr ""
 
-#: oldp/apps/contact/forms.py:17
-msgid "Write here your message!"
+#: oldp/apps/cases/templates/cases/stats/base.html:27
+#: oldp/apps/cases/templates/cases/stats/overview.html:26
+msgid "By State"
 msgstr ""
 
-#: oldp/apps/contact/forms.py:18
-msgid "Message"
+#: oldp/apps/cases/templates/cases/stats/base.html:30
+#: oldp/apps/cases/templates/cases/stats/overview.html:35
+msgid "By Court"
 msgstr ""
 
-#: oldp/apps/contact/forms.py:34 oldp/apps/contact/forms.py:75
-msgid "You have to write something!"
+#: oldp/apps/cases/templates/cases/stats/base.html:34
+#: oldp/apps/cases/templates/cases/stats/overview.html:45
+msgid "By Source"
 msgstr ""
 
-#: oldp/apps/contact/forms.py:39
-msgid "Source URL"
+#: oldp/apps/cases/templates/cases/stats/base.html:42
+msgid "Filters"
 msgstr ""
 
-#: oldp/apps/contact/forms.py:42
-msgid "Enter the URL of the page which contains the infringement"
+#: oldp/apps/cases/templates/cases/stats/base.html:48
+#: oldp/apps/lib/templates/widgets/bootstrap_date_range.html:7
+#, fuzzy
+#| msgid "date_after"
+msgid "After"
+msgstr "After"
+
+#: oldp/apps/cases/templates/cases/stats/base.html:54
+#: oldp/apps/lib/templates/widgets/bootstrap_date_range.html:7
+#, fuzzy
+#| msgid "date_before"
+msgid "Before"
+msgstr "Before"
+
+#: oldp/apps/cases/templates/cases/stats/base.html:59
+#: oldp/apps/lib/templates/widgets/bootstrap_date_range.html:15
+#: oldp/apps/sources/views.py:26
+msgid "Last month"
 msgstr ""
 
-#: oldp/apps/contact/forms.py:45
-msgid "Type of infringement"
+#: oldp/apps/cases/templates/cases/stats/base.html:61
+#: oldp/apps/lib/templates/widgets/bootstrap_date_range.html:17
+msgid "Last year"
 msgstr ""
 
-#: oldp/apps/contact/forms.py:47 oldp/assets/templates/footer.html:16
-msgid "Privacy"
+#: oldp/apps/cases/templates/cases/stats/base.html:63
+msgid "Last 5 years"
 msgstr ""
 
-#: oldp/apps/contact/forms.py:48
-msgid "Copyright Infringement"
+#: oldp/apps/cases/templates/cases/stats/base.html:65
+msgid "All time"
 msgstr ""
 
-#: oldp/apps/contact/forms.py:49
+#: oldp/apps/cases/templates/cases/stats/base.html:70
+msgid "Group by"
+msgstr ""
+
+#: oldp/apps/cases/templates/cases/stats/base.html:72
+msgid "Month"
+msgstr ""
+
+#: oldp/apps/cases/templates/cases/stats/base.html:73
+msgid "Year"
+msgstr ""
+
+#: oldp/apps/cases/templates/cases/stats/base.html:74
+msgid "Day"
+msgstr ""
+
+#: oldp/apps/cases/templates/cases/stats/base.html:82
+msgid "Select a state"
+msgstr ""
+
+#: oldp/apps/cases/templates/cases/stats/base.html:92
+msgid "Apply"
+msgstr ""
+
+#: oldp/apps/cases/templates/cases/stats/base.html:100
+msgid "Download (JSON)"
+msgstr ""
+
+#: oldp/apps/cases/templates/cases/stats/base.html:135
+msgid "Loading statistics..."
+msgstr ""
+
+#: oldp/apps/cases/templates/cases/stats/base.html:167
+#: oldp/apps/sources/views.py:34
+msgid "Total"
+msgstr ""
+
+#: oldp/apps/cases/templates/cases/stats/base.html:168
+msgid "cases"
+msgstr ""
+
+#: oldp/apps/cases/templates/cases/stats/base.html:169
+msgid "Date"
+msgstr ""
+
+#: oldp/apps/cases/templates/cases/stats/base.html:170
+msgid "Count"
+msgstr ""
+
+#: oldp/apps/cases/templates/cases/stats/base.html:172
+#: oldp/apps/contact/forms.py:86
 msgid "Other"
 msgstr ""
 
-#: oldp/apps/contact/forms.py:63
+#: oldp/apps/cases/templates/cases/stats/base.html:173
+msgid "Error loading statistics"
+msgstr ""
+
+#: oldp/apps/cases/templates/cases/stats/base.html:174
+msgid "Please select a state to view court statistics."
+msgstr ""
+
+#: oldp/apps/cases/templates/cases/stats/base.html:176
+msgid "yearly"
+msgstr ""
+
+#: oldp/apps/cases/templates/cases/stats/base.html:177
+msgid "monthly"
+msgstr ""
+
+#: oldp/apps/cases/templates/cases/stats/base.html:178
+msgid "daily"
+msgstr ""
+
+#: oldp/apps/cases/templates/cases/stats/by_country.html:6
+msgid ""
+"Cases grouped by country. Each bar segment represents a different country. "
+"The table below shows the total count per country."
+msgstr ""
+
+#: oldp/apps/cases/templates/cases/stats/by_court.html:6
+msgid ""
+"Cases grouped by court. Select a state from the sidebar to view the courts "
+"within that state. Each bar segment represents a different court."
+msgstr ""
+
+#: oldp/apps/cases/templates/cases/stats/by_source.html:6
+msgid ""
+"Cases grouped by data source. Each bar segment represents a different "
+"source. The table below shows the total count per source."
+msgstr ""
+
+#: oldp/apps/cases/templates/cases/stats/by_state.html:6
+msgid ""
+"Cases grouped by state. Each bar segment represents a different state. The "
+"table below shows the total count per state."
+msgstr ""
+
+#: oldp/apps/cases/templates/cases/stats/overview.html:6
+msgid ""
+"This chart shows the total number of court cases published over time. Use "
+"the filters in the sidebar to adjust the date range and time granularity."
+msgstr ""
+
+#: oldp/apps/cases/templates/cases/stats/overview.html:12
+msgid "Explore by Dimension"
+msgstr ""
+
+#: oldp/apps/cases/templates/cases/stats/overview.html:18
+msgid "See how cases are distributed across countries."
+msgstr ""
+
+#: oldp/apps/cases/templates/cases/stats/overview.html:19
+#: oldp/apps/cases/templates/cases/stats/overview.html:28
+#: oldp/apps/cases/templates/cases/stats/overview.html:37
+#: oldp/apps/cases/templates/cases/stats/overview.html:47
+msgid "View"
+msgstr ""
+
+#: oldp/apps/cases/templates/cases/stats/overview.html:27
+msgid "Compare case volumes across states."
+msgstr ""
+
+#: oldp/apps/cases/templates/cases/stats/overview.html:36
+msgid "Drill down into individual courts within a state."
+msgstr ""
+
+#: oldp/apps/cases/templates/cases/stats/overview.html:46
+msgid "See which data sources contribute the most cases."
+msgstr ""
+
+#: oldp/apps/cases/views.py:34
+msgid "Case"
+msgstr ""
+
+#: oldp/apps/contact/forms.py:23
+msgid "Invalid input."
+msgstr ""
+
+#: oldp/apps/contact/forms.py:28 oldp/apps/contact/forms.py:91
+msgid "Full name"
+msgstr ""
+
+#: oldp/apps/contact/forms.py:31 oldp/apps/contact/forms.py:95
+msgid "Email address"
+msgstr ""
+
+#: oldp/apps/contact/forms.py:36
+msgid "Write here your message!"
+msgstr ""
+
+#: oldp/apps/contact/forms.py:37
+msgid "Message"
+msgstr ""
+
+#: oldp/apps/contact/forms.py:45
+msgid "Captcha: Wie viele Monate hat ein Jahr?"
+msgstr ""
+
+#: oldp/apps/contact/forms.py:66 oldp/apps/contact/forms.py:121
+msgid "You have to write something!"
+msgstr ""
+
+#: oldp/apps/contact/forms.py:70
+msgid "Sie müssen die Frage unter \"Captcha\" korrekt beantworten."
+msgstr ""
+
+#: oldp/apps/contact/forms.py:76
+msgid "Source URL"
+msgstr ""
+
+#: oldp/apps/contact/forms.py:79
+msgid "Enter the URL of the page which contains the infringement"
+msgstr ""
+
+#: oldp/apps/contact/forms.py:82
+msgid "Type of infringement"
+msgstr ""
+
+#: oldp/apps/contact/forms.py:84
+#: oldp/apps/homepage/templates/homepage/landing_page.html:126
+#: oldp/assets/templates/footer.html:15
+msgid "Privacy"
+msgstr ""
+
+#: oldp/apps/contact/forms.py:85
+msgid "Copyright Infringement"
+msgstr ""
+
+#: oldp/apps/contact/forms.py:100
 msgid "Please provide more details on your complaint."
 msgstr ""
 
-#: oldp/apps/contact/forms.py:64
+#: oldp/apps/contact/forms.py:101
 msgid "Additional information"
 msgstr ""
 
 #: oldp/apps/contact/templates/contact/form.html:9
 #: oldp/apps/contact/templates/contact/thankyou.html:9
-#: oldp/apps/contact/views.py:27 oldp/apps/contact/views.py:56
-#: oldp/apps/homepage/templates/homepage/index.html:92
-#: oldp/assets/templates/footer.html:14
+#: oldp/apps/contact/views.py:29 oldp/apps/contact/views.py:63
+#: oldp/apps/homepage/templates/homepage/index.html:113
+#: oldp/assets/templates/footer.html:13
 msgid "Contact"
 msgstr ""
 
@@ -236,7 +1239,7 @@ msgid "Submit"
 msgstr ""
 
 #: oldp/apps/contact/templates/contact/report_content.html:9
-#: oldp/apps/contact/views.py:49 oldp/assets/templates/footer.html:17
+#: oldp/apps/contact/views.py:54 oldp/assets/templates/footer.html:16
 #, fuzzy
 #| msgid "empty_related_content"
 msgid "Report content"
@@ -248,39 +1251,31 @@ msgid ""
 "else's rights."
 msgstr ""
 
-#: oldp/apps/courts/filters.py:51 oldp/apps/courts/views.py:20
+#: oldp/apps/courts/filters.py:42 oldp/apps/courts/views.py:19
 msgid "Court title"
 msgstr ""
 
-#: oldp/apps/courts/templates/courts/cases_list.html:13
-#: oldp/apps/courts/templates/courts/court_filter.html:59
-#: oldp/apps/courts/views.py:46 oldp/assets/templates/header.html:31
-msgid "Courts"
-msgstr ""
-
 #: oldp/apps/courts/templates/courts/cases_list.html:40
-#: oldp/apps/courts/views.py:25
+#: oldp/apps/courts/views.py:21
 msgid "ECLI code"
 msgstr ""
 
-#: oldp/apps/courts/templates/courts/cases_list.html:59
-#: oldp/apps/homepage/templates/homepage/index.html:65
-#: oldp/apps/laws/templates/laws/references.html:46
-#, python-format
-msgid "Show all %(cases_count)s cases ..."
+#: oldp/apps/courts/templates/courts/cases_list.html:45
+msgid "View case statistics for courts in"
 msgstr ""
 
 #: oldp/apps/homepage/templates/errors/404.html:9
 #: oldp/apps/homepage/templates/errors/500.html:9
 #: oldp/apps/homepage/templates/errors/bad_request.html:9
 #: oldp/apps/homepage/templates/errors/permission_denied.html:9
-#: oldp/apps/homepage/views.py:38 oldp/apps/homepage/views.py:45
-#: oldp/apps/homepage/views.py:52 oldp/apps/homepage/views.py:59
+#: oldp/apps/homepage/views.py:79 oldp/apps/homepage/views.py:88
+#: oldp/apps/homepage/views.py:98 oldp/apps/homepage/views.py:109
+#: oldp/apps/search/templates/search/search.html:65
 msgid "Error"
 msgstr ""
 
 #: oldp/apps/homepage/templates/errors/404.html:9
-#: oldp/apps/homepage/views.py:45
+#: oldp/apps/homepage/views.py:88
 msgid "Not found"
 msgstr ""
 
@@ -302,7 +1297,7 @@ msgid ""
 msgstr ""
 
 #: oldp/apps/homepage/templates/errors/bad_request.html:9
-#: oldp/apps/homepage/views.py:59
+#: oldp/apps/homepage/views.py:109
 msgid "Bad request"
 msgstr ""
 
@@ -311,7 +1306,7 @@ msgid "You sent an invalid request."
 msgstr ""
 
 #: oldp/apps/homepage/templates/errors/permission_denied.html:9
-#: oldp/apps/homepage/views.py:52
+#: oldp/apps/homepage/views.py:98
 msgid "Permission denied"
 msgstr ""
 
@@ -359,24 +1354,201 @@ msgstr "illegal OR legal"
 msgid "search_example_query3"
 msgstr "bgb 144"
 
+#: oldp/apps/homepage/templates/homepage/index.html:14
+msgid "Getting Started with the API"
+msgstr ""
+
+#: oldp/apps/homepage/templates/homepage/index.html:17
+msgid ""
+"Our REST API allows you to view, create or edit content available on this "
+"site. Most read requests (e.g. view cases) do not need to be authenticated, "
+"but any action that would require a user to be logged in (such as creating "
+"annotations) requires an API key."
+msgstr ""
+
+#: oldp/apps/homepage/templates/homepage/index.html:24
+#, python-format
+msgid ""
+"To make authenticated requests, you'll need to <a "
+"href=\"%(signup_url)s\">set up an account</a> and obtain your <a "
+"href=\"%(api_url)s\">API key</a>."
+msgstr ""
+
+#: oldp/apps/homepage/templates/homepage/index.html:29
+msgid "We have different endpoints for cases, laws, courts and more."
+msgstr ""
+
+#: oldp/apps/homepage/templates/homepage/index.html:33
+msgid ""
+"Several API Clients are available in <a href=\"http://github.com/"
+"openlegaldata/oldp-sdk-python\">Python</a>, <a href=\"http://github.com/"
+"openlegaldata/oldp-sdk-php\">PHP</a>, <a href=\"http://github.com/"
+"openlegaldata/oldp-sdk-java\">Java</a> and <a href=\"http://github.com/"
+"openlegaldata/oldp-sdk-javascript\">Javascript</a>."
+msgstr ""
+
 #: oldp/apps/homepage/templates/homepage/index.html:45
+#, python-format
+msgid ""
+"The <a href=\"%(redoc_url)s\">full documentation</a> is a great way to "
+"explore all the features of the API. You might also want to check out our <a "
+"href=\"https://github.com/openlegaldata/oldp-notebooks\">example apps</a>."
+msgstr ""
+
+#: oldp/apps/homepage/templates/homepage/index.html:53
+#, python-format
+msgid ""
+"Questions? Comments? Want to tell us about the cool stuff you've built with "
+"our API? <a href=\"%(contact_url)s\">Get in touch</a>."
+msgstr ""
+
+#: oldp/apps/homepage/templates/homepage/index.html:61
 msgid "Try it out!"
 msgstr ""
 
-#: oldp/apps/homepage/templates/homepage/index.html:46
+#: oldp/apps/homepage/templates/homepage/index.html:62
 msgid "Documentation"
 msgstr ""
 
-#: oldp/apps/homepage/templates/homepage/index.html:47
+#: oldp/apps/homepage/templates/homepage/index.html:63
 msgid "Examples"
 msgstr ""
 
-#: oldp/apps/homepage/templates/homepage/index.html:54
+#: oldp/apps/homepage/templates/homepage/index.html:70
 msgid "Latest Cases"
 msgstr ""
 
-#: oldp/apps/homepage/views.py:27 oldp/apps/homepage/views.py:66
+#: oldp/apps/homepage/templates/homepage/index.html:81
+msgid "View all cases"
+msgstr ""
+
+#: oldp/apps/homepage/templates/homepage/index.html:88
+msgid "Contribute"
+msgstr ""
+
+#: oldp/apps/homepage/templates/homepage/index.html:91
+msgid ""
+"Open Legal Data is a non-profit initiative by volunteers. Our initiative was "
+"founded to provide free, public, and open access to legal documents for "
+"educational, charitable, and scientific purposes to the benefit of the "
+"general public and the public interest."
+msgstr ""
+
+#: oldp/apps/homepage/templates/homepage/index.html:97
+msgid ""
+"We develop technologies such as this platform to facilitate legal research."
+msgstr ""
+
+#: oldp/apps/homepage/templates/homepage/index.html:103
+msgid ""
+"Yet, we depend on your support and, therefore, do not hesitate to send us "
+"your feedback or comments. Contributions are needed and always welcome!"
+msgstr ""
+
+#: oldp/apps/homepage/templates/homepage/index.html:111
+#: oldp/apps/homepage/templates/homepage/landing_page.html:130
+msgid "Twitter"
+msgstr ""
+
+#: oldp/apps/homepage/templates/homepage/index.html:112
+#: oldp/apps/homepage/templates/homepage/landing_page.html:131
+msgid "GitHub"
+msgstr ""
+
+#: oldp/apps/homepage/templates/homepage/landing_page.html:15
+msgid "Free Access to Legal Information"
+msgstr ""
+
+#: oldp/apps/homepage/templates/homepage/landing_page.html:17
+msgid ""
+"Our open data platform is currently available for the following countries:"
+msgstr ""
+
+#: oldp/apps/homepage/templates/homepage/landing_page.html:22
+msgid "Germany / Deutschland"
+msgstr ""
+
+#: oldp/apps/homepage/templates/homepage/landing_page.html:36
+msgid ""
+"<strong>OPENLEGALDATA.IO</strong> is a free and open platform that makes "
+"legal documents and information accessible to the public. Our goal is to "
+"enhance the transparency of the jurisdiction with the help of open data and "
+"by supporting people without legal education to understand the justice "
+"system. The project is committed to the Open Data Principles and the Free "
+"Access to Law Movement."
+msgstr ""
+
+#: oldp/apps/homepage/templates/homepage/landing_page.html:43
+msgid "Read more about the project."
+msgstr ""
+
+#: oldp/apps/homepage/templates/homepage/landing_page.html:55
+msgid "Increase Transparency"
+msgstr ""
+
+#: oldp/apps/homepage/templates/homepage/landing_page.html:65
+msgid "Join the team!"
+msgstr ""
+
+#: oldp/apps/homepage/templates/homepage/landing_page.html:75
+msgid "Open Data"
+msgstr ""
+
+#: oldp/apps/homepage/templates/homepage/landing_page.html:86
+msgid "Legal Research"
+msgstr ""
+
+#: oldp/apps/homepage/templates/homepage/landing_page.html:96
+msgid "Our Blog"
+msgstr ""
+
+#: oldp/apps/homepage/templates/homepage/landing_page.html:108
+msgid "Show more posts"
+msgstr ""
+
+#: oldp/apps/homepage/templates/homepage/landing_page.html:124
+msgid "About"
+msgstr ""
+
+#: oldp/apps/homepage/templates/homepage/landing_page.html:125
+#: oldp/assets/templates/footer.html:14
+msgid "Imprint"
+msgstr ""
+
+#: oldp/apps/homepage/templates/homepage/landing_page.html:128
+msgid "Blog"
+msgstr ""
+
+#: oldp/apps/homepage/views.py:20
+msgid "View all laws"
+msgstr ""
+
+#: oldp/apps/homepage/views.py:67
 msgid "Free Access to Legal Data"
+msgstr ""
+
+#: oldp/apps/laws/models.py:26
+msgid "Revision date cannot be in the future."
+msgstr ""
+
+#: oldp/apps/laws/models.py:29
+msgid "Revision date cannot be before 1800 (unreasonably old for German laws)."
+msgstr ""
+
+#: oldp/apps/laws/search_indexes.py:11
+msgid "Law"
+msgstr ""
+
+#: oldp/apps/laws/serializers.py:127 oldp/apps/laws/serializers.py:206
+msgid "Book code cannot be empty."
+msgstr ""
+
+#: oldp/apps/laws/serializers.py:133
+msgid "Book title cannot be empty."
+msgstr ""
+
+#: oldp/apps/laws/serializers.py:212
+msgid "Section cannot be empty."
 msgstr ""
 
 #: oldp/apps/laws/templates/laws/book.html:33
@@ -399,12 +1571,6 @@ msgstr ""
 msgid "btn_show_all"
 msgstr "Show all"
 
-#: oldp/apps/laws/templates/laws/index.html:9
-#: oldp/apps/laws/templates/laws/law.html:83 oldp/apps/laws/views.py:52
-#: oldp/assets/templates/header.html:38
-msgid "Laws"
-msgstr ""
-
 #: oldp/apps/laws/templates/laws/index.html:24
 msgid "More Laws"
 msgstr ""
@@ -413,24 +1579,26 @@ msgstr ""
 msgid "Related Laws"
 msgstr ""
 
-#: oldp/apps/laws/templates/laws/law.html:98
-msgid "law_outdated_warning"
-msgstr "This law text might be outdated since the content is not actively maintained. Please check with official sources."
+#: oldp/apps/laws/templates/laws/law.html:105
+#: oldp/assets/templates/account/email.html:62
+msgid "Warning:"
+msgstr ""
 
-#: oldp/apps/laws/templates/laws/law.html:103
+#: oldp/apps/laws/templates/laws/law.html:105
+msgid "law_outdated_warning"
+msgstr ""
+"This law text might be outdated since the content is not actively "
+"maintained. Please check with official sources."
+
+#: oldp/apps/laws/templates/laws/law.html:110
 #, python-format
 msgid ""
 "You are currently viewing an <strong>outdated revision</strong> of this law. "
 "Click <a href=\"%(url)s\">here</a> to view the latest revision."
 msgstr ""
 
-#: oldp/apps/laws/templates/laws/law.html:132
+#: oldp/apps/laws/templates/laws/law.html:143
 msgid "This law is deprecated."
-msgstr ""
-
-#: oldp/apps/laws/templates/laws/references.html:5
-#: oldp/apps/references/templates/references.html:5
-msgid "References"
 msgstr ""
 
 #: oldp/apps/laws/templates/laws/references.html:20
@@ -446,28 +1614,28 @@ msgstr ""
 msgid "Referenced by"
 msgstr ""
 
-#: oldp/apps/laws/views.py:78
+#: oldp/apps/laws/templates/laws/references.html:66
+msgid "No cases cite this section yet."
+msgstr ""
+
+#: oldp/apps/laws/views.py:111
 #, python-format
 msgid ""
 "The requested revision (%s) was not found. Showing instead the latest "
 "revision."
 msgstr ""
 
-#: oldp/apps/lib/filters.py:15
+#: oldp/apps/lib/filters.py:18
 msgid "descending"
 msgstr ""
 
-#: oldp/apps/lib/templates/widgets/bootstrap_date_range.html:7
-#, fuzzy
-#| msgid "date_after"
-msgid "After"
-msgstr "After"
+#: oldp/apps/lib/tests/test_filters.py:64
+msgid "Name Field"
+msgstr ""
 
-#: oldp/apps/lib/templates/widgets/bootstrap_date_range.html:7
-#, fuzzy
-#| msgid "date_before"
-msgid "Before"
-msgstr "Before"
+#: oldp/apps/lib/tests/test_filters.py:77
+msgid "Name (Z-A)"
+msgstr ""
 
 #: oldp/apps/lib/widgets.py:37
 msgid "All"
@@ -506,46 +1674,106 @@ msgstr ""
 msgid "Try fewer keywords."
 msgstr ""
 
-#: oldp/apps/search/templates/search/facets.html:22
+#: oldp/apps/search/templates/search/facets.html:14
 msgid "No filter available."
 msgstr ""
 
-#: oldp/apps/search/templates/search/facets.html:28
+#: oldp/apps/search/templates/search/facets.html:20
 msgid "Document type"
 msgstr ""
 
-#: oldp/apps/search/templates/search/facets.html:41
+#: oldp/apps/search/templates/search/facets.html:33
 msgid "Law book"
 msgstr ""
 
 #: oldp/apps/search/templates/search/search.html:29
-#: oldp/apps/search/views.py:157
+#: oldp/apps/search/views.py:303 oldp/apps/search/views.py:354
 msgid "Search"
 msgstr ""
 
-#: oldp/apps/search/templates/search/search.html:42
+#: oldp/apps/search/templates/search/search.html:44
+msgid "Cases citing"
+msgstr ""
+
+#: oldp/apps/search/templates/search/search.html:46
+msgid "Cases citing case"
+msgstr ""
+
+#: oldp/apps/search/templates/search/search.html:51
+msgid "(unknown)"
+msgstr ""
+
+#: oldp/apps/search/templates/search/search.html:54
+msgid "Remove filter"
+msgstr ""
+
+#: oldp/apps/search/templates/search/search.html:72
+#, python-format
+msgid "%(count)s citing cases."
+msgstr ""
+
+#: oldp/apps/search/templates/search/search.html:74
 #, python-format
 msgid "%(count)s results sorted by <b>relevance</b>."
 msgstr ""
 
-#: oldp/assets/templates/account/base.html:11
+#: oldp/apps/search/utils.py:62
+msgid ""
+"Search backend is currently unavailable, so the list of citing cases cannot "
+"be loaded. Please try again later."
+msgstr ""
+
+#: oldp/apps/search/views.py:293
+msgid ""
+"Search timed out. The first request after a cold start can be slow — please "
+"try again."
+msgstr ""
+
+#: oldp/apps/search/views.py:298
+msgid "Search is currently unavailable. Please try again later."
+msgstr ""
+
+#: oldp/apps/sources/templates/sources/stats.html:10
+msgid "Source: Statistics"
+msgstr ""
+
+#: oldp/apps/sources/views.py:16
+msgid "Last day"
+msgstr ""
+
+#: oldp/apps/sources/views.py:21
+msgid "Last week"
+msgstr ""
+
+#: oldp/apps/sources/views.py:31
+msgid "Last three month"
+msgstr ""
+
+#: oldp/assets/templates/account/base.html:17
 msgid "E-mail Addresses"
 msgstr ""
 
-#: oldp/assets/templates/account/base.html:14
+#: oldp/assets/templates/account/base.html:20
 #: oldp/assets/templates/account/password_change.html:6
 #: oldp/assets/templates/account/password_change.html:14
 #: oldp/assets/templates/account/password_reset_from_key.html:6
 #: oldp/assets/templates/account/password_reset_from_key.html:11
 #: oldp/assets/templates/account/password_reset_from_key.html:23
-#: oldp/assets/templates/header.html:51
+#: oldp/assets/templates/header.html:44
 msgid "Change Password"
 msgstr ""
 
-#: oldp/assets/templates/account/base.html:35
+#: oldp/assets/templates/account/base.html:23
+msgid "Personal Tokens"
+msgstr ""
+
+#: oldp/assets/templates/account/base.html:26
+msgid "Application Tokens"
+msgstr ""
+
+#: oldp/assets/templates/account/base.html:44
 #: oldp/assets/templates/account/email.html:6
-#: oldp/assets/templates/header.html:44
-#: oldp/assets/templates/socialaccount/connections.html:34
+#: oldp/assets/templates/header.html:37
 msgid "Account"
 msgstr ""
 
@@ -555,10 +1783,6 @@ msgstr ""
 
 #: oldp/assets/templates/account/email.html:22
 msgid "E-mail"
-msgstr ""
-
-#: oldp/assets/templates/account/email.html:25
-msgid "Status"
 msgstr ""
 
 #: oldp/assets/templates/account/email.html:41
@@ -582,12 +1806,7 @@ msgid "Re-send Verification"
 msgstr ""
 
 #: oldp/assets/templates/account/email.html:55
-#: oldp/assets/templates/socialaccount/connections.html:58
 msgid "Remove"
-msgstr ""
-
-#: oldp/assets/templates/account/email.html:62
-msgid "Warning:"
 msgstr ""
 
 #: oldp/assets/templates/account/email.html:62
@@ -627,39 +1846,25 @@ msgstr ""
 #: oldp/assets/templates/account/email_confirm.html:28
 #, python-format
 msgid ""
-"This e-mail confirmation link expired or is invalid. Please <a href="
-"\"%(email_url)s\">issue a new e-mail confirmation request</a>."
+"This e-mail confirmation link expired or is invalid. Please <a "
+"href=\"%(email_url)s\">issue a new e-mail confirmation request</a>."
 msgstr ""
 
 #: oldp/assets/templates/account/login.html:7
 #: oldp/assets/templates/account/login.html:12
-#: oldp/assets/templates/account/login.html:43
-#: oldp/assets/templates/header.html:44
+#: oldp/assets/templates/account/login.html:44
+#: oldp/assets/templates/header.html:37
 msgid "Sign In"
 msgstr ""
 
-#: oldp/assets/templates/account/login.html:16
-#, python-format
-msgid ""
-"Please sign in with one\n"
-"of your existing third party accounts. Or, <a href=\"%(signup_url)s\">sign "
-"up</a>\n"
-"for a %(site_name)s account and sign in\n"
-"below:"
-msgstr ""
-
-#: oldp/assets/templates/account/login.html:27
-msgid "or"
-msgstr ""
-
-#: oldp/assets/templates/account/login.html:44
+#: oldp/assets/templates/account/login.html:45
 msgid "Forgot Password?"
 msgstr ""
 
 #: oldp/assets/templates/account/logout.html:5
 #: oldp/assets/templates/account/logout.html:9
 #: oldp/assets/templates/account/logout.html:18
-#: oldp/assets/templates/header.html:59
+#: oldp/assets/templates/header.html:52
 msgid "Sign Out"
 msgstr ""
 
@@ -667,22 +1872,22 @@ msgstr ""
 msgid "Are you sure you want to sign out?"
 msgstr ""
 
-#: oldp/assets/templates/account/password_reset.html:7
-#: oldp/assets/templates/account/password_reset.html:11
+#: oldp/assets/templates/account/password_reset.html:8
+#: oldp/assets/templates/account/password_reset.html:12
 msgid "Password Reset"
 msgstr ""
 
-#: oldp/assets/templates/account/password_reset.html:16
+#: oldp/assets/templates/account/password_reset.html:17
 msgid ""
 "Forgotten your password? Enter your e-mail address below, and we'll send you "
 "an e-mail allowing you to reset it."
 msgstr ""
 
-#: oldp/assets/templates/account/password_reset.html:22
+#: oldp/assets/templates/account/password_reset.html:23
 msgid "Reset My Password"
 msgstr ""
 
-#: oldp/assets/templates/account/password_reset.html:26
+#: oldp/assets/templates/account/password_reset.html:27
 msgid "Please contact us if you have any trouble resetting your password."
 msgstr ""
 
@@ -708,15 +1913,12 @@ msgid "Set Password"
 msgstr ""
 
 #: oldp/assets/templates/account/signup.html:6
-#: oldp/assets/templates/socialaccount/signup.html:6
 msgid "Signup"
 msgstr ""
 
 #: oldp/assets/templates/account/signup.html:10
 #: oldp/assets/templates/account/signup.html:21
-#: oldp/assets/templates/header.html:62
-#: oldp/assets/templates/socialaccount/signup.html:9
-#: oldp/assets/templates/socialaccount/signup.html:21
+#: oldp/assets/templates/header.html:55
 msgid "Sign Up"
 msgstr ""
 
@@ -726,50 +1928,91 @@ msgid ""
 "Already have an account? Then please <a href=\"%(login_url)s\">sign in</a>."
 msgstr ""
 
-#: oldp/assets/templates/account/verification_sent.html:6
-#: oldp/assets/templates/account/verification_sent.html:10
-#: oldp/assets/templates/account/verified_email_required.html:6
-#: oldp/assets/templates/account/verified_email_required.html:10
+#: oldp/assets/templates/account/verification_sent.html:5
+#: oldp/assets/templates/account/verification_sent.html:9
+#: oldp/assets/templates/account/verified_email_required.html:5
+#: oldp/assets/templates/account/verified_email_required.html:9
 msgid "Verify Your E-mail Address"
 msgstr ""
 
-#: oldp/assets/templates/account/verification_sent.html:12
+#: oldp/assets/templates/account/verification_sent.html:11
 msgid ""
 "We have sent an e-mail to you for verification. Follow the link provided to "
 "finalize the signup process. Please contact us if you do not receive it "
 "within a few minutes."
 msgstr ""
 
-#: oldp/assets/templates/account/verified_email_required.html:14
+#: oldp/assets/templates/account/verified_email_required.html:13
 msgid ""
 "This part of the site requires us to verify that\n"
 "        you are who you claim to be. For this purpose, we require that you\n"
 "        verify ownership of your e-mail address. "
 msgstr ""
 
-#: oldp/assets/templates/account/verified_email_required.html:18
+#: oldp/assets/templates/account/verified_email_required.html:17
 msgid ""
 "We have sent an e-mail to you for\n"
 "        verification. Please click on the link inside this e-mail. Please\n"
 "        contact us if you do not receive it within a few minutes."
 msgstr ""
 
-#: oldp/assets/templates/account/verified_email_required.html:22
+#: oldp/assets/templates/account/verified_email_required.html:21
 #, python-format
 msgid ""
 "<strong>Note:</strong> you can still <a href=\"%(email_url)s\">change your e-"
 "mail address</a>."
 msgstr ""
 
-#: oldp/assets/templates/footer.html:15
-msgid "Imprint"
+#: oldp/assets/templates/admin/index.html:18
+msgid "Creation Dashboards"
 msgstr ""
 
-#: oldp/assets/templates/header.html:52
+#: oldp/assets/templates/admin/index.html:21
+#: oldp/assets/templates/admin/index.html:25
+#: oldp/assets/templates/admin/index.html:29
+#: oldp/assets/templates/admin/index.html:33
+msgid "Creation statistics, API submissions and pending approvals"
+msgstr ""
+
+#: oldp/assets/templates/admin/index.html:45
+msgid "Recent actions"
+msgstr ""
+
+#: oldp/assets/templates/admin/index.html:46
+msgid "My actions"
+msgstr ""
+
+#: oldp/assets/templates/admin/index.html:49
+msgid "None available"
+msgstr ""
+
+#: oldp/assets/templates/admin/index.html:54
+msgid "Added:"
+msgstr ""
+
+#: oldp/assets/templates/admin/index.html:54
+msgid "Changed:"
+msgstr ""
+
+#: oldp/assets/templates/admin/index.html:54
+msgid "Deleted:"
+msgstr ""
+
+#: oldp/assets/templates/admin/index.html:64
+#, fuzzy
+#| msgid "empty_related_content"
+msgid "Unknown content"
+msgstr "No related content found."
+
+#: oldp/assets/templates/header.html:43
+msgid "API Keys"
+msgstr ""
+
+#: oldp/assets/templates/header.html:45
 msgid "Change E-mail"
 msgstr ""
 
-#: oldp/assets/templates/header.html:61
+#: oldp/assets/templates/header.html:54
 msgid "Login"
 msgstr ""
 
@@ -777,60 +2020,20 @@ msgstr ""
 msgid "Sorry, we could not find any results."
 msgstr ""
 
-#: oldp/assets/templates/pagination_list_view.html:41
-#, python-format
-msgid "%(start)s-%(end)s of %(count)s items"
-msgstr ""
-
-#: oldp/assets/templates/pagination_list_view.html:43
+#: oldp/assets/templates/pagination_list_view.html:42
 #, python-format
 msgid "%(start)s-%(end)s of > %(max_count)s items"
 msgstr ""
 
-#: oldp/assets/templates/socialaccount/connections.html:5
-msgid "Connected Accounts"
-msgstr ""
-
-#: oldp/assets/templates/socialaccount/connections.html:11
-msgid ""
-"You can sign in to your account using any of the following third party "
-"accounts:"
-msgstr ""
-
-#: oldp/assets/templates/socialaccount/connections.html:31
-msgid "Provider"
-msgstr ""
-
-#: oldp/assets/templates/socialaccount/connections.html:67
-msgid "None!"
-msgstr ""
-
-#: oldp/assets/templates/socialaccount/connections.html:67
-msgid ""
-"You currently have no social network accounts connected to this account."
-msgstr ""
-
-#: oldp/assets/templates/socialaccount/connections.html:71
-msgid "Add a 3rd Party Account"
-msgstr ""
-
-#: oldp/assets/templates/socialaccount/signup.html:11
+#: oldp/assets/templates/pagination_list_view.html:44
 #, python-format
-msgid ""
-"You are about to use your %(provider_name)s account to login to \n"
-"%(site_name)s. As a final step, please complete the following form:"
+msgid "%(start)s-%(end)s of %(count)s items"
 msgstr ""
 
-#: oldp/settings.py:222
+#: oldp/settings.py:258
 msgid "English"
 msgstr ""
 
-#: oldp/settings.py:223
+#: oldp/settings.py:259
 msgid "German"
 msgstr ""
-
-#~ msgid "empty_references"
-#~ msgstr "No references found."
-
-#~ msgid "do_search"
-#~ msgstr "Search"


### PR DESCRIPTION
Replaces the SQL JOIN path that powered the citing-cases panel on `/law/<book>/<sec>/` (and adds the equivalent panel to `/case/<slug>/`) with an Elasticsearch term lookup on a new `CaseIndex` multi-value field. Cold-cache cost of "all cases citing § 823 BGB" drops from ~3s (SQL JOIN) to ~50ms (ES inverted index).

The relational citation graph stays the source of truth; ES is a denormalised read-only view. Same architecture every search-heavy product (GitHub, Algolia, Westlaw) uses for "find documents tagged with X" filter queries.

## What changes

### CaseIndex (`oldp/apps/cases/search_indexes.py`)

Two new multi-value fields:

- `cited_laws`: list of `"{book_slug}__{section_slug}"` tokens. Shared helper `cited_law_token(book, section)` keeps the format in lockstep between indexer and search view.
- `cited_cases`: list of Case PKs (as strings).

`prepare_cited_*` query the `Reference` table directly (one index-driven SELECT per case) rather than walking `casereferencemarker_set` -> `references`.

### Search view (`oldp/apps/search/views.py`)

`/search/` accepts new query params:

- `?cited_law_book=&cited_law_section=` — filter to cases citing the given law section.
- `?cited_case=<id>` — filter to cases citing the given case.

The form clamps results to `Case` model. The view exposes the resolved filter (kind + label + clear URL) in template context so the search results page renders a dismissible chip with `×` clear link.

### Law / Case detail views

Both views now use shared helper `citing_cases_via_es(field, value)` in `oldp/apps/search/utils.py` that:

1. Issues the ES filter query.
2. Hydrates results via Haystack's `load_all` (one batched SQL fetch).
3. Returns `(cases_list, total_count, error_message)`.
4. **On ES failure surfaces the structured error message — no SQL fallback** per explicit direction.

The template renders the error plus a deep link to the full search results page; the user can retry once ES recovers.

`/case/<slug>/` gets a new "Cited by" panel that mirrors `/law/<sec>/`'s "Referenced by" panel — this is a brand-new feature for the case detail page.

## Cold-cache cost comparison

| Path | Before | After |
|---|--:|--:|
| `/law/bgb/823` citing-cases lookup (cold) | ~3,200 ms (SQL STRAIGHT_JOIN) | ~50 ms (ES term lookup, expected) |
| `/case/<slug>` "cited by" panel | (didn't exist) | ~50 ms (new feature) |

ES inverted index is purpose-built for this query shape. The relational JOIN path was hitting cold-page random reads against a 7.5 GB citation graph through a 1 GB InnoDB buffer pool.

## Migration / deploy notes

The new fields require a full case reindex to be populated:

    python manage.py update_index cases

Estimated 15-30 minutes for ~423k cases (laws was 4m30s for ~110k). Before the reindex runs, the citing-cases panel on every law/case detail page renders the empty-state "No cases cite this section yet." — the `cited_laws` / `cited_cases` fields are missing on every doc so the ES filter matches nothing. That's the safe transient state; it self-resolves as the reindex progresses. Existing search functionality (free-text search, facets) is unaffected by the reindex.

## Compat

- No API surface change (the citation graph REST endpoints in `oldp/apps/cases/api_views.py` and `oldp/apps/laws/api_views.py` continue to use the SQL helpers).
- `Law.get_referencing_cases` is no longer called from views but kept on the model for back-compat (still has a test).
- ES is now in the read path for `/law/<sec>/` and `/case/<slug>/`. ES outage = "search unavailable" notice + search-page deep link, no fallback to SQL.

## Test plan

- [x] `make lint` passes.
- [x] Full test suite: 1144 tests, same 6 pre-existing failures as `master`.
- [x] 4 new tests: filter resolver (with/without params, unknown target), search view chip rendering, ES-failure error surface.
- [ ] Post-deploy: run `update_index cases` and verify `/law/bgb/823` shows ~14k citing cases panel with the deep link to `/search/?cited_law_book=bgb&cited_law_section=823`.