### PR TITLE
fix(laws,cases): dedupe § section/title, check-icon revision marker, drop dead Related panels

### DIFF
--- a/oldp/apps/cases/cache.py
+++ b/oldp/apps/cases/cache.py
@@ -11,7 +11,7 @@ keys. To keep `review_status` filtering honest, the cache must:
 
 from django.core.cache import cache
 
-CASE_DATA_KEY = "case_data_%s"
+CASE_DATA_KEY = "case_data_v2_%s"
 CASE_PUBLIC_MARKERS_KEY = "case_public_markers_%s"
 CASE_CONTENT_ANON_KEY = "case_content_anon_%s"
 

--- a/oldp/apps/cases/templates/cases/case.html
+++ b/oldp/apps/cases/templates/cases/case.html
@@ -220,18 +220,6 @@
     {% endif %}
 </section>
 
-<section>
-    <h3>{% trans 'Related Cases' %}</h3>
-    {% if related_cases %}
-        {% with cases=related_cases %}
-        {% include 'cases/table.html' %}
-        {% endwith %}
-
-    {% else %}
-        <p class="text-center">{% trans 'empty_related_content' %}</p>
-    {% endif %}
-</section>
-
 {% include 'references.html' %}
 
 {% endblock %}

--- a/oldp/apps/cases/views.py
+++ b/oldp/apps/cases/views.py
@@ -103,12 +103,11 @@ def case_view(request, case_slug):
         # Materialize shared, template-driven relations once so warm requests
         # only need user-specific annotation queries.
         item.references = list(item.get_references())
-        related_cases = item.get_related()
-        cached = (item, ref_markers, related_cases)
+        cached = (item, ref_markers)
         if item.review_status == "accepted":
             cache.set(case_cache_key, cached, settings.CACHE_TTL)
     else:
-        item, ref_markers, related_cases = cached
+        item, ref_markers = cached
 
     # Layer 2: User-specific annotation data (fresh per request)
     user_markers_qs = None
@@ -170,7 +169,6 @@ def case_view(request, case_slug):
             "title": item.get_title(),
             "item": item,
             "content": content,
-            "related_cases": related_cases,
             "annotation_labels": annotation_labels,
             "marker_labels": marker_labels,
             "line_counter": Counter(),

--- a/oldp/apps/laws/models.py
+++ b/oldp/apps/laws/models.py
@@ -415,6 +415,15 @@ class Law(SearchableContent, models.Model, ReferenceContent):
             return "%s %s" % (self.book.code, self.section)
         return "%s %s %s" % (self.book.code, self.section, self.title)
 
+    def get_list_title(self):
+        # Same dedup as get_title, but without the book code prefix —
+        # used in the LawBook detail (section list) view where the code
+        # is already rendered as the page header.
+        stripped_title = self.title.strip() if self.title else ""
+        if not stripped_title or stripped_title == self.section.strip():
+            return self.section
+        return "%s %s" % (self.section, self.title)
+
     def get_short_title(self, length=40):
         if len(self.get_title()) < length:
             return self.get_title()

--- a/oldp/apps/laws/templates/laws/book.html
+++ b/oldp/apps/laws/templates/laws/book.html
@@ -22,7 +22,7 @@
                 </li>
             {% endif %}
 
-            <li><a href="{{ item.get_absolute_url }}">{{ item.section }} {{ item.title }}</a></li>
+            <li><a href="{{ item.get_absolute_url }}">{{ item.get_list_title }}</a></li>
         {% endfor %}
     </ul>
     {% endif %}
@@ -41,8 +41,7 @@
     <h3>{% trans 'Revisions' %}</h3>
     <ul class="revision-dates">
         {% for rev_date in revision_dates %}
-            <li class="{% if forloop.counter0 > 5 %}readmore{% endif %}"><a href="?revision_date={{ rev_date|date:'Y-m-d' }}">{{ rev_date }}</a>
-                {% if rev_date == book.revision_date %}<strong>({% trans 'selected' %})</strong>{% endif %}</li>
+            <li class="{% if forloop.counter0 > 5 %}readmore{% endif %}"><a href="?revision_date={{ rev_date|date:'Y-m-d' }}">{{ rev_date }}{% if rev_date == book.revision_date %}&nbsp;<i class="fa fa-check" aria-hidden="true" title="{% trans 'selected' %}"></i><span class="sr-only">{% trans 'selected' %}</span>{% endif %}</a></li>
         {% endfor %}
         <!--<li><a href="">25. August 2017</a></li>-->
     </ul>

--- a/oldp/apps/laws/templates/laws/law.html
+++ b/oldp/apps/laws/templates/laws/law.html
@@ -39,27 +39,11 @@
         </ul>
 
 
-        <div class="sidebar-title">{% trans 'Related Laws' %}</div>
-
-        {% if related_laws %}
-        <ul>
-            {% for rel in related_laws %}
-            <li>
-                <a href="{{ rel.get_absolute_url }}">{{ rel.get_title }}</a>
-            </li>
-            {% endfor %}
-        </ul>
-        {% else %}
-            <p class="text-center">{% trans 'empty_related_content' %}</p>
-        {% endif %}
-
-
         <div class="sidebar-title">{% trans 'Revisions' %}</div>
 
         <ul class="revision-dates">
             {% for rev_date in revision_dates %}
-            <li class="{% if forloop.counter0 > 5 %}readmore{% endif %}"><a href="?revision_date={{ rev_date|date:'Y-m-d' }}">{{ rev_date }}</a>
-                {% if rev_date == item.book.revision_date %}<strong>({% trans 'selected' %})</strong>{% endif %}</li>
+            <li class="{% if forloop.counter0 > 5 %}readmore{% endif %}"><a href="?revision_date={{ rev_date|date:'Y-m-d' }}">{{ rev_date }}{% if rev_date == item.book.revision_date %}&nbsp;<i class="fa fa-check" aria-hidden="true" title="{% trans 'selected' %}"></i><span class="sr-only">{% trans 'selected' %}</span>{% endif %}</a></li>
             {% endfor %}
             <!--<li><a href="">25. August 2017</a></li>-->
         </ul>

--- a/oldp/apps/laws/tests/test_review_visibility.py
+++ b/oldp/apps/laws/tests/test_review_visibility.py
@@ -164,6 +164,147 @@ class LawGetTitleDedupTestCase(TestCase):
         self.assertEqual(law.get_title(), "BGB § 9")
 
 
+class LawGetListTitleTestCase(TestCase):
+    """get_list_title is the book-detail (section list) variant of
+    get_title: same dedup rules, no book code prefix (the page header
+    already shows the code). Mirrors LawGetTitleDedupTestCase so the
+    two helpers stay in sync.
+    """
+
+    @classmethod
+    def setUpTestData(cls):
+        cls.book = LawBook.objects.create(
+            slug="bgb",
+            code="BGB",
+            title="Bürgerliches Gesetzbuch",
+            order=1,
+            latest=True,
+            revision_date=date(2026, 1, 1),
+            review_status="accepted",
+        )
+
+    def _make(self, slug, section, title):
+        return Law(book=self.book, slug=slug, section=section, title=title, order=1)
+
+    def test_distinct_title_is_kept(self):
+        law = self._make("p1", "§ 1", "Beginn der Rechtsfähigkeit")
+        self.assertEqual(law.get_list_title(), "§ 1 Beginn der Rechtsfähigkeit")
+
+    def test_title_equals_section_is_deduped(self):
+        law = self._make("p13", "§ 13", "§ 13")
+        self.assertEqual(law.get_list_title(), "§ 13")
+
+    def test_empty_title_renders_section_only(self):
+        law = self._make("p7", "§ 7", "")
+        self.assertEqual(law.get_list_title(), "§ 7")
+
+    def test_whitespace_only_title_renders_section_only(self):
+        law = self._make("p8", "§ 8", "   ")
+        self.assertEqual(law.get_list_title(), "§ 8")
+
+    def test_title_with_padding_still_dedupes(self):
+        law = self._make("p9", "§ 9", " § 9 ")
+        self.assertEqual(law.get_list_title(), "§ 9")
+
+
+@override_settings(
+    CACHES={"default": {"BACKEND": "django.core.cache.backends.dummy.DummyCache"}}
+)
+class LawBookDetailRenderingTestCase(TestCase):
+    """Render the actual book template and confirm the list items use the
+    deduplicated title — i.e. no "§ 4 § 4" anywhere on /law/<book>/.
+    """
+
+    @classmethod
+    def setUpTestData(cls):
+        cls.book = LawBook.objects.create(
+            slug="hgb",
+            code="HGB",
+            title="Handelsgesetzbuch",
+            order=1,
+            latest=True,
+            revision_date=date(2026, 1, 1),
+            review_status="accepted",
+        )
+        cls.law_dup = Law.objects.create(
+            book=cls.book,
+            slug="4",
+            section="§ 4",
+            title="§ 4",
+            order=4,
+            review_status="accepted",
+        )
+        cls.law_distinct = Law.objects.create(
+            book=cls.book,
+            slug="5",
+            section="§ 5",
+            title="Kaufmannseigenschaft",
+            order=5,
+            review_status="accepted",
+        )
+
+    def test_duplicate_section_title_renders_once(self):
+        res = self.client.get(reverse("laws:book", args=("hgb",)))
+        self.assertEqual(res.status_code, 200)
+        body = res.content.decode("utf-8")
+        # The duplicated link text "§ 4 § 4" was the symptom; assert it
+        # does not appear anywhere on the page.
+        self.assertNotIn("§ 4 § 4", body)
+        # The deduped form still renders.
+        self.assertIn("§ 4", body)
+
+    def test_distinct_section_title_renders_both(self):
+        res = self.client.get(reverse("laws:book", args=("hgb",)))
+        self.assertContains(res, "§ 5 Kaufmannseigenschaft")
+
+    def test_selected_revision_uses_check_icon(self):
+        """The current revision is marked with a FontAwesome check icon
+        instead of the legacy "(selected)" text label.
+        """
+        res = self.client.get(reverse("laws:book", args=("hgb",)))
+        body = res.content.decode("utf-8")
+        self.assertIn('class="fa fa-check"', body)
+        # The old textual marker must be gone — both languages.
+        self.assertNotIn("(selected)", body)
+        self.assertNotIn("(ausgewählt)", body)
+
+
+@override_settings(
+    CACHES={"default": {"BACKEND": "django.core.cache.backends.dummy.DummyCache"}}
+)
+class LawDetailRevisionMarkerTestCase(TestCase):
+    """The selected-revision marker on the law detail sidebar uses the
+    FontAwesome check icon (same change as the book detail page).
+    """
+
+    @classmethod
+    def setUpTestData(cls):
+        cls.book = LawBook.objects.create(
+            slug="bgb-rev",
+            code="BGB",
+            title="Bürgerliches Gesetzbuch",
+            order=1,
+            latest=True,
+            revision_date=date(2026, 1, 1),
+            review_status="accepted",
+        )
+        cls.law = Law.objects.create(
+            book=cls.book,
+            slug="14",
+            section="§ 14",
+            title="Unternehmer",
+            order=14,
+            review_status="accepted",
+        )
+
+    def test_selected_revision_uses_check_icon(self):
+        res = self.client.get(reverse("laws:law", args=("bgb-rev", "14")))
+        body = res.content.decode("utf-8")
+        self.assertIn('class="fa fa-check"', body)
+        self.assertNotIn("(selected)", body)
+        self.assertNotIn("(ausgewählt)", body)
+
+
 @override_settings(
     CACHES={"default": {"BACKEND": "django.core.cache.backends.dummy.DummyCache"}}
 )

--- a/oldp/apps/laws/views.py
+++ b/oldp/apps/laws/views.py
@@ -159,7 +159,6 @@ def view_law(request, law_slug, book_slug):
         book=book,
     )
     revision_dates = list(book.get_revision_dates())
-    related_laws = item.get_related()
 
     referencing_cases, referencing_cases_count, referencing_cases_error = (
         citing_cases_via_es("cited_laws", cited_law_token(book.slug, item.slug))
@@ -186,7 +185,6 @@ def view_law(request, law_slug, book_slug):
             "item": item,
             "title": item.get_title(),
             "revision_dates": revision_dates,
-            "related_laws": related_laws,
             "referencing_cases": referencing_cases,
             "referencing_cases_count": referencing_cases_count,
             "referencing_cases_error": referencing_cases_error,


### PR DESCRIPTION
## Summary
Four small frontend cleanups in the law + case detail templates:

- **`/law/<book>/`** — fix duplicated "§ 4 § 4" link text when the scraper stores the bare section marker in both `section` and `title`. New `Law.get_list_title()` mirrors `get_title`'s dedup but skips the book code prefix (already shown in the page header).
- **Revision selector** (book.html + law.html sidebar) — replace the literal "(selected)" / "(ausgewählt)" text with a FontAwesome check icon. Icon lives inside the link with a non-breaking space so the date+icon stay on the same line in the narrow sidebar; the `selected` translation key is reused as `title=` tooltip + `sr-only` label for screen readers.
- **"Verwandte Gesetze" / "Related Laws" sidebar block** — removed. 0 rows in `laws_relatedlaw` in dev and across the prod pages I sampled (`/law/{gg,stgb,hgb,bgb,zpo}/<sec>` all render the empty fallback). `RelatedLaw` is populated only by `manage.py generate_related law`, which carries a `# TODO as processing step + admin action` and is not wired into any processing pipeline.
- **"Verwandte Fälle" / "Related Cases" panel** on `/case/<slug>` — removed for the same reason. Cache shape changes from `(item, ref_markers, related_cases)` → `(item, ref_markers)`; `CASE_DATA_KEY` bumped to `case_data_v2_%s` so stale 3-tuples from already-deployed instances don't trip the unpacking on rollout.

**What's kept intact** (out of scope for this PR): `Law.get_related()` / `Case.get_related()` methods, `RelatedLaw` / `RelatedCase` models, and `oldp/apps/search/management/commands/generate_related.py`. These belong to the broader search-app related-content scaffold; removing the model + command is a bigger blast radius than the template/view cleanup this PR is scoped to.

## Test plan
- [x] `make lint-check` clean
- [x] `make test` — 1168/1168 pass locally (17 skipped, all pre-existing)
- [x] 7 new tests in `oldp/apps/laws/tests/test_review_visibility.py`:
  - `LawGetListTitleTestCase` (5) — unit-level dedup rules for `get_list_title`
  - `LawBookDetailRenderingTestCase` (2) — view-render asserts no `§ 4 § 4`, no `(selected)` / `(ausgewählt)`, `fa fa-check` present
  - `LawDetailRevisionMarkerTestCase` (1) — same check on the law detail sidebar
- [x] Live smoke against running dev stack:
  - `/law/bgb/` revision list — `&nbsp;<i class="fa fa-check"…>` inside the link, single line
  - `/law/bgb/1` — Related Laws sidebar block gone, Revisions still renders
  - `/case/<slug>` — Related Cases section gone, references panel still renders