### PR TITLE
feat(laws): dedupe_latest_books command + tie-break in set_law_book_revision

### DIFF
--- a/oldp/apps/laws/management/commands/dedupe_latest_books.py
+++ b/oldp/apps/laws/management/commands/dedupe_latest_books.py
@@ -1,0 +1,86 @@
+"""Resolve duplicate ``latest=True`` rows in ``laws_lawbook``.
+
+``oldp.apps.laws.views.get_latest_law_book`` queries
+``LawBook.objects.filter(slug=book_slug, latest=True)`` and warns
+``Book has more than one instance with latest=true: <slug>`` whenever
+that query returns more than one row. In production we see this for
+slugs like ``gg`` and ``uag``, which means two revisions of the same
+slug both carry ``latest=True``.
+
+This command finds slugs with more than one ``latest=True`` row, keeps
+the row with the latest ``revision_date`` (tiebreak: highest ``pk``),
+and unsets ``latest`` on the rest. ``--dry-run`` reports what would
+change without writing.
+
+Usage:
+    ./manage.py dedupe_latest_books            # apply
+    ./manage.py dedupe_latest_books --dry-run  # report only
+"""
+
+from __future__ import annotations
+
+import logging
+
+from django.core.management import BaseCommand
+from django.db import transaction
+from django.db.models import Count
+
+from oldp.apps.laws.models import LawBook
+
+logger = logging.getLogger(__name__)
+
+
+class Command(BaseCommand):
+    help = "Resolve duplicate latest=True LawBook rows (per slug)."
+
+    def add_arguments(self, parser):
+        parser.add_argument(
+            "--dry-run",
+            action="store_true",
+            help="Report duplicates without modifying the database.",
+        )
+
+    def handle(self, *args, dry_run: bool = False, **options):
+        duplicate_slugs = list(
+            LawBook.objects.filter(latest=True)
+            .values("slug")
+            .annotate(n=Count("id"))
+            .filter(n__gt=1)
+            .values_list("slug", "n")
+        )
+
+        if not duplicate_slugs:
+            self.stdout.write("No duplicate latest=True rows found.")
+            return
+
+        self.stdout.write(
+            f"Found {len(duplicate_slugs)} slug(s) with duplicate latest=True:"
+        )
+        for slug, n in duplicate_slugs:
+            self.stdout.write(f"  {slug}: {n} rows")
+
+        total_unset = 0
+        with transaction.atomic():
+            for slug, _ in duplicate_slugs:
+                rows = list(
+                    LawBook.objects.filter(slug=slug, latest=True)
+                    .order_by("-revision_date", "-pk")
+                    .values_list("pk", "revision_date")
+                )
+                keeper_pk, keeper_date = rows[0]
+                losers = [pk for pk, _ in rows[1:]]
+                self.stdout.write(
+                    f"  {slug}: keeping pk={keeper_pk} "
+                    f"(revision_date={keeper_date}); unsetting "
+                    f"pk={','.join(str(p) for p in losers)}"
+                )
+                if not dry_run:
+                    n = LawBook.objects.filter(pk__in=losers).update(latest=False)
+                    total_unset += n
+
+        if dry_run:
+            self.stdout.write(self.style.WARNING("Dry run — no changes written."))
+        else:
+            self.stdout.write(
+                self.style.SUCCESS(f"Unset latest on {total_unset} row(s).")
+            )

--- a/oldp/apps/laws/management/commands/set_law_book_revision.py
+++ b/oldp/apps/laws/management/commands/set_law_book_revision.py
@@ -22,23 +22,34 @@ class Command(BaseCommand):
             .order_by("code")
         )
 
-        # Update each code atomically to avoid race conditions
-        # First set the new latest=True, then unset old ones
+        # Update each code atomically to avoid race conditions.
+        # When multiple rows share the same max revision_date for a code
+        # (which happens for books imported on the same day), break the
+        # tie by highest pk so exactly ONE row ends up with latest=True.
+        # Without this tie-break, every duplicate gets latest=True and
+        # ``Law.get_latest_revision_url`` raises
+        # ``MultipleObjectsReturned`` on every request — see also
+        # ``dedupe_latest_books`` for cleaning up existing duplicates.
         with transaction.atomic():
             for rev in latest_revisions:
                 code = rev["code"]
                 max_date = rev["max_date"]
 
-                # First, mark the latest revision as latest=True
-                updated = LawBook.objects.filter(
-                    code=code, revision_date=max_date
-                ).update(latest=True)
+                keeper_pk = (
+                    LawBook.objects.filter(code=code, revision_date=max_date)
+                    .order_by("-pk")
+                    .values_list("pk", flat=True)
+                    .first()
+                )
+                if keeper_pk is None:
+                    continue
 
-                # Then, mark all other revisions for this code as latest=False
-                LawBook.objects.filter(code=code).exclude(
-                    revision_date=max_date
-                ).update(latest=False)
+                LawBook.objects.filter(pk=keeper_pk).update(latest=True)
+
+                LawBook.objects.filter(code=code).exclude(pk=keeper_pk).update(
+                    latest=False
+                )
 
                 logger.debug(
-                    f"Set latest for: {code} (revision_date={max_date}, updated={updated})"
+                    f"Set latest for: {code} (pk={keeper_pk}, revision_date={max_date})"
                 )

--- a/oldp/apps/laws/tests/test_commands.py
+++ b/oldp/apps/laws/tests/test_commands.py
@@ -1,9 +1,10 @@
 import os
+from io import StringIO
 
 from django.core.management import call_command
 from django.test import TransactionTestCase, tag
 
-from oldp.apps.laws.models import Law
+from oldp.apps.laws.models import Law, LawBook
 from oldp.utils.test_utils import web_test
 
 RESOURCE_DIR = os.path.join(os.path.dirname(os.path.realpath(__file__)), "resources")
@@ -56,3 +57,53 @@ class LawsCommandsTestCase(TransactionTestCase):
 
     def test_set_law_book_order(self):
         call_command("set_law_book_order", *[], **{})
+
+    def _seed_two_gg_with_latest_true(self):
+        """Bypass clean()/unique_together and force the duplicate state we want
+        to repair. Returns the two gg pks (newer first)."""
+        # Clear all latest flags first so we control the exact state.
+        LawBook.objects.filter(slug="gg").update(latest=False)
+        gg = list(LawBook.objects.filter(slug="gg").order_by("-pk"))
+        LawBook.objects.filter(pk__in=[gg[0].pk, gg[1].pk]).update(latest=True)
+        return gg[0].pk, gg[1].pk
+
+    def test_dedupe_latest_books_no_duplicates(self):
+        out = StringIO()
+        call_command("dedupe_latest_books", stdout=out)
+        self.assertIn("No duplicate", out.getvalue())
+
+    def test_dedupe_latest_books_resolves_duplicates(self):
+        keeper_pk, loser_pk = self._seed_two_gg_with_latest_true()
+        self.assertEqual(
+            LawBook.objects.filter(slug="gg", latest=True).count(), 2
+        )
+
+        out = StringIO()
+        call_command("dedupe_latest_books", stdout=out)
+
+        latest_rows = LawBook.objects.filter(slug="gg", latest=True)
+        self.assertEqual(latest_rows.count(), 1)
+        # Keeper is the row with the highest revision_date (and pk tiebreak).
+        expected_pk = (
+            LawBook.objects.filter(slug="gg", pk__in=[keeper_pk, loser_pk])
+            .order_by("-revision_date", "-pk")
+            .first()
+            .pk
+        )
+        self.assertEqual(latest_rows.first().pk, expected_pk)
+        self.assertIn("Unset latest on 1", out.getvalue())
+
+    def test_dedupe_latest_books_dry_run(self):
+        self._seed_two_gg_with_latest_true()
+        self.assertEqual(
+            LawBook.objects.filter(slug="gg", latest=True).count(), 2
+        )
+
+        out = StringIO()
+        call_command("dedupe_latest_books", "--dry-run", stdout=out)
+
+        # Dry run must leave both latest=True rows intact.
+        self.assertEqual(
+            LawBook.objects.filter(slug="gg", latest=True).count(), 2
+        )
+        self.assertIn("Dry run", out.getvalue())

--- a/oldp/apps/laws/tests/test_commands.py
+++ b/oldp/apps/laws/tests/test_commands.py
@@ -60,7 +60,8 @@ class LawsCommandsTestCase(TransactionTestCase):
 
     def _seed_two_gg_with_latest_true(self):
         """Bypass clean()/unique_together and force the duplicate state we want
-        to repair. Returns the two gg pks (newer first)."""
+        to repair. Returns the two gg pks (newer first).
+        """
         # Clear all latest flags first so we control the exact state.
         LawBook.objects.filter(slug="gg").update(latest=False)
         gg = list(LawBook.objects.filter(slug="gg").order_by("-pk"))

--- a/oldp/apps/laws/tests/test_commands.py
+++ b/oldp/apps/laws/tests/test_commands.py
@@ -74,9 +74,7 @@ class LawsCommandsTestCase(TransactionTestCase):
 
     def test_dedupe_latest_books_resolves_duplicates(self):
         keeper_pk, loser_pk = self._seed_two_gg_with_latest_true()
-        self.assertEqual(
-            LawBook.objects.filter(slug="gg", latest=True).count(), 2
-        )
+        self.assertEqual(LawBook.objects.filter(slug="gg", latest=True).count(), 2)
 
         out = StringIO()
         call_command("dedupe_latest_books", stdout=out)
@@ -95,15 +93,11 @@ class LawsCommandsTestCase(TransactionTestCase):
 
     def test_dedupe_latest_books_dry_run(self):
         self._seed_two_gg_with_latest_true()
-        self.assertEqual(
-            LawBook.objects.filter(slug="gg", latest=True).count(), 2
-        )
+        self.assertEqual(LawBook.objects.filter(slug="gg", latest=True).count(), 2)
 
         out = StringIO()
         call_command("dedupe_latest_books", "--dry-run", stdout=out)
 
         # Dry run must leave both latest=True rows intact.
-        self.assertEqual(
-            LawBook.objects.filter(slug="gg", latest=True).count(), 2
-        )
+        self.assertEqual(LawBook.objects.filter(slug="gg", latest=True).count(), 2)
         self.assertIn("Dry run", out.getvalue())


### PR DESCRIPTION
## Summary

Fixes the production warning ``Book has more than one instance with latest=true: <slug>`` (logged by ``oldp.apps.laws.views.get_latest_law_book``). Slugs ``gg`` (78 hits/3d) and ``uag`` (27 hits/3d) currently trigger it on every request that touches the affected revision.

Two changes:

1. **New management command** ``dedupe_latest_books`` that groups by slug, keeps the highest ``revision_date`` (pk-tiebreak), and unsets ``latest`` on the rest. Has ``--dry-run``.
2. **Root-cause fix** in ``set_law_book_revision``: previously used ``filter(code=code, revision_date=max_date).update(latest=True)`` which set ``latest=True`` on *every* row matching that pair — so any rows sharing a max date got duplicate-latest. Now picks exactly one keeper per code (highest pk).

## Test plan
- [x] ``DJANGO_CONFIGURATION=TestConfiguration manage.py test oldp.apps.laws.tests.test_commands`` — 7 unskipped tests pass (3 new + existing).
- [x] New tests cover: no-duplicates path, dedupe correctness, ``--dry-run``.

## Production deployment

No schema migration — just a code change plus a one-shot data fix.

1. Merge this PR. CI builds the new ``ghcr.io/openlegaldata/oldp`` image.
2. In the ``deployment`` repo, bump the image tag in ``docker-compose.de-prod.yaml`` to the new release.
3. ``make up-app`` to restart the app container with the new image.
4. **Preview** the affected rows:
   ```
   docker compose -f docker-compose.de-prod.yaml exec app \
       python manage.py dedupe_latest_books --dry-run
   ```
   Expect output listing slugs like ``gg``, ``uag``, and any others — for each, the keeper pk + revision_date and the loser pks. No DB writes happen.
5. **Apply** once the dry-run output looks right:
   ```
   docker compose -f docker-compose.de-prod.yaml exec app \
       python manage.py dedupe_latest_books
   ```
   Final line reports ``Unset latest on N row(s).``.
6. Verify in Django logs that ``Book has more than one instance with latest=true`` warnings stop appearing. Tail ``oldp.log`` for ~5 min.
7. ``set_law_book_revision`` is the same code path that would otherwise re-introduce duplicates — its tie-break fix in this PR means future imports won't regress.

**Rollback:** the dedupe is non-destructive (rows are still present, only the ``latest`` flag flipped). To revert: ``UPDATE laws_lawbook SET latest=1 WHERE pk IN (...)`` for the pks reported in step 5. The dry-run output is the audit trail.

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>