### PR TITLE
fix(refs): convert references_* tables to utf8mb4 (closes #229)

### DIFF
--- a/oldp/apps/references/migrations/0015_convert_references_utf8mb4.py
+++ b/oldp/apps/references/migrations/0015_convert_references_utf8mb4.py
@@ -1,0 +1,123 @@
+r"""Convert references_* tables to utf8mb4 (closes openlegaldata/oldp#229).
+
+``process_cases ... extract_refs`` fails on every row whose extracted
+marker text contains a 3-byte UTF-8 character (THIN SPACE U+2009,
+NARROW NO-BREAK SPACE U+202F, etc.) because the
+``references_casereferencemarker.text`` column — and the sibling
+``references_lawreferencemarker`` / ``references_reference`` tables —
+were created when the MariaDB default was a narrow charset (latin1
+in our case). Without this conversion roughly 14% of the post-#228
+backfill of ``cases_case.references_extracted_at IS NULL`` rows
+hard-fail with::
+
+    MySQLdb.OperationalError (1366, "Incorrect string value:
+    '\\xE2\\x80\\x89...' for column
+    `oldp`.`references_casereferencemarker`.`text` at row N")
+
+Mirrors the pattern of ``cases/0026_convert_utf8mb4`` and
+``laws/0025_convert_utf8mb4``, but with one important difference:
+``references_casereferencemarker`` is the marker table for ~17 M rows
+in production, so the ALTER may take real time. The migration is
+marked ``atomic = False`` and the SQL is emitted as
+``ALGORITHM=INPLACE, LOCK=NONE`` where supported, falling back to a
+plain ALTER if the server rejects the algorithm hint.
+
+Idempotent: skips tables already on ``utf8mb4`` via
+``information_schema.tables.table_collation``. Reverse is a documented
+no-op — see the other utf8mb4 conversion migrations in this repo.
+"""
+
+from __future__ import annotations
+
+import logging
+
+from django.db import migrations
+
+logger = logging.getLogger(__name__)
+
+# Tables affected by issue #229. The marker tables are the ones that
+# actually break extraction; ``references_reference`` is included for
+# consistency so future schema queries don't need to discriminate by
+# charset.
+TABLES = (
+    "references_casereferencemarker",
+    "references_lawreferencemarker",
+    "references_reference",
+)
+
+TARGET_CHARSET = "utf8mb4"
+TARGET_COLLATION = "utf8mb4_unicode_ci"
+
+
+def convert(apps, schema_editor):
+    if schema_editor.connection.vendor != "mysql":
+        return
+    cursor = schema_editor.connection.cursor()
+    cursor.execute(
+        """
+        SELECT table_name, table_collation
+        FROM information_schema.tables
+        WHERE table_schema = DATABASE()
+          AND table_name IN %s
+        """,
+        [TABLES],
+    )
+    rows = cursor.fetchall()
+    if not rows:
+        logger.info("convert_references_utf8mb4: no target tables in schema; skipping")
+        return
+    for name, collation in rows:
+        if collation and collation.startswith(TARGET_CHARSET):
+            logger.info(
+                "convert_references_utf8mb4: %s already on %s; skipping",
+                name,
+                collation,
+            )
+            continue
+        # Prefer the in-place / no-lock algorithm where the server
+        # supports it (MariaDB 10.3+, MySQL 8). If the engine rejects
+        # those hints (e.g. because of a unique index on the converted
+        # column that would need a copy), fall back to a plain
+        # ALTER, which copies the table.
+        sql_inplace = (
+            f"ALTER TABLE `{name}` "
+            f"CONVERT TO CHARACTER SET {TARGET_CHARSET} COLLATE {TARGET_COLLATION}, "
+            f"ALGORITHM=INPLACE, LOCK=NONE"
+        )
+        sql_copy = (
+            f"ALTER TABLE `{name}` "
+            f"CONVERT TO CHARACTER SET {TARGET_CHARSET} COLLATE {TARGET_COLLATION}"
+        )
+        try:
+            logger.info(
+                "convert_references_utf8mb4: %s (%s) -> %s (INPLACE/NONE)",
+                name,
+                collation,
+                TARGET_COLLATION,
+            )
+            cursor.execute(sql_inplace)
+        except Exception as exc:  # noqa: BLE001 — fall back regardless
+            logger.warning(
+                "convert_references_utf8mb4: INPLACE failed on %s (%s); "
+                "falling back to copying ALTER",
+                name,
+                exc,
+            )
+            cursor.execute(sql_copy)
+
+
+def noop(apps, schema_editor):
+    """Charset conversion of textual columns is effectively irreversible."""
+    pass
+
+
+class Migration(migrations.Migration):
+    atomic = False  # ALTER TABLE on MySQL/MariaDB is implicitly committing.
+
+    dependencies = [
+        ("references", "0014_backfill_reference_law_slugs"),
+    ]
+
+    operations = [
+        migrations.RunPython(convert, noop),
+    ]


### PR DESCRIPTION
## Summary

Closes #229.

``process_cases ... extract_refs`` fails per-row with MySQL ``OperationalError (1366, "Incorrect string value")`` on any case whose extracted marker text contains a 3-byte UTF-8 character that doesn't fit the column's current narrow charset. Observed bytes in production:

| UTF-8 bytes | Codepoint | Name |
|---|---|---|
| ``\xE2\x80\x89`` | U+2009 | THIN SPACE |
| ``\xE2\x80\xAF`` | U+202F | NARROW NO-BREAK SPACE |

The ``references_*`` tables were created when the MariaDB default was ``latin1`` and never converted, mirroring the legacy that ``cases/0026_convert_utf8mb4`` and ``laws/0025_convert_utf8mb4`` already repaired for the ``cases_case`` / ``laws_*`` tables. Per #229, ~14% of the post-#228 backfill (of ~45k rows with ``references_extracted_at IS NULL``) hard-fails today.

Same root cause as #233 (auth tables) — different tables.

## What the migration does

Adds ``references/0015_convert_references_utf8mb4.py`` that runs

```sql
ALTER TABLE <name> CONVERT TO CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci
```

on each of:

- ``references_casereferencemarker`` (~17 M rows in prod)
- ``references_lawreferencemarker``
- ``references_reference``

Differences from #233 (which only touched small auth tables):

- ``atomic = False`` (ALTER TABLE on MySQL/MariaDB is implicitly committing).
- Emits ``ALGORITHM=INPLACE, LOCK=NONE`` first and falls back to a copying ALTER only if the server rejects the algorithm hint (e.g. an existing index constraint prevents in-place).
- Idempotent against ``information_schema.tables.table_collation`` — re-running is a no-op.
- Reverse is a documented no-op (charset conversion of text is effectively irreversible).

## Test plan
- [x] ``DJANGO_CONFIGURATION=TestConfiguration manage.py migrate references`` — applies cleanly.
- [x] Pre-existing failures in ``oldp.apps.references`` (9 fails on master) are unchanged.
- [ ] Apply in prod and re-run the ``extract_refs`` backfill — verify the ``Incorrect string value`` errors stop and ``references_extracted_at IS NULL`` count drops.

## Production deployment

**Substantial downtime risk on ``references_casereferencemarker``** — it's the ~17 M-row marker table. Plan a window before merging.

1. **Inspect table size first** so you know what you're committing to:
   ```
   docker compose -f docker-compose.de-prod.yaml exec db mariadb -u root oldp -e "
     SHOW TABLE STATUS WHERE Name IN (
       'references_casereferencemarker',
       'references_lawreferencemarker',
       'references_reference'
     );
   "
   ```
   Expect ``references_casereferencemarker`` to be the slow one. Note ``Data_length + Index_length`` — that's roughly the bytes the ALTER will rewrite if INPLACE/NONE isn't accepted.

2. **Snapshot the DB**:
   ```
   docker compose -f docker-compose.de-prod.yaml exec db \
       mariadb-dump -u root --single-transaction oldp > /srv/backups/oldp-pre-refs-utf8mb4-$(date -u +%Y%m%d-%H%M).sql
   ```

3. **Try the in-place ALTER manually first** (the migration will do this automatically, but pre-running outside the migration lets you measure and bail without leaving a half-applied migration record):
   ```
   docker compose -f docker-compose.de-prod.yaml exec db mariadb -u root oldp -e "
     ALTER TABLE references_casereferencemarker
       CONVERT TO CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci,
       ALGORITHM=INPLACE, LOCK=NONE;
   "
   ```
   - If this succeeds: writes continue throughout, total time scales with table size but the site stays up.
   - If MariaDB rejects with ``ERROR 1846 (0A000): ALGORITHM=INPLACE is not supported`` or ``LOCK=NONE is not supported``, fall back to ``pt-online-schema-change`` (Percona Toolkit) or schedule a maintenance window and let the migration use its copying-ALTER fallback.

4. Once you're confident the ALTER will run in an acceptable window:
   - Merge this PR. CI builds the new image.
   - In the ``deployment`` repo, bump the image tag in ``docker-compose.de-prod.yaml``.
   - ``make up-app`` — entrypoint runs ``manage.py migrate`` and applies the migration. The migration logs each ALTER via ``logger.info``, so you can ``docker compose logs -f app`` to see progress.

5. Verify post-migration:
   ```
   docker compose -f docker-compose.de-prod.yaml exec db mariadb -u root oldp -e "
     SELECT table_name, table_collation
       FROM information_schema.tables
      WHERE table_schema='oldp'
        AND table_name IN (
          'references_casereferencemarker',
          'references_lawreferencemarker',
          'references_reference'
        );
   "
   ```
   All three rows should now show ``utf8mb4_unicode_ci``.

6. **Re-run the ``extract_refs`` backfill** from issue #229:
   ```
   docker compose -f docker-compose.de-prod.yaml --env-file oldp-de-prod.env \
     run --rm --no-deps --entrypoint bash app -lc \
       "cd /oldp && python manage.py process_cases --input-handler db \
          --filter references_extracted_at__isnull=True \
          --limit -1 --per-page 200 extract_refs"
   ```
   The ``Incorrect string value`` failures should stop. Confirm by tailing ``oldp.log`` and watching for ``Cannot process case`` warnings — there should be no more THIN SPACE / NARROW NO-BREAK SPACE hits.

**Rollback:** the ALTER is committed before the migration record is written (since ``atomic = False``), so a failed migration leaves the table converted but the ``django_migrations`` row missing. To recover from the (very unlikely) case where the ALTER itself corrupts data: restore the snapshot from step 2 and revert the image bump. Charset conversion of UTF-8-encoded bytes from latin1 storage is effectively lossless on the codepoints we hit in practice, so a real data-loss scenario is hard to construct here.

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>