### PR TITLE
fix(markers): fuzzy re-anchor stale offsets at render time

### DIFF
--- a/oldp/apps/lib/markers.py
+++ b/oldp/apps/lib/markers.py
@@ -24,7 +24,7 @@ def _slice_to_plain(value: str) -> str:
 def _find_marker_raw_span(
     content: str, marker_text: str, hint_start: int
 ) -> Tuple[int, int] | None:
-    """Locate the raw-content span matching ``marker_text``.
+    r"""Locate the raw-content span matching ``marker_text``.
 
     Stored marker offsets sometimes drift out of sync with
     ``case.content`` — either because the case was re-imported with a
@@ -48,9 +48,7 @@ def _find_marker_raw_span(
     if "\xa0" in marker_text:
         candidates.add(marker_text.replace("\xa0", "&#160;"))
     if "§" in marker_text and "\xa0" in marker_text:
-        candidates.add(
-            marker_text.replace("§", "&#167;").replace("\xa0", "&#160;")
-        )
+        candidates.add(marker_text.replace("§", "&#167;").replace("\xa0", "&#160;"))
 
     best: Tuple[int, int, int] | None = None
     for cand in candidates:

--- a/oldp/apps/lib/markers.py
+++ b/oldp/apps/lib/markers.py
@@ -21,6 +21,55 @@ def _slice_to_plain(value: str) -> str:
     return html.unescape(strip_tags(value))
 
 
+def _find_marker_raw_span(
+    content: str, marker_text: str, hint_start: int
+) -> Tuple[int, int] | None:
+    """Locate the raw-content span matching ``marker_text``.
+
+    Stored marker offsets sometimes drift out of sync with
+    ``case.content`` — either because the case was re-imported with a
+    different HTML-entity encoding (``&#167;`` vs ``§``) or because a
+    later content edit shifted the rest of the document. The render-
+    time guard in :func:`insert_markers` falls back to this helper to
+    recover the citation: it tries the literal ``marker_text`` plus a
+    small set of common HTML-entity inversions for the two characters
+    refex normalizes most often in German legal text (``§`` and
+    ``\\xa0`` non-breaking space), and returns the occurrence closest
+    to ``hint_start``.
+
+    Returns the ``(start, end)`` raw-content span on success, or
+    ``None`` when nothing matches — in which case the marker is
+    skipped (preserving the #228 "no broken anchor around random word
+    fragments" invariant).
+    """
+    candidates = {marker_text}
+    if "§" in marker_text:
+        candidates.add(marker_text.replace("§", "&#167;"))
+    if "\xa0" in marker_text:
+        candidates.add(marker_text.replace("\xa0", "&#160;"))
+    if "§" in marker_text and "\xa0" in marker_text:
+        candidates.add(
+            marker_text.replace("§", "&#167;").replace("\xa0", "&#160;")
+        )
+
+    best: Tuple[int, int, int] | None = None
+    for cand in candidates:
+        if not cand:
+            continue
+        idx = 0
+        while True:
+            pos = content.find(cand, idx)
+            if pos < 0:
+                break
+            dist = abs(pos - hint_start)
+            if best is None or dist < best[0]:
+                best = (dist, pos, pos + len(cand))
+            idx = pos + 1
+    if best is None:
+        return None
+    return best[1], best[2]
+
+
 class BaseMarker(object):
     def get_start_position(self) -> int:
         raise NotImplementedError()
@@ -92,44 +141,34 @@ class BaseMarker(object):
 
 
 def insert_markers(content: str, markers: List[BaseMarker]):
-    """Insert markers into content
+    """Insert markers into content.
+
+    Two-phase: first resolve each marker's effective ``(start, end)``
+    for this render (with re-anchor on offset drift), then sort by
+    start, detect overlaps, and splice the open/close tokens in.
 
     :param content: Without markers
     :param markers:
     :return:
     """
-    marker_offset = 0
-    content_with_markers = content
-    sorted_markers = sorted(
-        markers, key=lambda k: k.get_start_position()
-    )  # order by occurrence in text
-
-    for i, marker in enumerate(sorted_markers):
-        # Check on overlaps
-        if (
-            i > 0
-            and sorted_markers[i - 1].get_end_position() >= marker.get_start_position()
-        ):
-            logger.error("Marker overlaps with previous marker: %s" % marker)
-        elif (
-            i + 1 < len(sorted_markers)
-            and sorted_markers[i + 1].get_start_position() <= marker.get_end_position()
-        ):
-            logger.error("Marker overlaps with next marker: %s" % marker)
-        else:
-            # Integrity guard: if the marker carries an expected text and
-            # the slice at (start, end) doesn't match, the stored offsets
-            # are stale (typically: ``case.content`` was modified after
-            # reference extraction). Render nothing rather than wrap a
-            # random word fragment in a citation anchor.
-            expected = marker.get_expected_text()
-            if expected is not None:
-                start = marker.get_start_position()
-                end = marker.get_end_position()
-                actual = _slice_to_plain(content[start:end])
-                if actual != expected:
+    # Phase 1: resolve effective offsets per marker.
+    # For markers with an expected text (ReferenceMarker rows that
+    # captured the citation text at extraction time): verify the slice
+    # matches; if not, fuzzy-search content for the citation and re-
+    # anchor. Skip when neither path lands a match.
+    resolved: List[Tuple[int, int, BaseMarker]] = []
+    for marker in markers:
+        start = marker.get_start_position()
+        end = marker.get_end_position()
+        expected = marker.get_expected_text()
+        if expected is not None:
+            actual = _slice_to_plain(content[start:end])
+            if actual != expected:
+                found = _find_marker_raw_span(content, expected, start)
+                if found is None:
                     logger.warning(
-                        "Skipping stale marker %s: expected %r at [%d:%d] but found %r",
+                        "Skipping stale marker %s: expected %r at [%d:%d] "
+                        "but found %r; no fallback match in content",
                         marker,
                         expected,
                         start,
@@ -137,10 +176,43 @@ def insert_markers(content: str, markers: List[BaseMarker]):
                         actual,
                     )
                     continue
+                logger.info(
+                    "Re-anchored stale marker %s: stored [%d:%d] -> render [%d:%d]",
+                    marker,
+                    start,
+                    end,
+                    found[0],
+                    found[1],
+                )
+                start, end = found
+        resolved.append((start, end, marker))
 
-            # Everything fine, replace content
-            content_with_markers, marker_offset = marker.insert_marker(
-                content_with_markers, marker_offset
-            )
+    # Phase 2: order by position, drop overlaps, splice.
+    resolved.sort(key=lambda triple: triple[0])
+
+    marker_offset = 0
+    content_with_markers = content
+    for i, (start, end, marker) in enumerate(resolved):
+        # Check on overlaps
+        if i > 0 and resolved[i - 1][1] >= start:
+            logger.error("Marker overlaps with previous marker: %s" % marker)
+            continue
+        if i + 1 < len(resolved) and resolved[i + 1][0] <= end:
+            logger.error("Marker overlaps with next marker: %s" % marker)
+            continue
+
+        adjusted_start = start + marker_offset
+        adjusted_end = end + marker_offset
+        marker_open = marker.get_marker_open()
+        marker_close = marker.get_marker_close()
+        marker_offset += len(marker_open) + len(marker_close)
+
+        content_with_markers = (
+            content_with_markers[:adjusted_start]
+            + marker_open
+            + content_with_markers[adjusted_start:adjusted_end]
+            + marker_close
+            + content_with_markers[adjusted_end:]
+        )
 
     return content_with_markers

--- a/oldp/apps/lib/tests/test_markers.py
+++ b/oldp/apps/lib/tests/test_markers.py
@@ -337,6 +337,93 @@ class IntegrityGuardTestCase(TestCase):
 
 
 @tag("lib", "markers")
+class StaleMarkerReanchorTestCase(TestCase):
+    """Fuzzy re-anchor for stale offsets that still appear in content."""
+
+    def test_offset_drift_recovered_by_literal_search(self):
+        """A small offset shift on a unique citation is recovered."""
+        content = "PREFIX prepended. See § 25 StVG for details."
+        # Marker offsets were captured before "PREFIX prepended. " was added
+        stored_start = content.index("§ 25 StVG") - len("PREFIX prepended. ")
+        stored_end = stored_start + len("§ 25 StVG")
+        markers = [
+            ExpectedTextMarker(stored_start, stored_end, text="§ 25 StVG", marker_id="r")
+        ]
+
+        result = insert_markers(content, markers)
+
+        self.assertIn("[ref=r]§ 25 StVG[/ref]", result)
+
+    def test_entity_encoded_content_recovered(self):
+        """Stored slice is in plain text but live content has ``&#167;``.
+
+        Mirrors the prod BGH case where api-time extraction wrote
+        marker.text='§ 134 BGB' but stored content keeps the entity
+        encoded as ``&#167; 134 BGB`` (length 14 vs 9 → offsets shift
+        by 5/case occurrence).
+        """
+        content = "Vorne &#167; 134 BGB Hinten"
+        # Pretend offsets were stored against the decoded form
+        hint = 6  # roughly where the &#167; entity starts
+        markers = [
+            ExpectedTextMarker(hint, hint + len("§ 134 BGB"), text="§ 134 BGB", marker_id="x")
+        ]
+
+        result = insert_markers(content, markers)
+
+        self.assertIn("[ref=x]&#167; 134 BGB[/ref]", result)
+
+    def test_multiple_candidates_picks_nearest_to_hint(self):
+        """Same citation appearing twice: hint-distance picks the right one."""
+        content = (
+            "First occurrence § 25 StVG here, "
+            "second occurrence § 25 StVG there."
+        )
+        # Two markers: one near the first occurrence, one near the second
+        first_pos = content.index("§ 25 StVG")
+        second_pos = content.rindex("§ 25 StVG")
+        # Both stored offsets drift by -3 chars (simulating a small prefix
+        # change since extraction):
+        markers = [
+            ExpectedTextMarker(first_pos - 3, first_pos - 3 + 9, text="§ 25 StVG", marker_id="a"),
+            ExpectedTextMarker(second_pos - 3, second_pos - 3 + 9, text="§ 25 StVG", marker_id="b"),
+        ]
+
+        result = insert_markers(content, markers)
+
+        # Both citations should be wrapped (one with each marker_id)
+        self.assertIn("[ref=a]§ 25 StVG[/ref]", result)
+        self.assertIn("[ref=b]§ 25 StVG[/ref]", result)
+
+    def test_unrecoverable_marker_still_skipped(self):
+        """When the citation no longer exists in content, skip (no broken anchor)."""
+        content = "Some completely different text here"
+        markers = [
+            ExpectedTextMarker(5, 14, text="§ 25 StVG", marker_id="gone")
+        ]
+
+        result = insert_markers(content, markers)
+
+        # Content rendered unchanged — guard preserved
+        self.assertEqual(result, content)
+
+    def test_nbsp_entity_inversion_handled(self):
+        """``\\xa0`` in marker text maps to ``&#160;`` in stored content."""
+        content = "Siehe &#167;&#160;130a Satz&#160;1 VwGO unten."
+        # Hint near where the entity-encoded citation starts
+        marker_text = "§\xa0130a Satz\xa01 VwGO"
+        markers = [
+            ExpectedTextMarker(0, len(marker_text), text=marker_text, marker_id="nbsp")
+        ]
+
+        result = insert_markers(content, markers)
+
+        self.assertIn(
+            "[ref=nbsp]&#167;&#160;130a Satz&#160;1 VwGO[/ref]", result
+        )
+
+
+@tag("lib", "markers")
 class CustomMarkerFormatTestCase(TestCase):
     """Tests for custom marker formats."""
 

--- a/oldp/apps/lib/tests/test_markers.py
+++ b/oldp/apps/lib/tests/test_markers.py
@@ -347,7 +347,9 @@ class StaleMarkerReanchorTestCase(TestCase):
         stored_start = content.index("§ 25 StVG") - len("PREFIX prepended. ")
         stored_end = stored_start + len("§ 25 StVG")
         markers = [
-            ExpectedTextMarker(stored_start, stored_end, text="§ 25 StVG", marker_id="r")
+            ExpectedTextMarker(
+                stored_start, stored_end, text="§ 25 StVG", marker_id="r"
+            )
         ]
 
         result = insert_markers(content, markers)
@@ -366,7 +368,9 @@ class StaleMarkerReanchorTestCase(TestCase):
         # Pretend offsets were stored against the decoded form
         hint = 6  # roughly where the &#167; entity starts
         markers = [
-            ExpectedTextMarker(hint, hint + len("§ 134 BGB"), text="§ 134 BGB", marker_id="x")
+            ExpectedTextMarker(
+                hint, hint + len("§ 134 BGB"), text="§ 134 BGB", marker_id="x"
+            )
         ]
 
         result = insert_markers(content, markers)
@@ -375,18 +379,19 @@ class StaleMarkerReanchorTestCase(TestCase):
 
     def test_multiple_candidates_picks_nearest_to_hint(self):
         """Same citation appearing twice: hint-distance picks the right one."""
-        content = (
-            "First occurrence § 25 StVG here, "
-            "second occurrence § 25 StVG there."
-        )
+        content = "First occurrence § 25 StVG here, second occurrence § 25 StVG there."
         # Two markers: one near the first occurrence, one near the second
         first_pos = content.index("§ 25 StVG")
         second_pos = content.rindex("§ 25 StVG")
         # Both stored offsets drift by -3 chars (simulating a small prefix
         # change since extraction):
         markers = [
-            ExpectedTextMarker(first_pos - 3, first_pos - 3 + 9, text="§ 25 StVG", marker_id="a"),
-            ExpectedTextMarker(second_pos - 3, second_pos - 3 + 9, text="§ 25 StVG", marker_id="b"),
+            ExpectedTextMarker(
+                first_pos - 3, first_pos - 3 + 9, text="§ 25 StVG", marker_id="a"
+            ),
+            ExpectedTextMarker(
+                second_pos - 3, second_pos - 3 + 9, text="§ 25 StVG", marker_id="b"
+            ),
         ]
 
         result = insert_markers(content, markers)
@@ -398,9 +403,7 @@ class StaleMarkerReanchorTestCase(TestCase):
     def test_unrecoverable_marker_still_skipped(self):
         """When the citation no longer exists in content, skip (no broken anchor)."""
         content = "Some completely different text here"
-        markers = [
-            ExpectedTextMarker(5, 14, text="§ 25 StVG", marker_id="gone")
-        ]
+        markers = [ExpectedTextMarker(5, 14, text="§ 25 StVG", marker_id="gone")]
 
         result = insert_markers(content, markers)
 
@@ -408,7 +411,7 @@ class StaleMarkerReanchorTestCase(TestCase):
         self.assertEqual(result, content)
 
     def test_nbsp_entity_inversion_handled(self):
-        """``\\xa0`` in marker text maps to ``&#160;`` in stored content."""
+        r"""``\xa0`` in marker text maps to ``&#160;`` in stored content."""
         content = "Siehe &#167;&#160;130a Satz&#160;1 VwGO unten."
         # Hint near where the entity-encoded citation starts
         marker_text = "§\xa0130a Satz\xa01 VwGO"
@@ -418,9 +421,7 @@ class StaleMarkerReanchorTestCase(TestCase):
 
         result = insert_markers(content, markers)
 
-        self.assertIn(
-            "[ref=nbsp]&#167;&#160;130a Satz&#160;1 VwGO[/ref]", result
-        )
+        self.assertIn("[ref=nbsp]&#167;&#160;130a Satz&#160;1 VwGO[/ref]", result)
 
 
 @tag("lib", "markers")


### PR DESCRIPTION
## Summary

- Fixes a regression in v0.10.12 where ~40k cases stopped rendering their reference markers.
- Root cause: the #228 integrity guard correctly hides markers whose stored `(start, end)` no longer slices its text — but on prod a large slice of cases carries minor offset drift purely from HTML-entity encoding swings between extraction and the current stored content. The citation text is still right there in `case.content`, just a few chars off.
- Fix: on slice mismatch, search `content` for the marker text using a small set of common HTML-entity variants (literal, `§` ↔ `&#167;`, `\xa0` ↔ `&#160;`) and pick the occurrence closest to the stored start. Falls back to skip (preserved #228 invariant) when nothing matches.

## Investigation

Concrete prod examples:

| Slug | Marker | Stored | Re-extract | Delta |
|------|--------|--------|------------|-------|
| `bgh-2026-05-19-i-zr-7825` | `§ 134 BGB` | 403-417 | 409-423 | -6 |
| `bgh-2026-05-19-i-zr-7825` | `§ 4 Abs. 4 GlüStV` | 549-576 | 555-582 | -6 |
| `bgh-2026-05-19-i-zr-7825` | `§ 543 … ZPO` | 762-796 | 768-802 | -6 |
| `bgh-2026-05-19-i-zr-7825` | `§ 544 … ZPO` | 862-901 | 868-907 | -6 |

A constant -6 char shift = exactly one `&#167;` (6 chars) appeared in the content between extraction and the saved version. Re-extraction on the same content produces the correct offsets, so the data is recoverable — but with ~40k cases needing re-extraction (some blocked by issue #229), the render-time fallback restores UX without waiting.

`insert_markers` was refactored to use a resolved `(start, end, marker)` tuple list so re-anchored offsets flow through overlap detection and splicing without mutating the marker instance.

## Test plan

- [x] `oldp/apps/lib/tests/test_markers.py` — 29 tests pass, including 5 new ones for the fuzzy re-anchor (offset drift, entity-encoded content, nearest-to-hint disambiguation, unrecoverable skip, `\xa0`/`&#160;` inversion).
- [x] `oldp/apps/cases/tests/test_models.py` — 75 tests pass (covers `Case.get_content_as_html`).
- [x] Locally-built `oldp:v0.10.12-hotfix1` image deployed to prod (separate compose-side commit).
- [x] Prod verification: BGH 2026-05-19 case, SG Berlin 2010-01-04 case, and a non-reextracted case (LG Nürnberg-Fürth 2026-05-21) all render the correct citation text inside `<a class="ref">` anchors. No broken word-fragment anchors observed.