### PR TITLE
fix(cases-api): accept and persist source_url on POST /api/cases/

### DIFF
--- a/docs/api/case-creation.md
+++ b/docs/api/case-creation.md
@@ -52,6 +52,7 @@ Authorization: Token YOUR_API_TOKEN
 | `ecli` | string | No | European Case Law Identifier |
 | `abstract` | string | No | Case summary/abstract in HTML format |
 | `title` | string | No | Case title |
+| `source_url` | string | No | URL the case content was extracted from (PDF, HTML detail page, API endpoint, ZIP, etc.). Defaults to empty string if omitted. |
 | `source` | object | No | Source information. If omitted, the default source is assigned. |
 | `source.name` | string | Yes (if `source` given) | Source name used for lookup. If no source with this name exists, a new one is created. |
 | `source.homepage` | string | No | Source homepage URL. Used only when creating a new source; ignored if the source already exists. |
@@ -70,6 +71,7 @@ curl -X POST "https://de.openlegaldata.io/api/cases/?extract_refs=true" \
     "type": "Urteil",
     "ecli": "ECLI:DE:BGH:2021:150521UIZR123.21.0",
     "abstract": "<p>Zur Haftung bei Verletzung von Verkehrssicherungspflichten.</p>",
+    "source_url": "https://example.com/scraper/cases/i-zr-123-21.pdf",
     "source": {
       "name": "My Court Scraper",
       "homepage": "https://example.com/scraper"
@@ -284,6 +286,7 @@ case_data = {
     "date": "2021-06-15",
     "content": "<p>Im Namen des Volkes ergeht folgendes Urteil...</p>",
     "type": "Urteil",
+    "source_url": "https://example.com/scraper/cases/ag-berlin-mitte-10-c-123-21.html",
 }
 
 response = requests.post(f"{BASE_URL}/cases/", json=case_data, headers=headers)

--- a/oldp/apps/cases/api_views.py
+++ b/oldp/apps/cases/api_views.py
@@ -211,6 +211,7 @@ class CaseViewSet(ReviewStatusFilterMixin, viewsets.ModelViewSet):
             ecli=data.get("ecli"),
             abstract=data.get("abstract"),
             title=data.get("title"),
+            source_url=data.get("source_url", ""),
             api_token=api_token,
             extract_refs=extract_refs,
             source_name=source_name,

--- a/oldp/apps/cases/serializers.py
+++ b/oldp/apps/cases/serializers.py
@@ -19,6 +19,7 @@ CASE_API_FIELDS = (
     "type",
     "ecli",
     "content",
+    "source_url",
     "review_status",
 )
 
@@ -128,6 +129,12 @@ class CaseCreateSerializer(serializers.Serializer):
     source = SourceInputSerializer(
         required=False,
         help_text="Source information (name, homepage). If omitted, the default source is used.",
+    )
+    source_url = serializers.URLField(
+        required=False,
+        allow_blank=True,
+        default="",
+        help_text="URL the case content was extracted from (PDF, HTML detail page, API endpoint, ZIP, etc.).",
     )
 
     def _get_validation_settings(self):

--- a/oldp/apps/cases/services/case_creator.py
+++ b/oldp/apps/cases/services/case_creator.py
@@ -108,6 +108,7 @@ class CaseCreator:
         ecli: Optional[str] = None,
         abstract: Optional[str] = None,
         title: Optional[str] = None,
+        source_url: Optional[str] = None,
         court_code: Optional[str] = None,
         api_token=None,
         extract_refs: Optional[bool] = None,
@@ -125,6 +126,7 @@ class CaseCreator:
             ecli: European Case Law Identifier
             abstract: Case summary in HTML
             title: Case title
+            source_url: URL the content was extracted from (PDF, HTML detail page, etc.)
             court_code: Optional court code for resolution
             api_token: APIToken used for creation (for tracking)
             extract_refs: Whether to extract references (overrides instance setting)
@@ -169,6 +171,7 @@ class CaseCreator:
             ecli=ecli or "",
             abstract=abstract or "",
             title=title or "",
+            source_url=source_url or "",
             review_status=review_status,
             source=source,
         )

--- a/oldp/apps/cases/tests/test_case_creation_api.py
+++ b/oldp/apps/cases/tests/test_case_creation_api.py
@@ -520,6 +520,34 @@ class CaseCreateSerializerTestCase(TestCase):
         serializer = CaseCreateSerializer(data=data)
         self.assertTrue(serializer.is_valid(), serializer.errors)
 
+    def test_valid_data_with_source_url(self):
+        """Test serializer accepts optional source_url field."""
+        data = {
+            "court_name": "Bundesgerichtshof",
+            "file_number": "I ZR 123/21",
+            "date": "2021-05-15",
+            "content": "<p>Case content with sufficient length</p>",
+            "source_url": "https://example.com/case/123",
+        }
+        serializer = CaseCreateSerializer(data=data)
+        self.assertTrue(serializer.is_valid(), serializer.errors)
+        self.assertEqual(
+            serializer.validated_data["source_url"], "https://example.com/case/123"
+        )
+
+    def test_source_url_invalid_url_rejected(self):
+        """Test serializer rejects malformed source_url."""
+        data = {
+            "court_name": "Bundesgerichtshof",
+            "file_number": "I ZR 123/21",
+            "date": "2021-05-15",
+            "content": "<p>Case content with sufficient length</p>",
+            "source_url": "not-a-url",
+        }
+        serializer = CaseCreateSerializer(data=data)
+        self.assertFalse(serializer.is_valid())
+        self.assertIn("source_url", serializer.errors)
+
     def test_valid_data_with_source(self):
         """Test serializer accepts optional source field."""
         data = {
@@ -944,6 +972,37 @@ class CaseCreationIntegrationTestCase(APITestCase):
             "pending",
             "API-created cases must be pending for approval workflow",
         )
+
+    def test_source_url_persisted_when_provided(self):
+        """source_url from the request payload is stored on the Case row."""
+        data = {
+            "court_name": self.court.name,
+            "file_number": "SOURCE-URL-001/21",
+            "date": "2021-05-15",
+            "content": "<p>Case with source URL</p>",
+            "source_url": "https://www.rechtsprechung-im-internet.de/docs/bsjrs/jb-KORE600682026.zip",
+        }
+        response = self.client.post(
+            "/api/cases/?extract_refs=false", data, format="json"
+        )
+        self.assertEqual(response.status_code, status.HTTP_201_CREATED)
+        case = Case.objects.get(pk=response.data["id"])
+        self.assertEqual(case.source_url, data["source_url"])
+
+    def test_source_url_optional_defaults_to_empty(self):
+        """Omitting source_url stays backwards-compatible (stored as '')."""
+        data = {
+            "court_name": self.court.name,
+            "file_number": "SOURCE-URL-002/21",
+            "date": "2021-05-15",
+            "content": "<p>Case without source URL</p>",
+        }
+        response = self.client.post(
+            "/api/cases/?extract_refs=false", data, format="json"
+        )
+        self.assertEqual(response.status_code, status.HTTP_201_CREATED)
+        case = Case.objects.get(pk=response.data["id"])
+        self.assertEqual(case.source_url, "")
 
     def test_duplicate_case_prevention(self):
         """Test that duplicate cases are prevented."""


### PR DESCRIPTION
## Summary

- Wire `source_url` through the new `/api/cases/` POST endpoint so values sent by the ingestor are actually persisted (was silently dropped at the serializer layer).
- Add `source_url` to `CASE_API_FIELDS` so it round-trips on `GET /api/cases/<slug>/`.
- Backwards-compatible: field is optional (`required=False, allow_blank=True, default=""`); existing API consumers that never sent the field keep working unchanged.

## Why

`oldp-ingestor` PR #4 (shipped in v0.1.4, Apr 2026) updated every case provider to emit `source_url` in the case payload. The server-side `CaseCreateSerializer` is a plain `serializers.Serializer` (not `ModelSerializer`), and DRF silently discards unknown input keys — so the ingestor's `source_url` never made it into `validated_data`, was never forwarded by the view, and never reached the `Case(...)` constructor. Every API-ingested case ended up with `source_url=''` (URLField default), losing the link back to the upstream PDF / HTML detail page / API endpoint the content was scraped from.

Three places had to be wired through:

1. `oldp/apps/cases/serializers.py` — declare `source_url` on `CaseCreateSerializer`.
2. `oldp/apps/cases/api_views.py` — forward `source_url` from `validated_data` to `creator.create_case(...)`.
3. `oldp/apps/cases/services/case_creator.py` — accept the `source_url` kwarg and set it on the `Case(...)` constructor.

## Tests

- `test_valid_data_with_source_url` — serializer accepts a URL string.
- `test_source_url_invalid_url_rejected` — malformed values fail validation.
- `test_source_url_persisted_when_provided` — end-to-end POST stores it.
- `test_source_url_optional_defaults_to_empty` — omitting `source_url` stays backwards-compatible.

All 67 case-creation tests pass locally; lint clean.

## Out of scope

Backfilling historical rows where `source_url` is empty. Per-case payloads were never persisted (only summary snapshots), and most provider source URLs are not synthesizable from existing `Case` fields because the source identifiers (juris doc_ids, ns UUIDs, etc.) are not stored on the model. Will be tracked separately.

## Test plan

- [x] `make test` (cases app) — 67/67 pass
- [x] `make lint-check` — clean
- [ ] Smoke test on stage: POST a case with `source_url`, GET it back, confirm field is set
- [ ] Smoke test on stage: POST a case without `source_url`, confirm 201 + empty string (no regression for older clients)