### PR TITLE
fix(references): skip stale citation markers + clear extracted_at on content drift

### DIFF
--- a/oldp/apps/cases/models.py
+++ b/oldp/apps/cases/models.py
@@ -196,6 +196,47 @@ class Case(
         ]
         # TODO court, year, file_number should be better
 
+    @classmethod
+    def from_db(cls, db, field_names, values):
+        # Snapshot the as-loaded ``content`` and ``references_extracted_at``
+        # so ``save()`` can detect a downstream mutation of ``content``
+        # and invalidate ``references_extracted_at`` when the caller
+        # didn't already refresh it. Marker offsets are anchored to
+        # whatever ``content`` was at extraction time; if a re-import or
+        # admin edit changes it without a fresh extraction, every stored
+        # ``CaseReferenceMarker`` silently drifts and the detail view
+        # renders broken anchors around random word fragments.
+        instance = super().from_db(db, field_names, values)
+        if "content" in field_names:
+            instance._content_at_load = instance.content
+        if "references_extracted_at" in field_names:
+            instance._references_extracted_at_at_load = instance.references_extracted_at
+        return instance
+
+    def save(self, *args, **kwargs):
+        loaded_content = getattr(self, "_content_at_load", None)
+        loaded_refs_at = getattr(self, "_references_extracted_at_at_load", None)
+        if (
+            self.pk is not None
+            and loaded_content is not None
+            and self.content != loaded_content
+            and self.references_extracted_at is not None
+            and self.references_extracted_at == loaded_refs_at
+        ):
+            # ``content`` changed but the caller didn't refresh
+            # ``references_extracted_at`` — markers are now stale.
+            # Cleared, not auto-re-extracted: extraction is too heavy
+            # to run inline on every save (model load is a ~200MB
+            # transformer for the default engine set). The standard
+            # ``process_cases`` batch filters on
+            # ``references_extracted_at IS NULL`` so the next run heals
+            # it; the defensive guard in ``insert_markers`` keeps the
+            # UI clean in the meantime.
+            self.references_extracted_at = None
+        super().save(*args, **kwargs)
+        self._content_at_load = self.content
+        self._references_extracted_at_at_load = self.references_extracted_at
+
     def is_private(self):
         """Whether this item is not publicly visible (pending or rejected)."""
         return self.review_status != "accepted"

--- a/oldp/apps/cases/tests/test_models.py
+++ b/oldp/apps/cases/tests/test_models.py
@@ -7,6 +7,7 @@ from django.conf import settings
 from django.core.exceptions import ValidationError
 from django.db import DataError
 from django.test import TestCase, tag
+from django.utils import timezone
 
 from oldp.apps.cases.models import Case
 from oldp.apps.courts.models import Court
@@ -152,3 +153,76 @@ class CasesModelsTestCase(TestCase):
 
         case = Case(title="Some titlr", file_number="ABC/123", slug="abc")
         self.assertTrue("abc" in case.get_absolute_url(), "Invalid url")
+
+
+@tag("models")
+class CaseContentDriftTestCase(TestCase):
+    """``Case.save()`` clears ``references_extracted_at`` when ``content``
+    changes, so the next ``process_cases`` run heals the now-stale
+    ``CaseReferenceMarker`` rows. See ``oldp.apps.cases.models.Case``.
+    """
+
+    fixtures = [
+        "locations/countries.json",
+        "locations/states.json",
+        "locations/cities.json",
+        "courts/courts.json",
+    ]
+
+    def _make_case(self, content):
+        case = Case.objects.create(
+            slug="drift-test",
+            file_number="DT/1",
+            court_id=Court.DEFAULT_ID,
+            content=content,
+            references_extracted_at=timezone.now(),
+        )
+        # Round-trip through the DB so ``from_db`` populates the
+        # snapshot of ``content`` and ``references_extracted_at``.
+        return Case.objects.get(pk=case.pk)
+
+    def test_changing_content_clears_extracted_at(self):
+        case = self._make_case("<p>original</p>")
+        self.assertIsNotNone(case.references_extracted_at)
+
+        case.content = "<p>modified</p>"
+        case.save()
+
+        case.refresh_from_db()
+        self.assertIsNone(case.references_extracted_at)
+
+    def test_unchanged_content_preserves_extracted_at(self):
+        case = self._make_case("<p>stable</p>")
+        original_ts = case.references_extracted_at
+
+        case.title = "new title"
+        case.save()
+
+        case.refresh_from_db()
+        self.assertEqual(case.references_extracted_at, original_ts)
+
+    def test_caller_refreshes_extracted_at_in_same_save(self):
+        """Processing pipeline rewrites ``content`` and stamps
+        ``references_extracted_at`` in the same save — that must not be
+        clobbered by the drift guard.
+        """
+        case = self._make_case("<p>orig [ref=u]x[/ref]</p>")
+
+        case.content = "<p>orig x</p>"
+        new_ts = timezone.now()
+        case.references_extracted_at = new_ts
+        case.save()
+
+        case.refresh_from_db()
+        self.assertIsNotNone(case.references_extracted_at)
+
+    def test_drift_guard_no_op_when_extracted_at_already_null(self):
+        case = self._make_case("<p>stale</p>")
+        case.references_extracted_at = None
+        case.save()
+        case.refresh_from_db()
+
+        case.content = "<p>changed</p>"
+        case.save()
+        case.refresh_from_db()
+        self.assertIsNone(case.references_extracted_at)

--- a/oldp/apps/lib/markers.py
+++ b/oldp/apps/lib/markers.py
@@ -1,7 +1,24 @@
+import html
 import logging
 from typing import List, Tuple
 
+from django.utils.html import strip_tags
+
 logger = logging.getLogger(__name__)
+
+
+def _slice_to_plain(value: str) -> str:
+    r"""Project a raw ``content`` slice to its plain-text form for
+    integrity comparison against a marker's expected text.
+
+    Mirrors the parts of refex's HTML normalization that affect short
+    citation spans: HTML entities are decoded (``&#167;`` → ``§``) and
+    inline tags are stripped (Wolters Kluwer RDFa ``<span>`` wrappers
+    around a section, ``<em>`` emphasis, etc.). Whitespace is left
+    intact — refex preserves ``\xa0`` and inner spaces inside
+    citations and we match on that exact form.
+    """
+    return html.unescape(strip_tags(value))
 
 
 class BaseMarker(object):
@@ -30,6 +47,19 @@ class BaseMarker(object):
 
     def get_marker_close(self):
         return self.get_marker_close_format().format(**self.__dict__)
+
+    def get_expected_text(self) -> str | None:
+        """Canonical text the marker's (start, end) slice should match.
+
+        Returning ``None`` opts out of the integrity check in
+        :func:`insert_markers`. Subclasses that persist the wrapped
+        citation text alongside the offsets should override this so
+        stored offsets that drift out of sync with ``content`` (e.g.
+        because ``case.content`` was modified without re-running
+        reference extraction) are skipped instead of producing broken
+        ``<a>`` tags around random word fragments.
+        """
+        return None
 
     def insert_marker(self, content, marker_offset) -> Tuple[str, int]:
         """Replace the original content with markers, e.g. [ref]xy[/ref].
@@ -87,6 +117,27 @@ def insert_markers(content: str, markers: List[BaseMarker]):
         ):
             logger.error("Marker overlaps with next marker: %s" % marker)
         else:
+            # Integrity guard: if the marker carries an expected text and
+            # the slice at (start, end) doesn't match, the stored offsets
+            # are stale (typically: ``case.content`` was modified after
+            # reference extraction). Render nothing rather than wrap a
+            # random word fragment in a citation anchor.
+            expected = marker.get_expected_text()
+            if expected is not None:
+                start = marker.get_start_position()
+                end = marker.get_end_position()
+                actual = _slice_to_plain(content[start:end])
+                if actual != expected:
+                    logger.warning(
+                        "Skipping stale marker %s: expected %r at [%d:%d] but found %r",
+                        marker,
+                        expected,
+                        start,
+                        end,
+                        actual,
+                    )
+                    continue
+
             # Everything fine, replace content
             content_with_markers, marker_offset = marker.insert_marker(
                 content_with_markers, marker_offset

--- a/oldp/apps/lib/tests/test_markers.py
+++ b/oldp/apps/lib/tests/test_markers.py
@@ -231,6 +231,111 @@ class InsertMarkersTestCase(TestCase):
         self.assertEqual(result, "Hello [ref=amp]&[/ref] World <test>")
 
 
+class ExpectedTextMarker(BaseMarker):
+    """Marker that carries a plain-text expectation for the (start, end) slice.
+
+    Models :class:`oldp.apps.references.models.ReferenceMarker`: the
+    citation text is captured at extraction time and the render-time
+    integrity guard compares it against ``content[start:end]``.
+    """
+
+    def __init__(self, start: int, end: int, text: str, marker_id: str = "test"):
+        self.start = start
+        self.end = end
+        self.text = text
+        self.marker_id = marker_id
+
+    def get_start_position(self) -> int:
+        return self.start
+
+    def get_end_position(self) -> int:
+        return self.end
+
+    def get_expected_text(self) -> str:
+        return self.text
+
+    def get_marker_open_format(self) -> str:
+        return "[ref={marker_id}]"
+
+    def get_marker_close_format(self) -> str:
+        return "[/ref]"
+
+
+@tag("lib", "markers")
+class IntegrityGuardTestCase(TestCase):
+    """Tests for the stale-marker integrity guard in ``insert_markers``."""
+
+    def test_matching_text_is_inserted(self):
+        """Marker whose stored slice matches its ``text`` renders normally."""
+        content = "Citation: § 25 StVG here"
+        markers = [ExpectedTextMarker(10, 19, text="§ 25 StVG", marker_id="ok")]
+
+        result = insert_markers(content, markers)
+
+        self.assertEqual(result, "Citation: [ref=ok]§ 25 StVG[/ref] here")
+
+    @patch("oldp.apps.lib.markers.logger")
+    def test_stale_offsets_skip_marker(self, mock_logger):
+        """Marker whose slice mismatches ``text`` is skipped, not rendered."""
+        # Simulates the prod bug: the stored marker text is "§ 25 StVG"
+        # but ``case.content`` was modified so (start, end) now slices
+        # an unrelated word fragment.
+        content = "Some completely different text here"
+        markers = [ExpectedTextMarker(5, 14, text="§ 25 StVG", marker_id="stale")]
+
+        result = insert_markers(content, markers)
+
+        self.assertEqual(result, content)
+        mock_logger.warning.assert_called_once()
+        # The warning should mention the expected text and what was found.
+        args = mock_logger.warning.call_args.args
+        self.assertIn("§ 25 StVG", args)
+
+    def test_slice_with_html_entities_matches_plain_text(self):
+        """Raw slice with HTML entities normalizes to plain text before compare.
+
+        Reflects how OLDP stores marker offsets: refex's
+        ``map_span_to_raw`` returns positions into raw HTML, so
+        ``content[start:end]`` can contain ``&#167;`` while ``marker.text``
+        holds the decoded ``§``. The guard must accept the match.
+        """
+        content = "Citation: &#167; 130a Satz 1 VwGO here"
+        end = len("Citation: &#167; 130a Satz 1 VwGO")
+        markers = [
+            ExpectedTextMarker(10, end, text="§ 130a Satz 1 VwGO", marker_id="ent")
+        ]
+
+        result = insert_markers(content, markers)
+
+        self.assertIn("[ref=ent]&#167; 130a Satz 1 VwGO[/ref]", result)
+
+    def test_slice_with_inline_tags_matches_after_strip(self):
+        """Inline HTML tags inside the slice (RDFa span wrappers etc.)
+        are stripped before comparison.
+        """
+        content = 'See <span class="rdfa">§ 25 StVG</span> for details'
+        start = content.index("<span")
+        end = content.index("</span>") + len("</span>")
+        markers = [ExpectedTextMarker(start, end, text="§ 25 StVG", marker_id="rdfa")]
+
+        result = insert_markers(content, markers)
+
+        self.assertIn('[ref=rdfa]<span class="rdfa">§ 25 StVG</span>[/ref]', result)
+
+    def test_marker_without_expected_text_still_renders(self):
+        """``BaseMarker.get_expected_text`` defaults to ``None`` → no check.
+
+        Annotation markers (``CaseMarker``) don't persist a canonical
+        text and must keep working unchanged.
+        """
+        content = "Annotation target here"
+        markers = [ConcreteMarker(0, 10, marker_id="ann")]
+
+        result = insert_markers(content, markers)
+
+        self.assertEqual(result, "[ref=ann]Annotation[/ref] target here")
+
+
 @tag("lib", "markers")
 class CustomMarkerFormatTestCase(TestCase):
     """Tests for custom marker formats."""

--- a/oldp/apps/references/models.py
+++ b/oldp/apps/references/models.py
@@ -220,6 +220,16 @@ class ReferenceMarker(models.Model, BaseMarker):
     def get_end_position(self):
         return self.end
 
+    def get_expected_text(self):
+        """Plain-text projection persisted at extraction time.
+
+        :func:`oldp.apps.lib.markers.insert_markers` compares this
+        against ``content[start:end]`` and skips the marker on
+        mismatch — typically when ``case.content`` was modified after
+        the markers were extracted.
+        """
+        return self.text
+
     def get_marker_open_format(self):
         return '<a href="#refs" onclick="clickRefMarker(this);" data-marker-id="{id}" class="ref">'
 


### PR DESCRIPTION
## Summary

Case-detail rendering wraps random word fragments in `<a class="ref">` anchors when a case's `content` is modified after reference extraction has run — marker `(start, end)` offsets stored at extraction time no longer line up with the current text.

Observed in prod for e.g. [`kg--2010-01-04-3-ws-b-66709-2-s`](https://de.openlegaldata.io/case/kg--2010-01-04-3-ws-b-66709-2-s) where every marker is uniformly shifted +1052 chars because `content` was rewritten 9 days after `references_extracted_at` without re-extraction. Marker `30508941` wraps `"ine Bestimmung"` instead of `"§ 25 Abs. 2a Satz 1 StVG"`. Same pattern on `kg--2026-01-27-5-ws-14825-5-ws-14`. Control case `bverwg-2020-08-06-6-b-1120` (timestamps equal) renders correctly.

refex and `BaseExtractRefs.save_citations` are correct — re-running extraction against current `case.content` locally produces aligned spans. The bug is that nothing invalidates markers when `case.content` changes out from under them.

## Fix

Two-part, both in OLDP. No `legal-reference-extraction` changes.

1. **Render-time integrity guard** in `oldp/apps/lib/markers.py`. New `BaseMarker.get_expected_text()` hook (default `None` = opt-out). `ReferenceMarker` overrides it to return `self.text` (the plain-text projection persisted by `save_citations`). On render, `insert_markers` compares `html.unescape(strip_tags(content[start:end]))` against the expected text — `strip_tags` + `html.unescape` so legitimate raw slices with `&#167;` entities or Wolters Kluwer RDFa `<span>` wrappers still match. Mismatch → skip the marker and log a warning. Annotation markers (`CaseMarker`) keep working via the `None` default.

2. **Drift detection on `Case.save()`** in `oldp/apps/cases/models.py`. `from_db` snapshots `content` and `references_extracted_at`; `save()` nulls `references_extracted_at` when `content` changed and the caller didn't refresh the timestamp in the same transaction (so the extract pipeline's own `case.content = remove_markers(...)` + `references_extracted_at = now()` save isn't clobbered). `process_cases` already filters on `references_extracted_at IS NULL`, so the next batch heals stale rows; the guard above keeps the UI clean in the meantime.

## Test plan

- [x] `oldp/apps/lib/tests/test_markers.py` — 5 new tests cover matching slice, stale-offset skip + warning, HTML-entity round-trip, RDFa `<span>` wrappers, and annotation-marker opt-out. All 24 marker tests pass.
- [x] `oldp/apps/cases/tests/test_models.py` — 4 new tests cover content drift clears `references_extracted_at`, unchanged content preserves it, simultaneous-update doesn't clobber the caller's stamp, and the no-op path when timestamp is already null.
- [x] End-to-end replay against actual prod HTML of case 517948: all 28 stale anchors skipped, zero leak through.
- [x] Same replay against working BVerwG case: all 75 freshly-extracted markers insert correctly, none falsely skipped.
- [x] `ruff check` + `ruff format --check` clean on all 5 changed files.
- [ ] `make test` in CI.

## Deployment

No schema migration required — `references_extracted_at` already exists and is nullable.

### 1. Deploy the code

Merge + roll the standard image build/deploy pipeline. After the rollout, the case-detail view immediately stops emitting broken anchors (the integrity guard runs at render time against the markers already in the DB), and any subsequent `case.save()` that changes `content` will null `references_extracted_at` automatically.

### 2. Mark currently stale cases for re-extraction

The drift guard only fires on *future* saves. Existing stale rows (`references_extracted_at < updated_date`) need their timestamp nulled in one DB update so the next `process_cases` batch picks them up:

```sql
UPDATE cases_case
SET references_extracted_at = NULL
WHERE references_extracted_at IS NOT NULL
  AND references_extracted_at < updated_date;
```

Run it inside a transaction and capture the rowcount before committing — that's the number of cases the backfill will touch. From the three reproducers + a spot check of nearby slugs, the affected set looks like the cases updated between roughly 2026-05-10 and 2026-05-19; the rowcount will confirm scope.

### 3. Re-extract

```bash
python manage.py process_cases \
    --input-handler db \
    --filter references_extracted_at__isnull=True \
    --step extract_refs \
    --limit -1
```

Existing flags (`--shards N --shard-index K`, `--per-page`) parallelise across workers if the rowcount warrants it — the prior 300k-case backfill used this same path. The processing step is wrapped in `transaction.atomic` with `bulk_delete_existing_markers` → re-extract → marker `bulk_create`, so readers never see a half-extracted state.

### 4. Verify

Spot-check the original reproducers — they should now render anchors around the citation text rather than mid-word fragments:

- https://de.openlegaldata.io/case/kg--2010-01-04-3-ws-b-66709-2-s
- https://de.openlegaldata.io/case/kg--2026-01-27-5-ws-14825-5-ws-14
- https://de.openlegaldata.io/case/bverwg-2020-08-06-6-b-1120 (control — was already correct, should stay correct)

Then confirm in logs that `Skipping stale marker` warnings drop to ~0 once the backfill finishes.

### Rollback

Revert the code commit; markers in the DB are unchanged by either the deploy or the backfill — only the `references_extracted_at` column is updated, and a stale-null is benign (it just queues a future re-extraction).

https://claude.ai/code/session_01Xi9kYjgdS3FZDb1fCfY3k2