### PR TITLE
perf+feat(cases): prefetch citations in CaseIndex + realtime ES sync on review_status

### DIFF
--- a/docs/api/case-creation.md
+++ b/docs/api/case-creation.md
@@ -220,6 +220,37 @@ Administrators can manage pending cases via the Django admin:
 4. Review case content and metadata
 5. Set **Review status** to `accepted` and save to approve the case
 
+### Bulk Approval
+
+For trusted submission paths (e.g., a vetted scraper backfill) the
+per-row admin flow is impractical. The `bulk_approve_cases`
+management command issues a single SQL `UPDATE` against the
+filtered queryset:
+
+```bash
+# Show count without writing
+python manage.py bulk_approve_cases --dry-run
+
+# Approve every pending case
+python manage.py bulk_approve_cases
+
+# Scoped approval (state, date range, originating token)
+python manage.py bulk_approve_cases --state 9
+python manage.py bulk_approve_cases --date-after 2022-10-01 --date-before 2026-01-01
+python manage.py bulk_approve_cases --token 42
+
+# Approve AND sync the touched rows into the ES index in the same pass
+python manage.py bulk_approve_cases --update-index
+```
+
+**Always pass `--update-index` on prod.** `QuerySet.update()` does
+not fire `post_save`, so the realtime ES sync handler on `Case`
+will not run — without `--update-index` the approved cases stay
+invisible to the search backend until the next `update_index
+cases` (~12.5 h with `-k 4` on prod). See
+[../elasticsearch.md](../elasticsearch.md#bulk-operations-bypass-the-signals)
+for the underlying mechanism.
+
 ### Querying API Submissions
 
 To view all cases created by a specific API token:

--- a/docs/elasticsearch.md
+++ b/docs/elasticsearch.md
@@ -39,7 +39,11 @@ the app container:
 Estimated runtime (May 2026 prod data):
 
 - `update_index laws` — ~4-5 min for ~110k law sections.
-- `update_index cases` — ~15-30 min for ~423k cases.
+- `update_index cases` — ~28 h single-worker, ~12.5 h with `-k 4`
+  for ~424k cases. Pass `-k 4` on prod to keep the wall time
+  manageable; the bottleneck is the ~1 MB `content` TextField pulled
+  per row, and parallel workers amortise the per-batch network cost
+  across 4 MySQL→app sockets.
 
 Before the reindex completes, downstream surfaces that rely on the
 new field render their empty state ("No cases cite this section
@@ -47,6 +51,57 @@ yet." / "No other cases cite this decision yet." in the web UI;
 empty paginated list in REST; `total_citing_cases: 0` in MCP). Free-
 text search, facets, and the search backend's existing fields are
 unaffected — the reindex is additive and incremental.
+
+### Realtime sync on Case writes
+
+`oldp.apps.cases.signals` connects `post_save` and `post_delete`
+handlers on `Case` that mirror the row-level `review_status` filter
+from `CaseIndex.index_queryset` into the ES index in realtime:
+
+| Event | ES action |
+|-------|-----------|
+| `Case.save()` with `review_status='accepted'`        | `index.update_object()` (upsert) |
+| `Case.save()` with `review_status` in `{pending,rejected}` | `index.remove_object()` |
+| `Case.delete()` (hard delete)                        | `index.remove_object()` |
+| `loaddata` (`raw=True` on the save signal)           | no-op — fixture flow runs `update_index` after |
+
+Both handlers defer via `transaction.on_commit`, so a rolled-back
+save never leaks into ES, and ES exceptions are logged but swallowed
+so a search-backend outage cannot break `Case.save()` callers. This
+covers admin edits and the case PATCH API endpoint; the only
+remaining drift source is `QuerySet.update()` (see below).
+
+### Bulk operations bypass the signals
+
+`Case.objects.filter(...).update(...)` is a single SQL `UPDATE` that
+**does not fire `post_save`**, so the realtime sync above does not
+run for bulk paths. `bulk_approve_cases` is the canonical example:
+
+    # Approve without updating ES — fast, but ES will drift
+    python manage.py bulk_approve_cases
+
+    # Approve and immediately sync the touched rows into ES
+    python manage.py bulk_approve_cases --update-index
+
+Always pass `--update-index` when running `bulk_approve_cases` on
+prod unless you plan to run a full `update_index cases` afterwards.
+The flag batches the updated PKs through `backend.update(index,
+cases)` in the same batch boundaries used by the SQL update, so
+there is no separate full-table scan.
+
+### Periodic reconciliation
+
+For periodic safety (e.g., after manual SQL edits or to catch any
+row that slipped through a bulk path) run the drift-prune script
+from the deployment repo:
+
+    deployment/scripts/prune_stale_es_docs.sh cases.case            # dry run
+    deployment/scripts/prune_stale_es_docs.sh cases.case --apply    # delete stale docs
+
+The script scrolls every `cases.case` doc PK from ES, diffs against
+the canonical `Case.get_queryset().values_list("pk")` set, and
+deletes only the orphans. Runs in seconds even on the full 424k
+index because it transfers only PKs, not document payloads.
 
 ### Service-layer surfaces backed by Elasticsearch
 

--- a/oldp/apps/cases/search_indexes.py
+++ b/oldp/apps/cases/search_indexes.py
@@ -1,3 +1,4 @@
+from django.db.models import Prefetch
 from haystack import indexes
 
 from oldp.apps.cases.models import Case
@@ -84,47 +85,74 @@ class CaseIndex(indexes.SearchIndex, indexes.Indexable):
     def prepare_date(self, obj):
         return obj.date  # .strftime('%Y-%m%-%d')
 
-    def prepare_cited_laws(self, obj):
-        """Collect distinct ``(law_book_slug, law_section_slug)`` pairs
-        from every reference attached to one of the case's reference
-        markers. Empty slugs are skipped — those rows are unassigned
-        references that haystack should not return as filter hits.
-
-        Querying ``Reference`` directly (rather than walking
-        ``casereferencemarker_set`` → ``references``) keeps the per-row
-        prepare cost to a single index-driven SELECT during reindex.
+    def _iter_prefetched_refs(self, obj):
+        """Yield every ``Reference`` attached to ``obj`` via its case
+        reference markers, using the per-batch prefetch chain set up by
+        ``index_queryset``. Falls back to a direct query when the
+        prefetch is absent (single-object reindex paths).
         """
-        from oldp.apps.references.models import Reference
+        markers = getattr(obj, "_prefetched_markers", None)
+        if markers is None:
+            from oldp.apps.references.models import Reference
 
-        pairs = (
-            Reference.objects.filter(
-                casereferencemarker__referenced_by_id=obj.pk,
+            yield from Reference.objects.filter(
+                casereferencemarker__referenced_by_id=obj.pk
             )
-            .exclude(law_book_slug="")
-            .exclude(law_section_slug="")
-            .values_list("law_book_slug", "law_section_slug")
-            .distinct()
-        )
+            return
+        for marker in markers:
+            yield from marker._prefetched_refs
+
+    def prepare_cited_laws(self, obj):
+        """Distinct ``(law_book_slug, law_section_slug)`` pairs across
+        the case's references. Empty slugs are skipped — those rows are
+        unassigned references that haystack should not return as filter
+        hits. Reads from the per-batch prefetch chain so each batch of
+        1000 cases costs 2 SQL queries instead of 2000.
+        """
+        pairs = {
+            (r.law_book_slug, r.law_section_slug)
+            for r in self._iter_prefetched_refs(obj)
+            if r.law_book_slug and r.law_section_slug
+        }
         return [cited_law_token(book, section) for book, section in pairs]
 
     def prepare_cited_cases(self, obj):
-        """Collect distinct cited-case PKs.
-
-        Stored as strings — haystack's ``MultiValueField`` tokenises
-        each entry, and ES indexes the string form for filter lookups.
-        Callers query with ``filter(cited_cases=str(case.pk))``.
+        """Distinct cited-case PKs, stored as strings — haystack's
+        ``MultiValueField`` tokenises each entry, and ES indexes the
+        string form for filter lookups. Callers query with
+        ``filter(cited_cases=str(case.pk))``.
         """
-        from oldp.apps.references.models import Reference
-
-        ids = (
-            Reference.objects.filter(
-                casereferencemarker__referenced_by_id=obj.pk,
-                case_id__isnull=False,
-            )
-            .values_list("case_id", flat=True)
-            .distinct()
-        )
+        ids = {
+            r.case_id for r in self._iter_prefetched_refs(obj) if r.case_id is not None
+        }
         return [str(i) for i in ids]
 
     def index_queryset(self, using=None):
-        return Case.get_queryset().select_related("court", "court__state")
+        """Reindex-time queryset. The prefetch chain pulls every case's
+        reference markers + the references through each marker in two
+        extra SQL queries per batch (one per join level), so the per-row
+        ``prepare_cited_laws`` / ``prepare_cited_cases`` work is pure
+        Python — no SQL per case. Without this, each 1000-case batch
+        triggered ~2000 individual ``Reference`` lookups.
+        """
+        from oldp.apps.references.models import CaseReferenceMarker, Reference
+
+        refs_qs = Reference.objects.only(
+            "id", "law_book_slug", "law_section_slug", "case_id"
+        )
+        markers_qs = CaseReferenceMarker.objects.only(
+            "id", "referenced_by_id"
+        ).prefetch_related(
+            Prefetch("references", queryset=refs_qs, to_attr="_prefetched_refs"),
+        )
+        return (
+            Case.get_queryset()
+            .select_related("court", "court__state")
+            .prefetch_related(
+                Prefetch(
+                    "casereferencemarker_set",
+                    queryset=markers_qs,
+                    to_attr="_prefetched_markers",
+                ),
+            )
+        )

--- a/oldp/apps/cases/signals.py
+++ b/oldp/apps/cases/signals.py
@@ -1,8 +1,15 @@
-from django.db.models.signals import post_save, pre_save
+import logging
+
+from django.db import transaction
+from django.db.models.signals import post_delete, post_save, pre_save
 from django.dispatch import receiver
+from haystack import connection_router, connections
+from haystack.exceptions import NotHandled
 
 from oldp.apps.cases.cache import invalidate_case_cache
 from oldp.apps.cases.models import Case
+
+logger = logging.getLogger(__name__)
 
 
 @receiver(pre_save, sender=Case)
@@ -23,3 +30,76 @@ def invalidate_case_detail_cache(sender, instance: Case, **kwargs):
     """
     if instance.slug:
         invalidate_case_cache(instance.slug)
+
+
+def _sync_case_to_search_index(instance: Case) -> None:
+    """Mirror the case's review_status to the ES search index.
+
+    ``CaseIndex.index_queryset`` only emits ``review_status='accepted'``
+    rows (via ``Case.get_queryset``), so the index is correct for
+    accepted cases — but when a case is demoted (accepted → pending or
+    rejected) the existing ES doc is never removed. ``update_index``
+    upserts; it doesn't reconcile. Without this hook the index drifts
+    until the next ``scripts/prune_stale_es_docs.sh`` run.
+
+    Promotions (any → accepted) are likewise covered: ``update_object``
+    upserts a fresh doc on transition into the indexable state.
+    """
+    using_backends = connection_router.for_write(instance=instance)
+    for using in using_backends:
+        try:
+            index = connections[using].get_unified_index().get_index(Case)
+        except NotHandled:
+            continue
+        try:
+            if instance.review_status == "accepted":
+                index.update_object(instance, using=using)
+            else:
+                index.remove_object(instance, using=using)
+        except Exception:
+            # ES outages must not break Case.save() callers; the index
+            # is rebuildable from the DB via ``update_index cases``.
+            logger.exception(
+                "search-index sync failed for case pk=%s using=%s",
+                instance.pk,
+                using,
+            )
+
+
+@receiver(post_save, sender=Case)
+def sync_case_to_search_index_on_save(
+    sender, instance: Case, raw: bool = False, **kwargs
+):
+    """Keep ES in sync with ``review_status`` transitions on every save.
+
+    Deferred to ``transaction.on_commit`` so a rolled-back save does
+    not leak into ES, and so bulk-save callers inside a transaction
+    coalesce naturally.
+    """
+    if raw:
+        # Loading fixtures — skip ES writes; ``loaddata`` is followed
+        # by an explicit ``update_index`` in our deploy flow.
+        return
+    transaction.on_commit(lambda: _sync_case_to_search_index(instance))
+
+
+@receiver(post_delete, sender=Case)
+def remove_case_from_search_index_on_delete(sender, instance: Case, **kwargs):
+    """Hard-deletes never leave residue in the index."""
+    transaction.on_commit(lambda: _sync_case_to_search_index_remove(instance))
+
+
+def _sync_case_to_search_index_remove(instance: Case) -> None:
+    using_backends = connection_router.for_write(instance=instance)
+    for using in using_backends:
+        try:
+            index = connections[using].get_unified_index().get_index(Case)
+            index.remove_object(instance, using=using)
+        except NotHandled:
+            continue
+        except Exception:
+            logger.exception(
+                "search-index removal failed for case pk=%s using=%s",
+                instance.pk,
+                using,
+            )

--- a/oldp/apps/cases/tests/test_search_index_sync.py
+++ b/oldp/apps/cases/tests/test_search_index_sync.py
@@ -1,0 +1,152 @@
+"""Tests for ``sync_case_to_search_index_on_save`` signal handler.
+
+Saves and hard-deletes of ``Case`` rows must mirror into ES via the
+``CaseIndex`` so the index does not drift when ``review_status``
+transitions away from ``accepted``. Without these signals the only
+reconciliation path was ``scripts/prune_stale_es_docs.sh``.
+
+The sync is deferred via ``transaction.on_commit`` so each test wraps
+its action in ``captureOnCommitCallbacks(execute=True)`` to run those
+callbacks in the test transaction.
+"""
+
+from unittest.mock import patch
+
+from django.test import TestCase
+
+from oldp.apps.cases.models import Case
+from oldp.apps.courts.models import Court
+
+
+class SyncCaseToSearchIndexTestCase(TestCase):
+    fixtures = [
+        "locations/countries.json",
+        "locations/cities.json",
+        "locations/states.json",
+        "courts/courts.json",
+    ]
+
+    def setUp(self):
+        self.court = Court.objects.first()
+
+    def _make_case(self, **overrides):
+        kwargs = dict(
+            court=self.court,
+            file_number="X 1/24",
+            date="2024-01-01",
+            content="<p>case body</p>",
+            review_status="accepted",
+        )
+        kwargs.update(overrides)
+        return Case.objects.create(**kwargs)
+
+    def test_save_accepted_calls_update_object(self):
+        with (
+            patch(
+                "oldp.apps.cases.search_indexes.CaseIndex.update_object"
+            ) as mock_update,
+            patch(
+                "oldp.apps.cases.search_indexes.CaseIndex.remove_object"
+            ) as mock_remove,
+            self.captureOnCommitCallbacks(execute=True),
+        ):
+            case = self._make_case(review_status="accepted")
+        mock_update.assert_called()
+        mock_remove.assert_not_called()
+        called_with_instance = mock_update.call_args.args[0]
+        self.assertEqual(called_with_instance.pk, case.pk)
+
+    def test_save_pending_calls_remove_object(self):
+        with (
+            patch(
+                "oldp.apps.cases.search_indexes.CaseIndex.update_object"
+            ) as mock_update,
+            patch(
+                "oldp.apps.cases.search_indexes.CaseIndex.remove_object"
+            ) as mock_remove,
+            self.captureOnCommitCallbacks(execute=True),
+        ):
+            self._make_case(review_status="pending")
+        mock_remove.assert_called()
+        mock_update.assert_not_called()
+
+    def test_save_rejected_calls_remove_object(self):
+        with (
+            patch(
+                "oldp.apps.cases.search_indexes.CaseIndex.update_object"
+            ) as mock_update,
+            patch(
+                "oldp.apps.cases.search_indexes.CaseIndex.remove_object"
+            ) as mock_remove,
+            self.captureOnCommitCallbacks(execute=True),
+        ):
+            self._make_case(review_status="rejected")
+        mock_remove.assert_called()
+        mock_update.assert_not_called()
+
+    def test_transition_accepted_to_pending_removes_from_index(self):
+        with self.captureOnCommitCallbacks(execute=True):
+            case = self._make_case(review_status="accepted")
+        with (
+            patch(
+                "oldp.apps.cases.search_indexes.CaseIndex.update_object"
+            ) as mock_update,
+            patch(
+                "oldp.apps.cases.search_indexes.CaseIndex.remove_object"
+            ) as mock_remove,
+            self.captureOnCommitCallbacks(execute=True),
+        ):
+            case.review_status = "pending"
+            case.save()
+        mock_remove.assert_called()
+        mock_update.assert_not_called()
+
+    def test_transition_pending_to_accepted_adds_to_index(self):
+        with self.captureOnCommitCallbacks(execute=True):
+            case = self._make_case(review_status="pending")
+        with (
+            patch(
+                "oldp.apps.cases.search_indexes.CaseIndex.update_object"
+            ) as mock_update,
+            patch(
+                "oldp.apps.cases.search_indexes.CaseIndex.remove_object"
+            ) as mock_remove,
+            self.captureOnCommitCallbacks(execute=True),
+        ):
+            case.review_status = "accepted"
+            case.save()
+        mock_update.assert_called()
+        mock_remove.assert_not_called()
+
+    def test_hard_delete_removes_from_index(self):
+        with self.captureOnCommitCallbacks(execute=True):
+            case = self._make_case(review_status="accepted")
+        with (
+            patch(
+                "oldp.apps.cases.search_indexes.CaseIndex.remove_object"
+            ) as mock_remove,
+            self.captureOnCommitCallbacks(execute=True),
+        ):
+            case.delete()
+        mock_remove.assert_called()
+
+    def test_raw_save_skips_sync(self):
+        """Loading fixtures (``raw=True``) bypasses ES — deploy pipeline
+        runs an explicit ``update_index`` after ``loaddata``.
+        """
+        from oldp.apps.cases.signals import sync_case_to_search_index_on_save
+
+        with self.captureOnCommitCallbacks(execute=True):
+            case = self._make_case(review_status="accepted")
+        with (
+            patch(
+                "oldp.apps.cases.search_indexes.CaseIndex.update_object"
+            ) as mock_update,
+            patch(
+                "oldp.apps.cases.search_indexes.CaseIndex.remove_object"
+            ) as mock_remove,
+            self.captureOnCommitCallbacks(execute=True),
+        ):
+            sync_case_to_search_index_on_save(sender=Case, instance=case, raw=True)
+        mock_update.assert_not_called()
+        mock_remove.assert_not_called()


### PR DESCRIPTION
## Summary

Two related improvements to how the `cases.case` ES index is kept in sync with the DB, after the 12.5 h prod reindex on v0.10.11 surfaced a per-batch N+1 in `CaseIndex.prepare_*` and the longstanding fact that `update_index` upserts but never removes orphans.

### 1. Prefetch the citation chain (perf)

`CaseIndex.prepare_cited_laws` and `prepare_cited_cases` each issued a fresh `Reference` query per case — ~2000 queries per 1000-case batch. `index_queryset` now pulls the marker chain plus the M2M references in two extra SQL queries per batch via `Prefetch`, and the `prepare_*` methods read from the cached chain. Single-instance paths (signal handler, ad-hoc shell) keep their existing direct-query fallback.

Wall-time win on the reindex was small because the per-row ~1 MB `content` TextField fetch dominates — but query load on the DB drops by 1000× per batch and this is the prerequisite for the next refactor where the fetch itself is also targeted.

### 2. Realtime ES sync on `Case` writes (feat)

Adds `post_save` + `post_delete` handlers on `Case` that mirror the row-level `review_status` filter from `CaseIndex.index_queryset` directly into ES:

| Event | ES action |
|---|---|
| `Case.save()` with `review_status='accepted'` | `index.update_object()` (upsert) |
| `Case.save()` with `review_status` ∈ `{pending,rejected}` | `index.remove_object()` |
| `Case.delete()` | `index.remove_object()` |
| `raw=True` (loaddata) | no-op — deploy flow runs `update_index` after fixtures |

Deferred via `transaction.on_commit` so a rolled-back save can't leak into ES, and ES exceptions are logged but swallowed so a search-backend outage can't break `Case.save()` callers. Verified end-to-end on prod (`oldp:v0.10.11-hotfix2`) by demoting and re-promoting case pk=521203 across the boundary.

### Known coverage gap (documented)

`QuerySet.update()` does not fire `post_save`, so `bulk_approve_cases` and similar bulk paths still bypass the realtime sync and must pass `--update-index`. Documented in:

- `docs/elasticsearch.md` — new "Realtime sync" / "Bulk operations bypass the signals" / "Periodic reconciliation" sections; also fixes the stale `update_index cases` runtime estimate (~15-30 min → 28 h single-worker / 12.5 h with `-k 4`).
- `docs/api/case-creation.md` — new "Bulk Approval" subsection with the standard invocations + an explicit prod-safety note about `--update-index`.

A drift-prune script (`scripts/prune_stale_es_docs.sh`) lives in the deployment repo for periodic reconciliation.

## Test plan

- [x] `make lint` — all 466 files clean
- [x] 7 new unit tests in `oldp/apps/cases/tests/test_search_index_sync.py` covering each save/delete/raw path
- [x] 41 existing review_status / signal tests still green
- [x] Parity check against prod data: `prepare_cited_laws` / `prepare_cited_cases` output identical to pre-change for 8 sample cases (PKs spanning the dataset)
- [x] End-to-end prod verification: `Case.save()` with review_status flips correctly add/remove the doc in ES

Note: `test_extract_law_refs_1` in `oldp/apps/cases/tests/test_processing.py` is failing on master as of this branch; failure is pre-existing and unrelated.