### PR TITLE
fix(auth): convert auth-related tables to utf8mb4 on MySQL/MariaDB

### DIFF
--- a/oldp/apps/accounts/migrations/0006_convert_auth_tables_utf8mb4.py
+++ b/oldp/apps/accounts/migrations/0006_convert_auth_tables_utf8mb4.py
@@ -1,0 +1,123 @@
+"""Convert auth-related tables to ``utf8mb4`` on MySQL/MariaDB.
+
+Production runs MariaDB with a connection charset of ``utf8mb4`` and
+collation ``utf8mb4_uca1400_ai_ci`` (the MariaDB 11 default), but the
+``auth_*``, ``account_*``, ``socialaccount_*``, ``django_session`` and
+``authtoken_*`` tables were originally created when the server default
+was ``latin1_swedish_ci`` and never converted.
+
+Result: every ``WHERE email = %s`` / ``WHERE username = %s`` query in the
+login flow compares a ``latin1_swedish_ci`` column against a
+``utf8mb4_*`` string literal and MariaDB refuses with::
+
+    OperationalError (1267, "Illegal mix of collations
+    (latin1_swedish_ci,IMPLICIT) and (utf8mb4_uca1400_ai_ci,COERCIBLE)
+    for operation '='")
+
+producing 500s on ``/accounts/login/`` and a silent index-loss on every
+other comparison against those columns (implicit charset conversion
+disables index usage).
+
+This migration runs ``ALTER TABLE <name> CONVERT TO CHARACTER SET
+utf8mb4 COLLATE utf8mb4_unicode_ci`` on each affected table that (a)
+exists in the schema and (b) is not already on ``utf8mb4``. It mirrors
+the targeted pattern used by ``cases/0026_convert_utf8mb4`` and
+``laws/0025_convert_utf8mb4``.
+
+Idempotent: re-running after success is a no-op because the filter on
+``information_schema.tables`` excludes already-converted tables.
+
+Reverse migration is a documented no-op: charset conversion of textual
+columns is effectively irreversible (any bytes outside latin1 would be
+lost on a backwards CONVERT).
+"""
+
+from __future__ import annotations
+
+import logging
+
+from django.db import migrations
+
+logger = logging.getLogger(__name__)
+
+# Tables touched by the auth/login flow that were created before
+# utf8mb4 became the default. Each name is checked against
+# information_schema.tables before ALTER so installs missing any of
+# these (e.g. tests that haven't run the corresponding 3rd-party
+# migrations) are tolerated.
+TABLES = (
+    "auth_user",
+    "auth_group",
+    "auth_permission",
+    "auth_user_groups",
+    "auth_user_user_permissions",
+    "auth_group_permissions",
+    "django_session",
+    "account_emailaddress",
+    "account_emailconfirmation",
+    "socialaccount_socialaccount",
+    "socialaccount_socialapp",
+    "socialaccount_socialapp_sites",
+    "socialaccount_socialtoken",
+    "authtoken_token",
+)
+
+TARGET_CHARSET = "utf8mb4"
+TARGET_COLLATION = "utf8mb4_unicode_ci"
+
+
+def convert(apps, schema_editor):
+    if schema_editor.connection.vendor != "mysql":
+        return
+    cursor = schema_editor.connection.cursor()
+    cursor.execute(
+        """
+        SELECT table_name, table_collation
+        FROM information_schema.tables
+        WHERE table_schema = DATABASE()
+          AND table_name IN %s
+        """,
+        [TABLES],
+    )
+    rows = cursor.fetchall()
+    if not rows:
+        logger.info(
+            "convert_auth_tables_utf8mb4: none of the target tables exist; skipping"
+        )
+        return
+    for name, collation in rows:
+        if collation and collation.startswith(TARGET_CHARSET):
+            logger.info(
+                "convert_auth_tables_utf8mb4: %s already on %s; skipping",
+                name,
+                collation,
+            )
+            continue
+        sql = (
+            f"ALTER TABLE `{name}` CONVERT TO CHARACTER SET "
+            f"{TARGET_CHARSET} COLLATE {TARGET_COLLATION}"
+        )
+        logger.info(
+            "convert_auth_tables_utf8mb4: %s (%s) -> %s",
+            name,
+            collation,
+            TARGET_COLLATION,
+        )
+        cursor.execute(sql)
+
+
+def noop(apps, schema_editor):
+    """Charset conversion of textual columns is effectively irreversible."""
+    pass
+
+
+class Migration(migrations.Migration):
+    atomic = False  # ALTER TABLE on MySQL/MariaDB is not transactional.
+
+    dependencies = [
+        ("accounts", "0005_backfill_default_permission_group"),
+    ]
+
+    operations = [
+        migrations.RunPython(convert, noop),
+    ]


### PR DESCRIPTION
## Summary

Fixes the recurring ``OperationalError (1267, "Illegal mix of collations (latin1_swedish_ci, IMPLICIT) and (utf8mb4_uca1400_ai_ci, COERCIBLE) for operation '='")`` on ``/accounts/login/``.

The ``auth_*``, ``account_*``, ``socialaccount_*``, ``django_session`` and ``authtoken_*`` tables were originally created when the MariaDB default server collation was ``latin1_swedish_ci``. The connection charset is now ``utf8mb4 / utf8mb4_uca1400_ai_ci`` (MariaDB 11 default), so every ``WHERE email = %s`` / ``WHERE username = %s`` comparison raises the implicit-conversion error.

Beyond the visible 500s, every comparison against those columns also **silently disables index usage** — each login pays a full table scan on ``auth_user.email``.

## What the migration does

Adds ``accounts/0006_convert_auth_tables_utf8mb4.py`` that runs

```sql
ALTER TABLE <name> CONVERT TO CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci
```

on each of the affected tables that (a) exists in the schema and (b) is not already on ``utf8mb4``. Mirrors the pattern of ``cases/0026_convert_utf8mb4`` and ``laws/0025_convert_utf8mb4``.

- Idempotent: filtered against ``information_schema.tables.table_collation``, so re-running is a no-op.
- ``atomic = False`` because ALTER TABLE on MySQL/MariaDB is implicitly committing.
- Reverse is a documented no-op (charset conversion of text is effectively irreversible).

## Test plan
- [x] ``DJANGO_CONFIGURATION=TestConfiguration manage.py migrate accounts`` — applies cleanly.
- [x] ``DJANGO_CONFIGURATION=TestConfiguration manage.py test oldp.apps.accounts`` — 98/98 pass.
- [ ] Apply in prod and confirm /accounts/login/ no longer 500s.

## Production deployment

**Brief downtime is expected** on the affected tables while the ``ALTER TABLE`` runs. ``auth_user`` and the ``account_*`` tables are small (single-digit MB on this install), so each table converts in under a second.

1. **Snapshot the DB** before the deploy:
   ```
   docker compose -f docker-compose.de-prod.yaml exec db \
       mariadb-dump -u root --single-transaction oldp > /srv/backups/oldp-pre-utf8mb4-$(date -u +%Y%m%d-%H%M).sql
   ```
2. Merge this PR. CI builds the new ``ghcr.io/openlegaldata/oldp`` image.
3. In the ``deployment`` repo, bump the image tag in ``docker-compose.de-prod.yaml`` to the new release.
4. ``make up-app`` — the entrypoint runs ``manage.py migrate`` and applies ``accounts/0006_convert_auth_tables_utf8mb4``. Expected migration runtime <30 s; if it stalls longer, the migration logs each ALTER via ``logger.info`` so you can see which table is in flight.
5. Verify post-migration:
   ```
   docker compose -f docker-compose.de-prod.yaml exec db mariadb -u root oldp -e "
     SELECT table_name, table_collation
       FROM information_schema.tables
      WHERE table_schema='oldp'
        AND table_name IN (
          'auth_user','account_emailaddress','django_session','authtoken_token'
        );
   "
   ```
   Every row should now show ``utf8mb4_unicode_ci``.
6. Smoke-test the login flow: POST to ``/accounts/login/`` with a known account and confirm 200 + session cookie. Then tail ``oldp.log`` for ~5 min and verify no more ``Illegal mix of collations`` ``OperationalError`` entries.

**Rollback:** if the migration aborts mid-table (very unlikely on small tables but possible on a locked row), the partial change is committed (ALTER is implicit COMMIT). Recovery is the DB snapshot from step 1:
```
docker compose -f docker-compose.de-prod.yaml exec -T db mariadb -u root oldp < /srv/backups/oldp-pre-utf8mb4-<timestamp>.sql
```
and revert the image bump.

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>