### PR TITLE
hotfix(templates): {% comment %} blocks + responsive primary-color chip

### DIFF
--- a/oldp/apps/cases/templates/cases/case.html
+++ b/oldp/apps/cases/templates/cases/case.html
@@ -185,11 +185,13 @@
 </section>
 
 <section>
-    {# Cited-by panel: cases that reference THIS case. Backed by the
-       ``cited_cases`` multi-value field on ``CaseIndex``; ES is the
-       sole source of truth. On backend failure we render an explicit
-       notice plus a link to the search page — the equivalent panel on
-       /law/<book>/<sec>/ behaves identically. #}
+    {% comment %}
+    Cited-by panel: cases that reference THIS case. Backed by the
+    cited_cases multi-value field on CaseIndex; ES is the sole source
+    of truth. On backend failure we render an explicit notice plus a
+    link to the search page — the equivalent panel on
+    /law/<book>/<sec>/ behaves identically.
+    {% endcomment %}
     <h3>{% trans 'Cited by' %}</h3>
 
     {% if referencing_cases_error %}

--- a/oldp/apps/laws/templates/laws/references.html
+++ b/oldp/apps/laws/templates/laws/references.html
@@ -35,13 +35,15 @@
     <h3>{% trans 'Referenced by' %}</h3>
 
     {% if referencing_cases_error %}
-        {# ES is the sole source of truth for the citing-cases panel
-           since we moved the lookup off the SQL JOIN path. When the
-           backend is unavailable we surface the error explicitly and
-           give the user a direct link to the search page, which they
-           can retry once ES recovers. The link itself does not need
-           ES to render — it round-trips through the standard search
-           view, which handles its own ``search_error`` state. #}
+        {% comment %}
+        ES is the sole source of truth for the citing-cases panel
+        since we moved the lookup off the SQL JOIN path. When the
+        backend is unavailable we surface the error explicitly and
+        give the user a direct link to the search page, which they
+        can retry once ES recovers. The link itself does not need
+        ES to render — it round-trips through the standard search
+        view, which handles its own search_error state.
+        {% endcomment %}
         <div class="alert alert-warning">
             <p>{{ referencing_cases_error }}</p>
             <a href="{{ referencing_cases_search_url }}" class="btn btn-sm btn-primary">

--- a/oldp/apps/search/templates/search/search.html
+++ b/oldp/apps/search/templates/search/search.html
@@ -33,27 +33,33 @@
 
         </form>
 
+        {% comment %}
+        Active citation-graph filter (set by /law/<sec>/ or /case/<slug>/
+        "View all citing cases" link). Rendered as a dismissible chip
+        that wraps cleanly on narrow viewports — primary theme colour;
+        text wraps inside the badge so long law titles or case file
+        numbers can't overflow the viewport on mobile.
+        {% endcomment %}
         {% if citation_filter %}
-            {# Active citation-graph filter (set by /law/<sec>/ or
-               /case/<slug>/ "View all citing cases" link). Render as
-               a dismissible chip so the user can clear it without
-               touching the URL bar. #}
-            <div class="active-filters" style="margin-top: .75rem;">
-                <span class="badge badge-pill badge-info" style="font-size: 0.95rem; padding: .5rem .75rem;">
-                    {% if citation_filter.kind == 'law' %}
-                        {% trans 'Cases citing' %}
-                    {% else %}
-                        {% trans 'Cases citing case' %}
-                    {% endif %}
+            <div class="active-filters my-3">
+                <div class="badge badge-primary d-inline-flex flex-wrap align-items-center text-left text-wrap p-2 mw-100" style="font-size: 0.95rem; gap: .35rem; white-space: normal;">
+                    <span>
+                        {% if citation_filter.kind == 'law' %}
+                            {% trans 'Cases citing' %}
+                        {% else %}
+                            {% trans 'Cases citing case' %}
+                        {% endif %}
+                    </span>
                     {% if citation_filter.label %}
                         <strong>{{ citation_filter.label }}</strong>
                     {% else %}
                         <em>{% trans '(unknown)' %}</em>
                     {% endif %}
-                    <a href="{{ clear_citation_url }}" class="badge-clear"
+                    <a href="{{ clear_citation_url }}"
+                       class="badge-clear ml-2 text-white"
                        aria-label="{% trans 'Remove filter' %}"
-                       style="color: inherit; margin-left: .5rem; text-decoration: none; font-weight: bold;">×</a>
-                </span>
+                       style="font-weight: bold; text-decoration: none;">&times;</a>
+                </div>
             </div>
         {% endif %}
 


### PR DESCRIPTION
## Summary

Two visible regressions surfaced on prod after #224:

1. **Template-comment leaks** — multi-line `{# … #}` blocks were rendered as visible page text on `/case/<slug>/`, `/law/<book>/<sec>/`, and `/search/?cited_*=…`. Django's `{# #}` syntax is single-line only; multi-line variants leak verbatim. Replaced with `{% comment %} … {% endcomment %}` in:
   - `oldp/apps/cases/templates/cases/case.html` (Cited-by panel header)
   - `oldp/apps/laws/templates/laws/references.html` (Referenced-by error branch)
   - `oldp/apps/search/templates/search/search.html` (citation filter chip header)

2. **Citation filter chip overflowed mobile viewport + wrong color** — `.active-filters .badge.badge-info` rendered with the default light-info background and a fixed-width inline-block that couldn't wrap long law titles or case file numbers. Switched to:
   - `badge-primary` (theme primary, `rgb(3, 121, 196)`) instead of `badge-info`
   - `d-inline-flex flex-wrap align-items-center text-wrap p-2 mw-100` so the chip wraps inside its row
   - `white-space: normal` so long labels wrap inside the badge
   - `text-white` on the inner `×` link so the close affordance stays visible on the primary background

## Verification

Built `oldp:v0.10.10-hotfix1` locally, deployed to prod, then ran Playwright (chromium 1223) against:

- `/search/?cited_law_book=bgb&cited_law_section=144` (short label)
- `/search/?cited_law_book=bgb&cited_law_section=823` (long label, stress-test for wrap)
- `/case/bgh-2018-02-27-vi-zr-12117` (Cited-by panel)
- `/law/bgb/144` (References + Referenced-by)

…across desktop 1440×900, tablet 768×1024, mobile 375×812. All 12 page loads reported `clean` for leaked template syntax (regex looks for any `{% … %}`, `{# … #}`, `{{ … }}` in `document.body.innerText`). Chip computed `background-color: rgb(3, 121, 196)` everywhere; widest measurement was 365px on the 375px mobile viewport (no overflow).

## Test plan

- [x] `{% comment %}` blocks render nothing on the affected pages (Playwright)
- [x] Chip uses primary theme color on desktop, tablet, mobile
- [x] Long-label chip wraps inside the badge instead of overflowing the viewport
- [x] No other multi-line `{# #}` comments introduced by #220/#223/#224 remain (grep audit)