### PR TITLE
feat(logging): env-configurable rotation parameters

### DIFF
--- a/README.md
+++ b/README.md
@@ -133,6 +133,8 @@ You can as well override specific settings from `src/oldp/settings.py` with envi
 | `DJANGO_TEST_WITH_ES` | `False` | Run tests that require Elasticsearch |
 | `DJANGO_TEST_WITH_WEB` | `False` | Run tests that require web access |
 | `DJANGO_LOG_FILE` | `oldp.log` | Name of log file (in logs directory) |
+| `DJANGO_LOG_MAX_BYTES` | `15728640` | Max size of `oldp.log` before rotation, in bytes (default 15 MB). Raise in production if rotation churns through history faster than you can analyze it. |
+| `DJANGO_LOG_BACKUP_COUNT` | `10` | Number of rotated backups (`oldp.log.1` … `oldp.log.N`) to retain. Total disk usage is roughly `DJANGO_LOG_MAX_BYTES × (DJANGO_LOG_BACKUP_COUNT + 1)`. |
 | `DJANGO_CACHE_DISABLE` | `False` | Set to `True` to disable cache (Redis) |
 | `DJANGO_CACHE_BACKEND` | `file` | Cache backend selector. Set to `redis` to use `django-redis`. |
 | `DJANGO_CACHE_TTL` | `21600` (6 h) | Default TTL in seconds for cached API and HTML views (`@cache_page(CACHE_TTL)`). |

--- a/oldp/settings.py
+++ b/oldp/settings.py
@@ -131,6 +131,14 @@ class BaseConfiguration(Configuration):
     EMAIL_HOST_USER = values.Value("")
     EMAIL_HOST_PASSWORD = values.Value("")
 
+    # Rotating-file log retention. Defaults give ~150 MB total
+    # (15 MB × 10 backups), which under heavy bot traffic is only a few
+    # hours of history. Raise via env var in production to keep enough
+    # history for incident analysis. Applied to LOGGING in
+    # ``_apply_dynamic_settings`` below.
+    LOG_MAX_BYTES = values.IntegerValue(1024 * 1024 * 15)
+    LOG_BACKUP_COUNT = values.IntegerValue(10)
+
     # AnonymousPublicCacheMiddleware — see oldp/utils/middleware.py.
     # Makes anonymous GETs on public paths CDN-cacheable by stripping
     # Vary: Cookie and Set-Cookie and emitting Cache-Control: public.
@@ -699,6 +707,13 @@ class BaseConfiguration(Configuration):
             cls.LOGGING["handlers"]["logfile"]["filename"] = os.path.join(
                 cls.BASE_DIR, "logs", log_file
             )
+
+        # Apply env-configurable rotation parameters to the logfile
+        # handler. LOG_MAX_BYTES/LOG_BACKUP_COUNT are resolved by
+        # django-configurations at this point.
+        if "handlers" in cls.LOGGING and "logfile" in cls.LOGGING["handlers"]:
+            cls.LOGGING["handlers"]["logfile"]["maxBytes"] = cls.LOG_MAX_BYTES
+            cls.LOGGING["handlers"]["logfile"]["backupCount"] = cls.LOG_BACKUP_COUNT
 
     @classmethod
     def post_setup(cls):


### PR DESCRIPTION
## Summary

- Add `DJANGO_LOG_MAX_BYTES` and `DJANGO_LOG_BACKUP_COUNT` env vars on `BaseConfiguration` to control `oldp.log` rotation without code changes.
- Defaults match the previous hard-coded values (15 MB × 10 backups), so existing deployments are unchanged.
- Under heavy bot traffic the current 15 MB × 10 retention rolls through ~150 MB in under 6 hours, wiping the history needed for incident analysis. Production can now bump retention via env (e.g. `DJANGO_LOG_MAX_BYTES=104857600` + `DJANGO_LOG_BACKUP_COUNT=50` ≈ 5 GB).

## Implementation

- `LOG_MAX_BYTES = values.IntegerValue(1024 * 1024 * 15)` and `LOG_BACKUP_COUNT = values.IntegerValue(10)` declared at class level so django-configurations resolves them from the env.
- Applied to `cls.LOGGING["handlers"]["logfile"]` inside `_apply_dynamic_settings` (post_setup), mirroring the existing `LOG_FILE` override.
- README env table updated with both new vars.

## Test plan
- [x] `DJANGO_CONFIGURATION=TestConfiguration manage.py test oldp.utils.tests` — 27 tests pass.
- [x] Smoke test: `LOGGING['handlers']['logfile']` carries the env values when set (52428800 / 25) and the documented defaults (15728640 / 10) when unset.
- [ ] Watch a single rotation cycle in prod after merge to confirm the new sizes are honored (handler is the `ModeAwareRotatingFileHandler` from #207, which also enforces 0644 on rollover).

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>