### PR TITLE
feat(search): combined citation+keyword+facets search, sort-by-date, REST+MCP parity

### DIFF
--- a/docs/api/api-overview.md
+++ b/docs/api/api-overview.md
@@ -236,6 +236,28 @@ curl -X GET "https://de.openlegaldata.io/api/cases/search/?text=urheberrecht+AND
   -H "Accept: application/json"
 ```
 
+`text` is required. Optional filters that compose with the keyword
+query (logical AND):
+
+| Param | Notes |
+|-------|-------|
+| `start_date`, `end_date` | `YYYY-MM-DD`, inclusive |
+| `cited_law_book` + `cited_law_section` | Restrict to cases citing a specific section (case search only — silently ignored on `/api/laws/search/`) |
+| `cited_case` | Restrict to cases citing the case with this id |
+| `return_text=1` | Include the full `text` alongside `snippets` |
+
+```bash
+# Cases citing § 823 BGB that mention "Mietrecht"
+curl -G "https://de.openlegaldata.io/api/cases/search/" \
+  --data-urlencode 'text=Mietrecht' \
+  --data-urlencode 'cited_law_book=bgb' \
+  --data-urlencode 'cited_law_section=823' \
+  -H "Authorization: Token $OLDP_API_TOKEN"
+```
+
+See [Search](../searching.md) for the full filter matrix across the web,
+REST, and MCP surfaces.
+
 ## Citations & Cross-References
 
 The citation graph is queryable in three complementary ways. The same

--- a/docs/elasticsearch.md
+++ b/docs/elasticsearch.md
@@ -48,6 +48,11 @@ empty paginated list in REST; `total_citing_cases: 0` in MCP). Free-
 text search, facets, and the search backend's existing fields are
 unaffected — the reindex is additive and incremental.
 
+For the user-facing search surfaces (web `/search/`, REST
+`/api/cases/search/`, MCP `search_cases`) and the full matrix of
+filters they support — keyword + facets + date range + citation graph,
+plus the `order_by=date` sort toggle — see [Search](searching.md).
+
 ### Service-layer surfaces backed by Elasticsearch
 
 After PR #224 / PR #225 the citation graph is served by ES on every

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -19,6 +19,8 @@ The platform makes legal information freely accessible for the general public an
 
    getting-started
    testing
+   searching
+   mcp
    api/api-overview
    api/api-swagger
    api/case-creation

--- a/docs/mcp.md
+++ b/docs/mcp.md
@@ -63,9 +63,12 @@ The server implements OAuth 2.0 with PKCE and Dynamic Client Registration (RFC 7
 
 | Tool | Description |
 |------|------------|
-| `search_cases` | Full-text search via Elasticsearch. Returns snippets, not full text |
+| `search_cases` | Full-text search via Elasticsearch. Returns snippets, not full text. Accepts citation-graph filters (`cited_law_book` + `cited_law_section` or `cited_case_id`) that compose with the keyword query — e.g. "cases citing § 823 BGB that mention 'Mietrecht'" |
 | `search_laws` | Full-text search across law sections. Returns snippets only |
 | `filter_cases` | Structured ORM filtering by court, date, file number, ECLI, etc. |
+
+See [Search](searching.md) for the full filter matrix and combined-search
+examples across all three surfaces.
 
 ### Retrieval
 

--- a/docs/searching.md
+++ b/docs/searching.md
@@ -1,0 +1,151 @@
+# Search
+
+OLDP exposes the same Elasticsearch-backed search engine on three surfaces:
+
+| Surface | Endpoint | Use case |
+|---------|----------|----------|
+| Web UI | `/search/` | Human browsing with facets, citation chip, pagination |
+| REST | `/api/cases/search/`, `/api/laws/search/` | Programmatic full-text queries |
+| MCP | `search_cases`, `search_laws` tools | Agent-driven research |
+
+All three share the same backend (`CaseIndex` / `LawIndex` in
+`oldp/apps/cases/search_indexes.py` and `oldp/apps/laws/search_indexes.py`)
+and the same `SearchQueryBuilder` (`oldp/apps/search/api.py`), so a result
+that matches in one surface also matches in the others — subject to each
+surface's input contract.
+
+## Available filters
+
+Every filter composes with every other filter (logical AND).
+
+| Filter | Web param | REST param | MCP kwarg (`search_cases`) | Notes |
+|--------|-----------|------------|----------------------------|-------|
+| Keyword query | `q` | `text` | `query` | Lucene syntax supported on all surfaces. REST requires this; web/MCP allow empty if other filters are set. |
+| Date range | `start_date`, `end_date` | `start_date`, `end_date` | `start_date`, `end_date` | `YYYY-MM-DD`, inclusive on both ends. Bad strings are logged and silently dropped. |
+| Court | `selected_facets=court_exact:<code>` | — (use `filter_cases` ORM tool for REST/MCP court filter) | `court_code` | Exact match on the court code (e.g. `BGH`). |
+| Decision type | `selected_facets=decision_type_exact:<type>` | — | `decision_type` | Exact, e.g. `Urteil`, `Beschluss`. |
+| Cited law section | `cited_law_book` + `cited_law_section` | `cited_law_book` + `cited_law_section` | `cited_law_book` + `cited_law_section` | Both required together. Case-only — silently ignored on `/api/laws/search/`. |
+| Cited case id | `cited_case=<int>` | `cited_case=<int>` | `cited_case_id` | Mutually exclusive with the law-citation pair (law citation wins when both are sent). |
+| Sort | `order_by=relevance\|date` | — (web only) | — | `date` = newest first; default is ES relevance score. |
+
+### Combined filters
+
+Citation filters compose with keyword + facets + date range. The form does
+not pick one filter at the cost of another — every filter narrows the
+result set independently.
+
+```
+# Cases citing § 823 BGB that mention "Mietrecht"
+/search/?q=Mietrecht&cited_law_book=bgb&cited_law_section=823
+
+# Same, restricted to BGH and 2020
+/search/?q=Mietrecht&selected_facets=court_exact:BGH
+       &start_date=2020-01-01&end_date=2020-12-31
+       &cited_law_book=bgb&cited_law_section=823
+
+# Newest cases first
+/search/?q=Mietrecht&order_by=date
+```
+
+The citation chip in the web UI shows the active citation filter with a
+clear (×) link that removes only the citation params and keeps `q` /
+facets intact. The "Sort by" group in the sidebar auto-submits on
+change. Clicking a year tile under the publication-date facet preserves
+the citation chip, every selected facet, and the current sort.
+
+### Sort order
+
+`order_by=date` orders by case publication date, newest first. Empty
+value (or any other value) leaves Elasticsearch's relevance score
+ordering. The results-count label tells you which order is active:
+
+```
+192 documents sorted by date.
+4 citing cases, sorted by date.
+```
+
+The German UI renders the equivalent: *"192 Dokumente sortiert nach
+Datum."* / *"4 zitierende Entscheidungen, sortiert nach Datum."*
+
+## REST examples
+
+```bash
+# Keyword + cited law section
+curl -G "https://de.openlegaldata.io/api/cases/search/" \
+  --data-urlencode "text=Mietrecht" \
+  --data-urlencode "cited_law_book=bgb" \
+  --data-urlencode "cited_law_section=823" \
+  -H "Authorization: Token $OLDP_API_TOKEN"
+
+# Keyword + date range
+curl -G "https://de.openlegaldata.io/api/cases/search/" \
+  --data-urlencode "text=Urheberrecht" \
+  --data-urlencode "start_date=2023-01-01" \
+  --data-urlencode "end_date=2023-12-31" \
+  -H "Authorization: Token $OLDP_API_TOKEN"
+
+# Cases citing a specific case (citation-graph filter)
+curl -G "https://de.openlegaldata.io/api/cases/search/" \
+  --data-urlencode "text=Schadensersatz" \
+  --data-urlencode "cited_case=12345" \
+  -H "Authorization: Token $OLDP_API_TOKEN"
+```
+
+The REST contract requires the `text` param (returns 400 otherwise).
+Citation params alone aren't accepted on the REST surface — use the
+dedicated nested actions (`/api/laws/<id>/citing_cases/`,
+`/api/cases/<id>/citing_cases/`) for "all citing cases" without keyword
+refinement. See [API overview — Citations & Cross-References](api/api-overview.md#citations--cross-references)
+for those endpoints.
+
+## MCP examples
+
+```python
+# All citing cases of § 823 BGB, paginated — no keyword
+get_cases_for_law(book_code="BGB", section="823", limit=20)
+
+# Same set, narrowed by keyword + court (combined search)
+search_cases(query="Mietrecht", court_code="BGH",
+             cited_law_book="bgb", cited_law_section="823", limit=10)
+
+# Cases citing a specific case (reverse citation) narrowed by keyword
+search_cases(query="Vermieterpflichten", cited_case_id=12345, limit=10)
+
+# Date-range only with citation graph
+search_cases(query="", start_date="2023-01-01", end_date="2023-12-31",
+             cited_law_book="bgb", cited_law_section="823")
+```
+
+For "give me every citing case" without keyword refinement, prefer the
+dedicated `get_cases_for_law` / `get_citing_cases` tools — `search_cases`
+exists for combined searches that intersect citations with keyword,
+court, or date.
+
+## Surface differences at a glance
+
+|  | Web | REST | MCP |
+|--|-----|------|-----|
+| Keyword required? | No (any other filter unlocks the query) | Yes (`text` returns 400 if missing) | No |
+| Facet selection | `selected_facets` | Use `filter_cases` for ORM filters | Built-in kwargs |
+| Sort order | `order_by` toggle | — (relevance only) | — (relevance only) |
+| Citation params | Optional | Optional | Optional |
+| Highlighting | Inline in result list | `snippets` field with `<em>` tags | `snippets` array |
+| Pagination | Standard | `limit` + `offset` | `limit` only (≤50) |
+
+## Backend details
+
+Citation lookups use multi-value fields on `CaseIndex`:
+
+- `cited_laws` — list of `"<book_slug>__<section_slug>"` tokens
+- `cited_cases` — list of cited-case PKs (as strings)
+
+Built via `oldp.apps.cases.search_indexes.cited_law_token(book, section)`;
+consumers should call this helper rather than concatenating the token
+manually. The slug pair is stable across book revisions, so citation
+queries survive book-revision turnover.
+
+For the underlying index fields, the operator-run reindex command, and
+the ES outage behaviour on each surface, see
+[Elasticsearch](elasticsearch.md). For the citation-graph endpoints
+(REST `/api/{cases,laws}/<id>/citing_*/` and the flat `/api/references/`),
+see [API overview — Citations & Cross-References](api/api-overview.md#citations--cross-references).

--- a/oldp/apps/cases/mcp.py
+++ b/oldp/apps/cases/mcp.py
@@ -53,6 +53,9 @@ class CaseTools(MCPToolset):
         start_date: str = "",
         end_date: str = "",
         decision_type: str = "",
+        cited_law_book: str = "",
+        cited_law_section: str = "",
+        cited_case_id: int = 0,
         limit: int = 10,
     ) -> dict:
         """Full-text search for German court cases via Elasticsearch.
@@ -60,12 +63,26 @@ class CaseTools(MCPToolset):
         Returns matching cases with highlighted snippets. Does NOT return
         full case text - use get_case to retrieve complete content.
 
+        The citation filters compose with ``query`` so you can answer
+        "cases citing § 823 BGB that mention 'Mietrecht'" in one call —
+        pass ``query="Mietrecht"`` together with ``cited_law_book="bgb"``
+        and ``cited_law_section="823"``. For "give me ALL citing cases"
+        without keyword refinement, prefer the dedicated
+        ``get_cases_for_law`` / ``get_citing_cases`` tools.
+        ``cited_case_id`` is mutually exclusive with the law citation
+        filter — if both are supplied, the law filter wins.
+
         Args:
             query: Search query text (supports Lucene syntax).
             court_code: Filter by court code (e.g. "BGH", "BVerfG").
             start_date: Filter cases from this date (YYYY-MM-DD).
             end_date: Filter cases up to this date (YYYY-MM-DD).
             decision_type: Filter by decision type (e.g. "Urteil", "Beschluss").
+            cited_law_book: Restrict to cases citing a law from this
+                book slug (e.g. "bgb"). Requires ``cited_law_section``.
+            cited_law_section: Restrict to cases citing this law section
+                slug (e.g. "823"). Requires ``cited_law_book``.
+            cited_case_id: Restrict to cases citing the case with this id.
             limit: Maximum results (default 10, max 50). Values above 50 are
                 clamped; the response then includes ``limit_clamped: true``
                 and the original ``requested_limit``.
@@ -75,6 +92,7 @@ class CaseTools(MCPToolset):
 
         try:
             from oldp.apps.search.api import SearchQueryBuilder
+            from oldp.apps.search.utils import apply_citation_filter
 
             builder = SearchQueryBuilder()
             builder.filter_models([Case])
@@ -100,6 +118,18 @@ class CaseTools(MCPToolset):
                 sqs = sqs.filter(court_exact=court_code)
             if decision_type:
                 sqs = sqs.filter(decision_type_exact=decision_type)
+
+            # Citation filter (law section OR case id). The clamp on
+            # ``facet_model_name_exact="Case"`` applied inside the helper
+            # is redundant here (we applied it above) but harmless.
+            sqs = apply_citation_filter(
+                sqs,
+                {
+                    "cited_law_book": cited_law_book,
+                    "cited_law_section": cited_law_section,
+                    "cited_case": str(cited_case_id) if cited_case_id else "",
+                },
+            )
 
             # Materialise the limited slice first. If it's empty we skip the
             # total-count round-trip entirely; otherwise we ask ES for the

--- a/oldp/apps/cases/tests/test_mcp.py
+++ b/oldp/apps/cases/tests/test_mcp.py
@@ -273,6 +273,38 @@ class CaseToolsTests(TestCase):
         )
         self.assertIn({"facet_model_name_exact": "Case"}, filters_with_facets)
 
+    def test_search_cases_chains_law_citation_filter(self):
+        """``cited_law_book`` + ``cited_law_section`` must chain a
+        ``cited_laws=<book>__<section>`` filter onto the keyword
+        query so MCP clients can run combined searches in one call.
+        """
+        _, filters = self._patched_search_cases(
+            query="mietrecht",
+            cited_law_book="bgb",
+            cited_law_section="823",
+        )
+        self.assertIn({"cited_laws": "bgb__823"}, filters)
+
+    def test_search_cases_chains_case_citation_filter(self):
+        _, filters = self._patched_search_cases(query="foo", cited_case_id=42)
+        self.assertIn({"cited_cases": "42"}, filters)
+
+    def test_search_cases_ignores_zero_cited_case_id(self):
+        """``cited_case_id=0`` is the default sentinel for "not supplied"
+        and must not produce a citation filter.
+        """
+        _, filters = self._patched_search_cases(query="foo", cited_case_id=0)
+        for f in filters:
+            self.assertNotIn("cited_cases", f)
+
+    def test_search_cases_partial_law_citation_is_ignored(self):
+        """``cited_law_book`` without ``cited_law_section`` (or vice
+        versa) should be ignored — the helper requires both.
+        """
+        _, filters = self._patched_search_cases(query="foo", cited_law_book="bgb")
+        for f in filters:
+            self.assertNotIn("cited_laws", f)
+
     # --- get_case_statistics tests ---
 
     def test_get_case_statistics_returns_dict(self):

--- a/oldp/apps/references/mcp.py
+++ b/oldp/apps/references/mcp.py
@@ -108,7 +108,8 @@ class ReferenceTools(MCPToolset):
 
         Find all cases that reference the given case in their text.
         Useful for understanding the impact and precedent value of a
-        decision.
+        decision. To narrow the citing set by keyword, court, or date,
+        use ``search_cases(query=..., cited_case_id=case_id)`` instead.
 
         Args:
             case_id: The database ID of the cited case.
@@ -164,7 +165,9 @@ class ReferenceTools(MCPToolset):
 
         Returns cases that reference the given statute section in their
         text. Useful for understanding how courts interpret a specific
-        provision.
+        provision. To narrow the citing set by keyword, court, or date,
+        use ``search_cases(query=..., cited_law_book=..., cited_law_section=...)``
+        instead.
 
         Args:
             book_code: Law book code (e.g. "BGB", "StGB").

--- a/oldp/apps/search/api.py
+++ b/oldp/apps/search/api.py
@@ -206,7 +206,13 @@ class SearchResultSerializer(serializers.Serializer):
 class SearchFilter(BaseFilterBackend):
     """Filter backend that performs full-text search.
 
-    Reads 'text' query parameter and runs search query.
+    Reads the ``text`` query parameter (required) and the optional
+    citation-graph filters ``cited_law_book`` + ``cited_law_section``
+    (paired) or ``cited_case``. Citation filters are silently ignored
+    when the view's ``search_models`` does not include ``Case``,
+    because ``cited_laws`` / ``cited_cases`` are not populated on the
+    Law index. Date-range filtering happens upstream in
+    :class:`SearchViewMixin.get_queryset`.
     """
 
     def get_schema_operation_parameters(self, view):

--- a/oldp/apps/search/api.py
+++ b/oldp/apps/search/api.py
@@ -22,6 +22,7 @@ from oldp.apps.search.exceptions import (
     SearchBackendUnavailable,
 )
 from oldp.apps.search.utils import (
+    apply_citation_filter,
     is_search_backend_error,
     is_search_backend_timeout,
 )
@@ -37,7 +38,10 @@ class SearchQueryBuilder:
     """
 
     def __init__(self, queryset=None):
-        self.queryset = queryset or SearchQuerySet()
+        # Explicit None check: EmptySearchQuerySet has __len__() == 0 and is
+        # falsy, so a truthiness fallback would silently swap in a fresh
+        # SearchQuerySet and drop any .narrow()/filter clauses already on it.
+        self.queryset = SearchQuerySet() if queryset is None else queryset
 
     def filter_models(self, models):
         """Filter by model classes."""
@@ -228,6 +232,38 @@ class SearchFilter(BaseFilterBackend):
                 "description": "Set to 1 to include full text in addition to snippets.",
                 "schema": {"type": "string", "enum": ["0", "1"]},
             },
+            {
+                "name": "cited_law_book",
+                "required": False,
+                "in": "query",
+                "description": (
+                    "Restrict results to cases citing a law from this book "
+                    "(slug, e.g. ``bgb``). Combine with ``cited_law_section``. "
+                    "Cases-only; ignored for law search."
+                ),
+                "schema": {"type": "string"},
+            },
+            {
+                "name": "cited_law_section",
+                "required": False,
+                "in": "query",
+                "description": (
+                    "Restrict results to cases citing this law section "
+                    "(slug, e.g. ``823``). Requires ``cited_law_book``."
+                ),
+                "schema": {"type": "string"},
+            },
+            {
+                "name": "cited_case",
+                "required": False,
+                "in": "query",
+                "description": (
+                    "Restrict results to cases citing the case with this "
+                    "numeric id. Mutually exclusive with "
+                    "``cited_law_book``/``cited_law_section``."
+                ),
+                "schema": {"type": "integer"},
+            },
         ]
 
     def filter_queryset(self, request, queryset, view):
@@ -254,6 +290,15 @@ class SearchFilter(BaseFilterBackend):
         search_models = getattr(view, "search_models", [])
         if search_models:
             queryset = queryset.models(*search_models)
+
+        # Citation filter only applies when the endpoint searches Cases —
+        # ``cited_laws`` / ``cited_cases`` are not populated on the Law
+        # index, so a citation filter on /api/laws/search/ would silently
+        # zero out the results. Ignore citation params there instead.
+        from oldp.apps.cases.models import Case
+
+        if Case in search_models or not search_models:
+            queryset = apply_citation_filter(queryset, request.query_params)
 
         return queryset
 

--- a/oldp/apps/search/templates/search/facets.html
+++ b/oldp/apps/search/templates/search/facets.html
@@ -9,10 +9,40 @@
         <input type="hidden" name="q" value="{{ query }}">
         <input type="hidden" name="start_date" value="" class="rangeFromDate">
         <input type="hidden" name="end_date" value="" class="rangeToDate">
+        {% if citation_filter %}
+            {% for key, value in citation_filter.params.items %}
+                <input type="hidden" name="{{ key }}" value="{{ value }}">
+            {% endfor %}
+        {% endif %}
+        {% for facet in selected_facets %}
+            <input type="hidden" name="selected_facets" value="{{ facet }}">
+        {% endfor %}
 
         {% if not search_facets  %}
             <p>{% trans 'No filter available.' %}</p>
         {% endif %}
+
+        <div class="search-facet">
+            <strong>{% trans 'Sort by' %}</strong>
+            <ul>
+                <li class="search-facet-choice">
+                    <label class="d-block">
+                        <input type="radio" name="order_by" value=""
+                               onchange="this.form.submit()"
+                               {% if not order_by %}checked{% endif %}>
+                        <span>{% trans 'Relevance' %}</span>
+                    </label>
+                </li>
+                <li class="search-facet-choice">
+                    <label class="d-block">
+                        <input type="radio" name="order_by" value="date"
+                               onchange="this.form.submit()"
+                               {% if order_by == 'date' %}checked{% endif %}>
+                        <span>{% trans 'Date (newest first)' %}</span>
+                    </label>
+                </li>
+            </ul>
+        </div>
 
         {% if search_facets.facet_model_name %}
             {% with facet=search_facets.facet_model_name %}
@@ -108,7 +138,7 @@
         <ul>
         {% for facet_date, count in facet_dates %}
             <li class="search-facet-choice {% if forloop.counter > 5 %} search-facet-choice-more {% endif %}" data-facet-name="date">
-                <a href="?q={{ query|urlencode }}&start_date={{ facet_date|date:'Y' }}-01-01&end_date={{ facet_date|date:'Y' }}-12-31">
+                <a href="?q={{ query|urlencode }}&start_date={{ facet_date|date:'Y' }}-01-01&end_date={{ facet_date|date:'Y' }}-12-31{% if order_by %}&order_by={{ order_by|urlencode }}{% endif %}{% if citation_filter %}{% for key, value in citation_filter.params.items %}&{{ key }}={{ value|urlencode }}{% endfor %}{% endif %}{% for facet in selected_facets %}&selected_facets={{ facet|urlencode }}{% endfor %}">
                     <input type="checkbox"{% if choice.selected %} checked{% endif %} style="pointer-events: none;"> <span>{{ facet_date|date:"Y" }}</span></a> ({{ count }})
             </li>
         {% endfor %}

--- a/oldp/apps/search/templates/search/search.html
+++ b/oldp/apps/search/templates/search/search.html
@@ -41,7 +41,7 @@
         numbers can't overflow the viewport on mobile.
         {% endcomment %}
         {% if citation_filter %}
-            <div class="active-filters my-3">
+            <div class="active-filters my-3 px-3">
                 <div class="badge badge-primary d-inline-flex flex-wrap align-items-center text-left text-wrap p-2 mw-100" style="font-size: 0.95rem; gap: .35rem; white-space: normal;">
                     <span>
                         {% if citation_filter.kind == 'law' %}
@@ -75,9 +75,15 @@
 
                     <div style="text-align: right; color: grey;">
                         {% if citation_filter %}
-                            {% blocktrans with count=page_obj.paginator.count %}{{ count }} citing cases.{% endblocktrans %}
+                            {% if order_by == 'date' %}
+                                {% blocktrans with count=page_obj.paginator.count %}{{ count }} citing cases, sorted by <b>date</b>.{% endblocktrans %}
+                            {% else %}
+                                {% blocktrans with count=page_obj.paginator.count %}{{ count }} citing cases, sorted by <b>relevance</b>.{% endblocktrans %}
+                            {% endif %}
+                        {% elif order_by == 'date' %}
+                            {% blocktrans with count=page_obj.paginator.count %}{{ count }} documents sorted by <b>date</b>.{% endblocktrans %}
                         {% else %}
-                            {% blocktrans with count=page_obj.paginator.count %}{{ count }} results sorted by <b>relevance</b>.{% endblocktrans %}
+                            {% blocktrans with count=page_obj.paginator.count %}{{ count }} documents sorted by <b>relevance</b>.{% endblocktrans %}
                         {% endif %}
                     </div>
 

--- a/oldp/apps/search/tests/test_combined_search_es.py
+++ b/oldp/apps/search/tests/test_combined_search_es.py
@@ -1,0 +1,254 @@
+r"""Real-Elasticsearch integration tests for combined citation + keyword + facets search.
+
+Verifies the post-fix behaviour end-to-end: the web /search/ view, the REST
+/api/cases/search/ endpoint, and the MCP search_cases tool all intersect
+citation filters with keyword and facet filters instead of letting one of
+them silently win.
+
+Skipped under the default mock backend (MOCK_ES_TESTS=True). Runs in the CI
+``test-es`` job and locally via:
+
+    DJANGO_MOCK_ES_TESTS="False" DJANGO_CONFIGURATION=TestConfiguration \
+        .venv/bin/python manage.py test \
+        oldp.apps.search.tests.test_combined_search_es --tag es
+"""
+
+from django.test import TestCase, override_settings
+from django.urls import reverse
+
+from oldp.apps.cases.mcp import CaseTools
+from oldp.apps.cases.models import Case
+from oldp.apps.courts.models import Court
+from oldp.apps.laws.models import Law, LawBook
+from oldp.apps.references.models import CaseReferenceMarker, Reference
+from oldp.utils.test_utils import ElasticsearchTestMixin, real_es_test
+
+
+@override_settings(
+    CACHES={
+        "default": {
+            "BACKEND": "django.core.cache.backends.locmem.LocMemCache",
+            "LOCATION": "combined-search-es-tests",
+        }
+    },
+    STORAGES={
+        "staticfiles": {
+            "BACKEND": "django.contrib.staticfiles.storage.StaticFilesStorage",
+        }
+    },
+)
+class CombinedSearchRealESTest(ElasticsearchTestMixin, TestCase):
+    """Index three cases with distinct (keyword, court, citation) signatures
+    and verify every combination of filters lands the right subset against
+    a real ES cluster.
+    """
+
+    fixtures = [
+        "locations/countries.json",
+        "locations/states.json",
+        "locations/cities.json",
+        "courts/courts.json",
+    ]
+
+    @classmethod
+    def setUpTestData(cls):
+        super().setUpTestData()
+        cls.bgh = (
+            Court.objects.filter(code__iexact="BGH").first() or Court.objects.first()
+        )
+        cls.lg = (
+            Court.objects.exclude(pk=cls.bgh.pk).first()
+            if cls.bgh is not None
+            else Court.objects.first()
+        )
+
+        cls.bgb_book = LawBook.objects.create(
+            slug="bgb-combo",
+            code="BGB-COMBO",
+            title="BGB combined-search fixture",
+            revision_date="2020-01-01",
+            latest=True,
+            review_status="accepted",
+        )
+        cls.law_823 = Law.objects.create(
+            book=cls.bgb_book,
+            slug="823",
+            section="§ 823",
+            title="Schadensersatzpflicht",
+            content="Schadensersatzpflicht...",
+            order=1,
+            review_status="accepted",
+        )
+        cls.law_444 = Law.objects.create(
+            book=cls.bgb_book,
+            slug="444",
+            section="§ 444",
+            title="Haftungsausschluss",
+            content="Haftungsausschluss...",
+            order=2,
+            review_status="accepted",
+        )
+
+        # Case A: keyword + BGH + cites §823 → matches all combined filters
+        cls.case_a = Case.objects.create(
+            court=cls.bgh,
+            date="2020-06-15",
+            file_number="A-1/20",
+            slug="case-a-combo",
+            title="Case A combo",
+            type="Urteil",
+            content="Mietrecht Streit über Schadensersatz nach Vermieterpflichten.",
+            review_status="accepted",
+        )
+        # Case B: keyword + LG + cites §444 (different section)
+        cls.case_b = Case.objects.create(
+            court=cls.lg,
+            date="2020-07-01",
+            file_number="B-2/20",
+            slug="case-b-combo",
+            title="Case B combo",
+            type="Urteil",
+            content="Mietrecht und Wohnungsmiete vor der Kammer.",
+            review_status="accepted",
+        )
+        # Case C: different keyword + BGH + cites §823
+        cls.case_c = Case.objects.create(
+            court=cls.bgh,
+            date="2020-08-12",
+            file_number="C-3/20",
+            slug="case-c-combo",
+            title="Case C combo",
+            type="Urteil",
+            content="Kaufrecht und Gewährleistung beim Verkäufer.",
+            review_status="accepted",
+        )
+
+        cls._link(cls.case_a, cls.law_823)
+        cls._link(cls.case_b, cls.law_444)
+        cls._link(cls.case_c, cls.law_823)
+
+    @classmethod
+    def _link(cls, case, law):
+        marker = CaseReferenceMarker.objects.create(
+            referenced_by=case,
+            text=law.section,
+            start=0,
+            end=10,
+            line_number=1,
+        )
+        ref = Reference.objects.create(
+            law=law,
+            law_book_slug=law.book.slug,
+            law_section_slug=law.slug,
+            to=f"{law.book.slug}/{law.slug}",
+        )
+        marker.references.add(ref)
+
+    def setUp(self):
+        super().setUp()
+        # Re-index Cases so the new ``cited_laws`` tokens hit ES. We also
+        # need Law docs available for the resolver's label lookup, though
+        # the citation field itself only lives on Case.
+        self.index_fixtures(models=[Case, Law])
+
+    def _search_pks(self, params):
+        qd = "&".join(f"{k}={v}" for k, v in params.items())
+        res = self.client.get(reverse("haystack_search") + "?" + qd)
+        self.assertEqual(res.status_code, 200, msg=res.content[:500])
+        return {int(r.pk) for r in res.context["object_list"]}
+
+    def _rest_pks(self, params):
+        qd = "&".join(f"{k}={v}" for k, v in params.items())
+        res = self.client.get("/api/cases/search/?" + qd)
+        self.assertEqual(res.status_code, 200, msg=res.content[:500])
+        return {int(r["id"]) for r in res.json()["results"]}
+
+    @real_es_test
+    def test_web_q_intersects_citation(self):
+        """``q=mietrecht + cited_law_book=bgb-combo + cited_law_section=823``
+        must return only Case A (Case B fails citation, Case C fails kw).
+        """
+        pks = self._search_pks(
+            {
+                "q": "mietrecht",
+                "cited_law_book": self.bgb_book.slug,
+                "cited_law_section": "823",
+            }
+        )
+        self.assertEqual(pks, {self.case_a.pk})
+
+    @real_es_test
+    def test_web_facets_intersect_citation_without_q(self):
+        pks = self._search_pks(
+            {
+                "selected_facets": f"court_exact:{self.bgh.code}",
+                "cited_law_book": self.bgb_book.slug,
+                "cited_law_section": "823",
+            }
+        )
+        self.assertEqual(pks, {self.case_a.pk, self.case_c.pk})
+
+    @real_es_test
+    def test_web_all_filters_combine(self):
+        pks = self._search_pks(
+            {
+                "q": "mietrecht",
+                "selected_facets": f"court_exact:{self.bgh.code}",
+                "start_date": "2020-01-01",
+                "end_date": "2020-12-31",
+                "cited_law_book": self.bgb_book.slug,
+                "cited_law_section": "823",
+            }
+        )
+        self.assertEqual(pks, {self.case_a.pk})
+
+    @real_es_test
+    def test_web_citation_only_regression(self):
+        """Pre-existing happy path must stay green: citation-only returns
+        every case that cites the section.
+        """
+        pks = self._search_pks(
+            {
+                "cited_law_book": self.bgb_book.slug,
+                "cited_law_section": "823",
+            }
+        )
+        self.assertEqual(pks, {self.case_a.pk, self.case_c.pk})
+
+    @real_es_test
+    def test_web_facets_only_regression(self):
+        """Locks in the Bug A fix in real ES: facets-only must not drop
+        the narrow query into a fresh empty SQS.
+        """
+        pks = self._search_pks({"selected_facets": f"court_exact:{self.bgh.code}"})
+        # Two of our three fixture cases are on BGH; we don't assert
+        # equality because other fixture cases (loaded via cases/cases.json
+        # is intentionally NOT in our fixtures list) won't be in the
+        # index. Just verify the BGH ones are present.
+        self.assertIn(self.case_a.pk, pks)
+        self.assertIn(self.case_c.pk, pks)
+        self.assertNotIn(self.case_b.pk, pks)
+
+    @real_es_test
+    def test_rest_intersects_text_and_citation(self):
+        pks = self._rest_pks(
+            {
+                "text": "mietrecht",
+                "cited_law_book": self.bgb_book.slug,
+                "cited_law_section": "823",
+            }
+        )
+        self.assertEqual(pks, {self.case_a.pk})
+
+    @real_es_test
+    def test_mcp_search_cases_intersects_query_and_citation(self):
+        tools = CaseTools()
+        result = tools.search_cases(
+            query="mietrecht",
+            cited_law_book=self.bgb_book.slug,
+            cited_law_section="823",
+            limit=10,
+        )
+        self.assertIn("results", result, msg=result)
+        ids = {r["id"] for r in result["results"]}
+        self.assertEqual(ids, {self.case_a.pk})

--- a/oldp/apps/search/tests/test_search_api.py
+++ b/oldp/apps/search/tests/test_search_api.py
@@ -206,3 +206,61 @@ class SearchApiMockedTestCase(TestCase):
             "/api/cases/search/?text=test&start_date=2020-01-01&end_date=2024-12-31"
         )
         self.assertEqual(200, res.status_code)
+
+    @patch("oldp.apps.search.api.SearchQuerySet")
+    def test_case_search_chains_law_citation_filter(self, mock_sqs_cls):
+        """``cited_law_book`` + ``cited_law_section`` should chain a
+        ``cited_laws=<token>`` filter and the Case clamp onto the
+        keyword query.
+        """
+        mock_sqs = self._make_mock_sqs()
+        mock_sqs_cls.return_value = mock_sqs
+
+        res = self.client.get(
+            "/api/cases/search/?text=mietrecht&cited_law_book=bgb&cited_law_section=823"
+        )
+        self.assertEqual(200, res.status_code)
+
+        filter_calls = [c.kwargs for c in mock_sqs.filter.call_args_list]
+        self.assertIn({"cited_laws": "bgb__823"}, filter_calls)
+        self.assertIn({"facet_model_name_exact": "Case"}, filter_calls)
+
+    @patch("oldp.apps.search.api.SearchQuerySet")
+    def test_case_search_chains_case_citation_filter(self, mock_sqs_cls):
+        mock_sqs = self._make_mock_sqs()
+        mock_sqs_cls.return_value = mock_sqs
+
+        res = self.client.get("/api/cases/search/?text=foo&cited_case=42")
+        self.assertEqual(200, res.status_code)
+
+        filter_calls = [c.kwargs for c in mock_sqs.filter.call_args_list]
+        self.assertIn({"cited_cases": "42"}, filter_calls)
+
+    @patch("oldp.apps.search.api.SearchQuerySet")
+    def test_law_search_ignores_citation_filter(self, mock_sqs_cls):
+        """Citation fields aren't populated on the Law index — silently
+        ignore citation params on ``/api/laws/search/`` rather than
+        clamping to Case and returning empty.
+        """
+        mock_sqs = self._make_mock_sqs()
+        mock_sqs_cls.return_value = mock_sqs
+
+        res = self.client.get(
+            "/api/laws/search/?text=foo&cited_law_book=bgb&cited_law_section=823"
+        )
+        self.assertEqual(200, res.status_code)
+
+        filter_calls = [c.kwargs for c in mock_sqs.filter.call_args_list]
+        self.assertNotIn({"cited_laws": "bgb__823"}, filter_calls)
+
+    def test_schema_lists_citation_params(self):
+        """The OpenAPI schema for ``SearchFilter`` should declare the
+        three citation params so REST docs surface them.
+        """
+        from oldp.apps.search.api import SearchFilter
+
+        params = SearchFilter().get_schema_operation_parameters(view=None)
+        names = {p["name"] for p in params}
+        self.assertIn("cited_law_book", names)
+        self.assertIn("cited_law_section", names)
+        self.assertIn("cited_case", names)

--- a/oldp/apps/search/tests/test_views.py
+++ b/oldp/apps/search/tests/test_views.py
@@ -203,6 +203,39 @@ class MockedSearchViewsTestCase(TestCase):
         self.assertIsNone(_resolve_citation_filter({}))
         self.assertIsNone(_resolve_citation_filter({"q": "anything"}))
 
+    @patch(
+        "oldp.apps.search.views.CustomSearchForm.search", return_value=_make_mock_sqs()
+    )
+    def test_facets_form_preserves_citation_params_in_hidden_inputs(self, mock_search):
+        """The date-range facets form must round-trip citation params so
+        users don't lose the citation filter when they pick a date range.
+        """
+        res = self.get_search_response(
+            {"q": "foo", "cited_law_book": "bgb", "cited_law_section": "823"}
+        )
+        self.assertEqual(res.status_code, 200)
+        body = res.content.decode()
+        self.assertIn('<input type="hidden" name="cited_law_book" value="bgb">', body)
+        self.assertIn(
+            '<input type="hidden" name="cited_law_section" value="823">', body
+        )
+
+    @patch(
+        "oldp.apps.search.views.CustomSearchForm.search", return_value=_make_mock_sqs()
+    )
+    def test_facets_form_preserves_selected_facets_in_hidden_inputs(self, mock_search):
+        """The date-range facets form must round-trip every selected facet
+        so users don't lose their facet selection when picking a date.
+        """
+        res = self.get_search_response(
+            {"q": "foo", "selected_facets": "court_exact:BGH"}
+        )
+        self.assertEqual(res.status_code, 200)
+        self.assertIn(
+            '<input type="hidden" name="selected_facets" value="court_exact:BGH">',
+            res.content.decode(),
+        )
+
     @override_settings(
         CACHES={
             "default": {
@@ -378,3 +411,169 @@ class MockedSearchViewsTestCase(TestCase):
         self.assertEqual(key1, key2)  # normalization is case-insensitive for cache key
         self.assertNotEqual(key1, key3)
         self.assertNotEqual(key1, key4)
+
+
+@tag("views")
+class CombinedSearchFormTestCase(TestCase):
+    """Verify that ``CustomSearchForm.search()`` composes every combination
+    of keyword, selected facets, date range, and citation filter into a
+    single ``SearchQuerySet`` — none of the filters get silently dropped.
+
+    Tests inspect the constructed SQS via ``query.build_query()`` and
+    ``query.narrow_queries`` so they don't need a real ES backend.
+    """
+
+    def _make_form(self, params):
+        from haystack.query import SearchQuerySet
+
+        from oldp.apps.search.views import CustomSearchForm
+
+        # ``selected_facets`` may appear once (a string) or many times
+        # (a list) — mirror what ``CustomSearchView.get_form_kwargs``
+        # does at runtime: pull every instance off the QueryDict and
+        # pass the list through as an explicit kwarg, because Haystack's
+        # FacetedSearchForm reads it from kwargs, not from form data.
+        qd = QueryDict("", mutable=True)
+        selected = params.pop("selected_facets", None)
+        if selected is not None:
+            if isinstance(selected, str):
+                selected = [selected]
+            qd.setlist("selected_facets", selected)
+        else:
+            selected = []
+        for k, v in params.items():
+            qd[k] = v
+        return CustomSearchForm(
+            qd, searchqueryset=SearchQuerySet(), selected_facets=selected
+        )
+
+    def test_q_only_unchanged(self):
+        sqs = self._make_form({"q": "mietrecht"}).search()
+        self.assertEqual(sqs.query.build_query(), "mietrecht")
+        self.assertEqual(sqs.query.narrow_queries, set())
+
+    def test_citation_only_unchanged(self):
+        sqs = self._make_form(
+            {"cited_law_book": "bgb", "cited_law_section": "823"}
+        ).search()
+        self.assertEqual(
+            sqs.query.build_query(),
+            "(cited_laws:bgb__823 AND facet_model_name_exact:Case)",
+        )
+        self.assertEqual(sqs.query.narrow_queries, set())
+
+    def test_q_and_citation_combine(self):
+        sqs = self._make_form(
+            {
+                "q": "mietrecht",
+                "cited_law_book": "bgb",
+                "cited_law_section": "823",
+            }
+        ).search()
+        self.assertEqual(
+            sqs.query.build_query(),
+            "(mietrecht AND cited_laws:bgb__823 AND facet_model_name_exact:Case)",
+        )
+
+    def test_facets_only_preserves_narrow(self):
+        """Pre-fix: ``narrow_queries`` was silently dropped because
+        ``SearchQueryBuilder`` swapped the (falsy) EmptySearchQuerySet
+        returned by ``super().search()`` for a fresh SearchQuerySet.
+        """
+        sqs = self._make_form({"selected_facets": "court_exact:BGH"}).search()
+        self.assertEqual(sqs.query.build_query(), "*:*")
+        self.assertEqual(sqs.query.narrow_queries, {'court_exact:"BGH"'})
+
+    def test_facets_and_citation_preserve_narrow(self):
+        sqs = self._make_form(
+            {
+                "selected_facets": "court_exact:BGH",
+                "cited_law_book": "bgb",
+                "cited_law_section": "823",
+            }
+        ).search()
+        self.assertEqual(
+            sqs.query.build_query(),
+            "(cited_laws:bgb__823 AND facet_model_name_exact:Case)",
+        )
+        self.assertEqual(sqs.query.narrow_queries, {'court_exact:"BGH"'})
+
+    def test_q_facets_citation_combine(self):
+        sqs = self._make_form(
+            {
+                "q": "mietrecht",
+                "selected_facets": "court_exact:BGH",
+                "cited_law_book": "bgb",
+                "cited_law_section": "823",
+            }
+        ).search()
+        self.assertEqual(
+            sqs.query.build_query(),
+            "(mietrecht AND cited_laws:bgb__823 AND facet_model_name_exact:Case)",
+        )
+        self.assertEqual(sqs.query.narrow_queries, {'court_exact:"BGH"'})
+
+    def test_q_facets_citation_date_range_all_combine(self):
+        sqs = self._make_form(
+            {
+                "q": "mietrecht",
+                "selected_facets": "court_exact:BGH",
+                "start_date": "2020-01-01",
+                "end_date": "2020-12-31",
+                "cited_law_book": "bgb",
+                "cited_law_section": "823",
+            }
+        ).search()
+        built = sqs.query.build_query()
+        self.assertIn("mietrecht", built)
+        self.assertIn("cited_laws:bgb__823", built)
+        self.assertIn("facet_model_name_exact:Case", built)
+        # Date clauses' exact textual form is backend-dependent; just
+        # assert both bounds are present and tagged as the ``date`` field.
+        self.assertIn("date:", built)
+        self.assertIn("2020-01-01", built)
+        self.assertIn("2020-12-31", built)
+        self.assertEqual(sqs.query.narrow_queries, {'court_exact:"BGH"'})
+
+    def test_no_filters_returns_no_query_found(self):
+        from haystack.query import EmptySearchQuerySet
+
+        sqs = self._make_form({}).search()
+        self.assertIsInstance(sqs, EmptySearchQuerySet)
+
+    def test_cited_case_branch_combines_with_q(self):
+        sqs = self._make_form({"q": "mietrecht", "cited_case": "42"}).search()
+        self.assertEqual(
+            sqs.query.build_query(),
+            "(mietrecht AND cited_cases:42 AND facet_model_name_exact:Case)",
+        )
+
+    def test_invalid_cited_case_is_ignored(self):
+        sqs = self._make_form({"q": "x", "cited_case": "not-an-int"}).search()
+        # parse_citation_params returns None on bad int → no citation chain
+        self.assertEqual(sqs.query.build_query(), "x")
+
+    def test_order_by_relevance_is_default(self):
+        sqs = self._make_form({"q": "x"}).search()
+        # No explicit order applied — Haystack/ES uses score
+        self.assertEqual(sqs.query.order_by, [])
+
+    def test_order_by_date_sorts_newest_first(self):
+        sqs = self._make_form({"q": "x", "order_by": "date"}).search()
+        self.assertEqual(sqs.query.order_by, ["-date"])
+
+    def test_order_by_unknown_value_falls_back_to_relevance(self):
+        sqs = self._make_form({"q": "x", "order_by": "bogus"}).search()
+        self.assertEqual(sqs.query.order_by, [])
+
+    def test_order_by_date_combines_with_citation(self):
+        sqs = self._make_form(
+            {
+                "q": "x",
+                "cited_law_book": "bgb",
+                "cited_law_section": "823",
+                "order_by": "date",
+            }
+        ).search()
+        self.assertEqual(sqs.query.order_by, ["-date"])
+        self.assertIn("cited_laws:bgb__823", sqs.query.build_query())

--- a/oldp/apps/search/utils.py
+++ b/oldp/apps/search/utils.py
@@ -1,6 +1,60 @@
 """Utility helpers for the search app."""
 
 
+def parse_citation_params(params):
+    """Parse citation query params into ``(kind, token)`` or ``None``.
+
+    Lightweight counterpart to ``_resolve_citation_filter`` in the search
+    view: only does the parsing + token construction, no DB lookup for a
+    display label. Used by every surface that filters by citation (web
+    form, REST ``SearchFilter``, MCP ``search_cases``) so the param
+    parsing lives in exactly one place.
+
+    Args:
+        params: A mapping-like object (``request.GET``,
+            ``request.query_params``, or a plain ``dict``) exposing
+            ``cited_law_book`` + ``cited_law_section`` or ``cited_case``.
+
+    Returns:
+        ``("law", "<book_slug>__<section_slug>")`` when both law params
+        are present, ``("case", "<pk>")`` when ``cited_case`` is a valid
+        int, otherwise ``None``.
+    """
+    from oldp.apps.cases.search_indexes import cited_law_token
+
+    book = (params.get("cited_law_book") or "").strip()
+    section = (params.get("cited_law_section") or "").strip()
+    case = (params.get("cited_case") or "").strip()
+    if book and section:
+        return ("law", cited_law_token(book, section))
+    if case:
+        try:
+            return ("case", str(int(case)))
+        except ValueError:
+            return None
+    return None
+
+
+def apply_citation_filter(queryset, params):
+    """Chain a citation filter onto ``queryset`` if citation params are set.
+
+    Convenience wrapper used by both the web form and the REST filter
+    backend. Returns the queryset unchanged if no citation params are
+    present, otherwise applies ``.filter(cited_laws=…)`` or
+    ``.filter(cited_cases=…)`` plus the ``facet_model_name_exact="Case"``
+    clamp (the citation fields only exist on the Case index).
+    """
+    citation = parse_citation_params(params)
+    if citation is None:
+        return queryset
+    kind, token = citation
+    if kind == "law":
+        queryset = queryset.filter(cited_laws=token)
+    else:
+        queryset = queryset.filter(cited_cases=token)
+    return queryset.filter(facet_model_name_exact="Case")
+
+
 def is_search_backend_error(exc: Exception) -> bool:
     """Check if an exception is an Elasticsearch connection/transport error."""
     try:

--- a/oldp/apps/search/utils.py
+++ b/oldp/apps/search/utils.py
@@ -38,9 +38,9 @@ def parse_citation_params(params):
 def apply_citation_filter(queryset, params):
     """Chain a citation filter onto ``queryset`` if citation params are set.
 
-    Convenience wrapper used by both the web form and the REST filter
-    backend. Returns the queryset unchanged if no citation params are
-    present, otherwise applies ``.filter(cited_laws=…)`` or
+    Convenience wrapper used by the web form, REST filter backend, and
+    MCP ``search_cases``. Returns the queryset unchanged if no citation
+    params are present, otherwise applies ``.filter(cited_laws=…)`` or
     ``.filter(cited_cases=…)`` plus the ``facet_model_name_exact="Case"``
     clamp (the citation fields only exist on the Case index).
     """

--- a/oldp/apps/search/views.py
+++ b/oldp/apps/search/views.py
@@ -162,7 +162,14 @@ class CustomSearchForm(FacetedSearchForm):
 
 
 class CustomSearchView(FacetedSearchView):
-    """Custom search view for haystack."""
+    """Custom search view for haystack.
+
+    Composes keyword (``q``), selected facets, date range, citation-graph
+    filters (``cited_law_book`` + ``cited_law_section`` or ``cited_case``),
+    and an ``order_by`` toggle into a single SearchQuerySet via
+    :class:`CustomSearchForm`. See ``docs/search.md`` for the full filter
+    matrix and combined-search semantics.
+    """
 
     form_class = CustomSearchForm
     paginator_class = LimitedPaginator

--- a/oldp/apps/search/views.py
+++ b/oldp/apps/search/views.py
@@ -11,11 +11,12 @@ from haystack.forms import FacetedSearchForm
 from haystack.generic_views import FacetedSearchView
 from haystack.query import SearchQuerySet
 
-from oldp.apps.cases.search_indexes import cited_law_token
 from oldp.apps.search.api import SearchQueryBuilder
 from oldp.apps.search.utils import (
+    apply_citation_filter,
     is_search_backend_error,
     is_search_backend_timeout,
+    parse_citation_params,
 )
 from oldp.utils.limited_paginator import LimitedPaginator
 
@@ -59,50 +60,45 @@ def _resolve_citation_filter(data):
     exist (we still apply the ES filter; the search will just return
     zero hits, which is correct behaviour).
     """
-    book = (data.get("cited_law_book") or "").strip()
-    section = (data.get("cited_law_section") or "").strip()
-    case_id_raw = (data.get("cited_case") or "").strip()
+    parsed = parse_citation_params(data)
+    if parsed is None:
+        return None
 
-    if book and section:
+    kind, token = parsed
+    if kind == "law":
         from oldp.apps.laws.models import Law
 
+        book = data.get("cited_law_book", "").strip()
+        section = data.get("cited_law_section", "").strip()
         law = (
             Law.objects.filter(book__slug=book, slug=section, book__latest=True)
             .select_related("book")
             .first()
         )
-        label = law.get_title() if law else None
         return {
             "kind": "law",
-            "token": cited_law_token(book, section),
-            "label": label,
+            "token": token,
+            "label": law.get_title() if law else None,
             "params": {"cited_law_book": book, "cited_law_section": section},
         }
 
-    if case_id_raw:
-        try:
-            case_id = int(case_id_raw)
-        except ValueError:
-            return None
-        from oldp.apps.cases.models import Case
+    from oldp.apps.cases.models import Case
 
-        case = Case.objects.filter(pk=case_id).select_related("court").first()
-        if case is not None:
-            label = (
-                f"{case.file_number} ({case.court.name})"
-                if case.court_id
-                else case.file_number
-            )
-        else:
-            label = None
-        return {
-            "kind": "case",
-            "token": str(case_id),
-            "label": label,
-            "params": {"cited_case": str(case_id)},
-        }
-
-    return None
+    case = Case.objects.filter(pk=int(token)).select_related("court").first()
+    if case is not None:
+        label = (
+            f"{case.file_number} ({case.court.name})"
+            if case.court_id
+            else case.file_number
+        )
+    else:
+        label = None
+    return {
+        "kind": "case",
+        "token": token,
+        "label": label,
+        "params": {"cited_case": token},
+    }
 
 
 class CustomSearchForm(FacetedSearchForm):
@@ -112,34 +108,57 @@ class CustomSearchForm(FacetedSearchForm):
         super().__init__(*args, **kwargs)
 
     def search(self):
-        # First, store the SearchQuerySet received from other processing.
-        sqs = super().search()
+        """Compose keyword, selected facets, date range, and citation filters.
 
+        Inlined instead of calling ``super().search()`` because Haystack's
+        ``SearchForm.search`` returns ``EmptySearchQuerySet`` whenever ``q``
+        is empty, and chaining ``.narrow()`` / ``.filter()`` onto Empty
+        stays Empty — so facets-only or citation-only requests would
+        silently return zero results. We start from ``self.searchqueryset``
+        (the highlighted, date-faceted SQS the view prepared) and apply
+        each filter explicitly. The narrow loop mirrors the few lines of
+        ``FacetedSearchForm.search`` so users keep both keyword and
+        selected facets across every combination.
+        """
         if not self.is_valid():
             return self.no_query_found()
 
-        # Date range filtering via shared builder
+        q = (self.cleaned_data.get("q") or "").strip()
+        selected_facets = list(getattr(self, "selected_facets", []) or [])
+        start_date = self.data.get("start_date", "")
+        end_date = self.data.get("end_date", "")
+        order_by = (self.data.get("order_by") or "").strip().lower()
+        citation_params = parse_citation_params(self.data)
+
+        if not (q or selected_facets or start_date or end_date or citation_params):
+            return self.no_query_found()
+
+        sqs = self.searchqueryset
+        if q:
+            sqs = sqs.auto_query(q)
+        if self.load_all:
+            sqs = sqs.load_all()
+        for facet in selected_facets:
+            if ":" not in facet:
+                continue
+            field, value = facet.split(":", 1)
+            if value:
+                sqs = sqs.narrow('%s:"%s"' % (field, sqs.query.clean(value)))
+
         builder = SearchQueryBuilder(queryset=sqs)
-        builder.apply_date_range(
-            self.data.get("start_date", ""),
-            self.data.get("end_date", ""),
-        )
-        # Citation graph filters. Both ``cited_laws`` and ``cited_cases``
-        # are multi-value fields on ``CaseIndex``; haystack emits a
-        # narrow-query like ``cited_laws:"bgb__823"`` which ES resolves
-        # against the inverted index in sub-100ms. We also clamp the
-        # model to Case here because the citation fields are not
-        # populated on ``LawIndex`` documents.
-        citation_filter = _resolve_citation_filter(self.data)
-        if citation_filter is not None:
-            sqs = builder.build()
-            if citation_filter["kind"] == "law":
-                sqs = sqs.filter(cited_laws=citation_filter["token"])
-            else:
-                sqs = sqs.filter(cited_cases=citation_filter["token"])
-            sqs = sqs.filter(facet_model_name="Case")
-            return sqs
-        return builder.build()
+        builder.apply_date_range(start_date, end_date)
+        sqs = builder.build()
+
+        # Citation graph filter — clamps to Case because ``cited_laws`` /
+        # ``cited_cases`` are not populated on the Law index documents.
+        sqs = apply_citation_filter(sqs, self.data)
+
+        # Optional ordering. Default (empty / "relevance") leaves ES's
+        # relevance scoring untouched. ``date`` orders newest-first.
+        # Anything else is silently ignored to keep URLs forgiving.
+        if order_by == "date":
+            sqs = sqs.order_by("-date")
+        return sqs
 
 
 class CustomSearchView(FacetedSearchView):
@@ -349,12 +368,25 @@ class CustomSearchView(FacetedSearchView):
             qs = remaining.urlencode()
             clear_citation_url = "?" + qs if qs else "?"
 
+        # Normalize order_by — anything other than "date" collapses to
+        # the empty default so the template's truthy check renders
+        # "relevance" in the count label and selects the right option in
+        # the sort dropdown.
+        order_by = (self.request.GET.get("order_by") or "").strip().lower()
+        if order_by != "date":
+            order_by = ""
+
         context.update(
             {
                 "title": _("Search") + " " + context["query"][:30],
                 "search_facets": self.get_search_facets(context),
                 "citation_filter": citation_filter,
                 "clear_citation_url": clear_citation_url,
+                # Round-trip every currently-selected facet through the
+                # facets sidebar and year-tile links so submitting the
+                # date-range form or clicking a year does not drop them.
+                "selected_facets": selected_facets,
+                "order_by": order_by,
                 # 'date_facets': date_facets,
             }
         )

--- a/oldp/locale/de/LC_MESSAGES/django.po
+++ b/oldp/locale/de/LC_MESSAGES/django.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2026-05-28 13:41+0000\n"
+"POT-Creation-Date: 2026-06-01 05:51+0000\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -35,6 +35,7 @@ msgid "Description"
 msgstr "Beschreibung"
 
 #: oldp/apps/accounts/admin.py:56
+#, python-brace-format
 msgid "Used in {} permission group(s)"
 msgstr "Verwendet in {} Berechtigungsgruppe(n)"
 
@@ -103,6 +104,7 @@ msgid "Actions"
 msgstr "Aktionen"
 
 #: oldp/apps/accounts/admin.py:180 oldp/apps/accounts/admin.py:299
+#, python-brace-format
 msgid "{} token(s) were successfully revoked."
 msgstr "{} Token wurde(n) erfolgreich widerrufen."
 
@@ -169,6 +171,7 @@ msgid "Expiration Status"
 msgstr "Ablaufstatus"
 
 #: oldp/apps/accounts/admin.py:308
+#, python-brace-format
 msgid "{} token(s) were successfully activated."
 msgstr "{} Token wurde(n) erfolgreich aktiviert."
 
@@ -177,6 +180,7 @@ msgid "Activate selected tokens"
 msgstr "Ausgewählte Token aktivieren"
 
 #: oldp/apps/accounts/admin.py:317
+#, python-brace-format
 msgid "{} token(s) were successfully deactivated."
 msgstr "{} Token wurde(n) erfolgreich deaktiviert."
 
@@ -213,7 +217,7 @@ msgid "Cases"
 msgstr "Urteile"
 
 #: oldp/apps/accounts/models.py:19 oldp/apps/laws/templates/laws/index.html:9
-#: oldp/apps/laws/templates/laws/law.html:90 oldp/apps/laws/views.py:71
+#: oldp/apps/laws/templates/laws/law.html:74 oldp/apps/laws/views.py:71
 #: oldp/assets/templates/admin/index.html:24
 #: oldp/assets/templates/header.html:31
 msgid "Laws"
@@ -792,6 +796,7 @@ msgid "Token name is required."
 msgstr "Token-Name ist erforderlich."
 
 #: oldp/apps/accounts/views.py:93
+#, python-brace-format
 msgid ""
 "API token '{}' has been created successfully. Make sure to copy it now - you "
 "won't be able to see it again!"
@@ -804,12 +809,13 @@ msgid "Create API Token"
 msgstr "API-Token erstellen"
 
 #: oldp/apps/accounts/views.py:119
+#, python-brace-format
 msgid "API token '{}' has been revoked successfully."
 msgstr "API-Token '{}' wurde erfolgreich widerrufen."
 
 #: oldp/apps/cases/filters.py:27 oldp/apps/cases/filters.py:145
 #: oldp/apps/cases/templates/cases/case.html:18
-#: oldp/apps/search/templates/search/facets.html:66
+#: oldp/apps/search/templates/search/facets.html:96
 msgid "Court"
 msgstr "Gericht"
 
@@ -825,12 +831,12 @@ msgid "Has reference to"
 msgstr "Zitiert"
 
 #: oldp/apps/cases/filters.py:52 oldp/apps/courts/filters.py:26
-#: oldp/apps/search/templates/search/facets.html:79
+#: oldp/apps/search/templates/search/facets.html:109
 msgid "Jurisdiction"
 msgstr "Gerichtsbarkeit"
 
 #: oldp/apps/cases/filters.py:57 oldp/apps/courts/filters.py:32
-#: oldp/apps/search/templates/search/facets.html:92
+#: oldp/apps/search/templates/search/facets.html:122
 msgid "Level of Appeal"
 msgstr "Sachliche Zuständigkeit"
 
@@ -840,7 +846,7 @@ msgid "Published on"
 msgstr "Erschienen am"
 
 #: oldp/apps/cases/filters.py:107 oldp/apps/cases/views.py:39
-#: oldp/apps/search/templates/search/facets.html:107
+#: oldp/apps/search/templates/search/facets.html:137
 msgid "Publication date"
 msgstr "Erscheinungsdatum"
 
@@ -941,7 +947,7 @@ msgid "Court chamber"
 msgstr "Spruchkörper"
 
 #: oldp/apps/cases/templates/cases/case.html:30
-#: oldp/apps/search/templates/search/facets.html:53
+#: oldp/apps/search/templates/search/facets.html:83
 msgid "Decision type"
 msgstr "Entscheidungsart"
 
@@ -966,7 +972,7 @@ msgid "Download"
 msgstr "Herunterladen"
 
 #: oldp/apps/cases/templates/cases/case.html:63
-#: oldp/apps/laws/templates/laws/law.html:72
+#: oldp/apps/laws/templates/laws/law.html:56
 msgid "API"
 msgstr "API"
 
@@ -983,7 +989,7 @@ msgstr "Kurz-URL"
 #: oldp/apps/cases/templates/cases/case.html:137
 #: oldp/apps/cases/templates/cases/stats/base.html:110
 #: oldp/apps/courts/templates/courts/cases_list.html:10
-#: oldp/apps/laws/templates/laws/law.html:87
+#: oldp/apps/laws/templates/laws/law.html:71
 #: oldp/apps/processing/templates/admin/processing/dashboard.html:8
 msgid "Home"
 msgstr "Startseite"
@@ -996,34 +1002,25 @@ msgstr "Dieser Inhalt sollte im Produktivbetrieb nicht sichtbar sein."
 msgid "btn_show_full_text"
 msgstr "Volltext anzeigen"
 
-#: oldp/apps/cases/templates/cases/case.html:193
+#: oldp/apps/cases/templates/cases/case.html:196
 msgid "Cited by"
 msgstr "Zitiert von"
 
-#: oldp/apps/cases/templates/cases/case.html:199
-#: oldp/apps/laws/templates/laws/references.html:48
+#: oldp/apps/cases/templates/cases/case.html:202
+#: oldp/apps/laws/templates/laws/references.html:51
 msgid "Open citing-cases search"
 msgstr "Suche nach zitierenden Entscheidungen öffnen"
 
-#: oldp/apps/cases/templates/cases/case.html:211
+#: oldp/apps/cases/templates/cases/case.html:214
 #: oldp/apps/courts/templates/courts/cases_list.html:65
-#: oldp/apps/laws/templates/laws/references.html:60
+#: oldp/apps/laws/templates/laws/references.html:63
 #, python-format
 msgid "Show all %(cases_count)s cases ..."
 msgstr "Alle %(cases_count)s Gerichtsentscheidungen anzeigen ..."
 
-#: oldp/apps/cases/templates/cases/case.html:217
+#: oldp/apps/cases/templates/cases/case.html:220
 msgid "No other cases cite this decision yet."
 msgstr "Bislang zitiert keine andere Entscheidung dieses Urteil."
-
-#: oldp/apps/cases/templates/cases/case.html:222
-msgid "Related Cases"
-msgstr "Verwandte Urteile"
-
-#: oldp/apps/cases/templates/cases/case.html:229
-#: oldp/apps/laws/templates/laws/law.html:53
-msgid "empty_related_content"
-msgstr "Keine verwandten Inhalte vorhanden."
 
 #: oldp/apps/cases/templates/cases/case_filter.html:21
 #: oldp/apps/courts/templates/courts/court_filter.html:23
@@ -1375,7 +1372,7 @@ msgstr "Urteilsstatistiken für Gerichte anzeigen in"
 #: oldp/apps/homepage/templates/errors/permission_denied.html:9
 #: oldp/apps/homepage/views.py:79 oldp/apps/homepage/views.py:88
 #: oldp/apps/homepage/views.py:98 oldp/apps/homepage/views.py:109
-#: oldp/apps/search/templates/search/search.html:65
+#: oldp/apps/search/templates/search/search.html:72
 msgid "Error"
 msgstr "Fehler"
 
@@ -1707,17 +1704,17 @@ msgid "Changelog"
 msgstr "Standangaben"
 
 #: oldp/apps/laws/templates/laws/book.html:41
-#: oldp/apps/laws/templates/laws/law.html:57
+#: oldp/apps/laws/templates/laws/law.html:42
 msgid "Revisions"
 msgstr "Versionen"
 
-#: oldp/apps/laws/templates/laws/book.html:45
-#: oldp/apps/laws/templates/laws/law.html:62
+#: oldp/apps/laws/templates/laws/book.html:44
+#: oldp/apps/laws/templates/laws/law.html:46
 msgid "selected"
 msgstr "ausgewählt"
 
-#: oldp/apps/laws/templates/laws/book.html:50
-#: oldp/apps/laws/templates/laws/law.html:67
+#: oldp/apps/laws/templates/laws/book.html:49
+#: oldp/apps/laws/templates/laws/law.html:51
 msgid "btn_show_all"
 msgstr "Alle anzeigen"
 
@@ -1725,22 +1722,18 @@ msgstr "Alle anzeigen"
 msgid "More Laws"
 msgstr "Weitere Gesetze"
 
-#: oldp/apps/laws/templates/laws/law.html:42
-msgid "Related Laws"
-msgstr "Verwandte Gesetze"
-
-#: oldp/apps/laws/templates/laws/law.html:105
+#: oldp/apps/laws/templates/laws/law.html:89
 #: oldp/assets/templates/account/email.html:62
 msgid "Warning:"
 msgstr "Warnung:"
 
-#: oldp/apps/laws/templates/laws/law.html:105
+#: oldp/apps/laws/templates/laws/law.html:89
 msgid "law_outdated_warning"
 msgstr ""
 "Dieser Gesetzestext ist möglicherweise veraltet, da der Inhalt nicht aktiv "
 "gepflegt wird. Bitte prüfen Sie die offiziellen Quellen."
 
-#: oldp/apps/laws/templates/laws/law.html:110
+#: oldp/apps/laws/templates/laws/law.html:94
 #, python-format
 msgid ""
 "You are currently viewing an <strong>outdated revision</strong> of this law. "
@@ -1749,7 +1742,7 @@ msgstr ""
 "Sie sehen eine <strong>veraltete Version</strong> des Gesetzestextes. "
 "Klicken Sie <a href=\"%(url)s\">hier</a> um die aktuelle Version anzuzeigen."
 
-#: oldp/apps/laws/templates/laws/law.html:143
+#: oldp/apps/laws/templates/laws/law.html:127
 msgid "This law is deprecated."
 msgstr "Dieser Paragraph ist weggefallen."
 
@@ -1766,7 +1759,7 @@ msgstr "Dieses Dokument enthält keine Referenzen."
 msgid "Referenced by"
 msgstr "Zitiert von"
 
-#: oldp/apps/laws/templates/laws/references.html:66
+#: oldp/apps/laws/templates/laws/references.html:69
 msgid "No cases cite this section yet."
 msgstr "Bislang zitiert keine Entscheidung diese Vorschrift."
 
@@ -1832,50 +1825,72 @@ msgstr "Versuche es mit allgemeineren Suchbegriffen"
 msgid "Try fewer keywords."
 msgstr "Versuche es mit weniger Suchbegriffen"
 
-#: oldp/apps/search/templates/search/facets.html:14
+#: oldp/apps/search/templates/search/facets.html:22
 msgid "No filter available."
 msgstr "Keine Filter verfügbar."
 
-#: oldp/apps/search/templates/search/facets.html:20
+#: oldp/apps/search/templates/search/facets.html:26
+msgid "Sort by"
+msgstr "Sortieren nach"
+
+#: oldp/apps/search/templates/search/facets.html:33
+msgid "Relevance"
+msgstr "Relevanz"
+
+#: oldp/apps/search/templates/search/facets.html:41
+msgid "Date (newest first)"
+msgstr "Datum (neueste zuerst)"
+
+#: oldp/apps/search/templates/search/facets.html:50
 msgid "Document type"
 msgstr "Dokumenttyp"
 
-#: oldp/apps/search/templates/search/facets.html:33
+#: oldp/apps/search/templates/search/facets.html:63
 msgid "Law book"
 msgstr "Gesetzbuch"
 
 #: oldp/apps/search/templates/search/search.html:29
-#: oldp/apps/search/views.py:303 oldp/apps/search/views.py:354
+#: oldp/apps/search/views.py:322 oldp/apps/search/views.py:381
 msgid "Search"
 msgstr "Suche"
 
-#: oldp/apps/search/templates/search/search.html:44
+#: oldp/apps/search/templates/search/search.html:49
 msgid "Cases citing"
 msgstr "Entscheidungen, die folgendes zitieren:"
 
-#: oldp/apps/search/templates/search/search.html:46
+#: oldp/apps/search/templates/search/search.html:51
 msgid "Cases citing case"
 msgstr "Entscheidungen, die folgendes Urteil zitieren:"
 
-#: oldp/apps/search/templates/search/search.html:51
+#: oldp/apps/search/templates/search/search.html:57
 msgid "(unknown)"
 msgstr "(unbekannt)"
 
-#: oldp/apps/search/templates/search/search.html:54
+#: oldp/apps/search/templates/search/search.html:61
 msgid "Remove filter"
 msgstr "Filter entfernen"
 
-#: oldp/apps/search/templates/search/search.html:72
+#: oldp/apps/search/templates/search/search.html:80
 #, python-format
-msgid "%(count)s citing cases."
-msgstr "%(count)s zitierende Entscheidungen."
+msgid "%(count)s citing cases, sorted by <b>date</b>."
+msgstr "%(count)s zitierende Entscheidungen, sortiert nach <b>Datum</b>."
 
-#: oldp/apps/search/templates/search/search.html:74
+#: oldp/apps/search/templates/search/search.html:82
 #, python-format
-msgid "%(count)s results sorted by <b>relevance</b>."
+msgid "%(count)s citing cases, sorted by <b>relevance</b>."
+msgstr "%(count)s zitierende Entscheidungen, sortiert nach <b>Relevanz</b>."
+
+#: oldp/apps/search/templates/search/search.html:85
+#, python-format
+msgid "%(count)s documents sorted by <b>date</b>."
+msgstr "%(count)s Dokumente sortiert nach <b>Datum</b>."
+
+#: oldp/apps/search/templates/search/search.html:87
+#, python-format
+msgid "%(count)s documents sorted by <b>relevance</b>."
 msgstr "%(count)s Dokumente sortiert nach <b>Relevanz</b>."
 
-#: oldp/apps/search/utils.py:119
+#: oldp/apps/search/utils.py:173
 msgid ""
 "Search backend is currently unavailable, so the list of citing cases cannot "
 "be loaded. Please try again later."
@@ -1884,13 +1899,13 @@ msgstr ""
 "Entscheidungen kann momentan nicht geladen werden. Bitte versuchen Sie es "
 "später erneut."
 
-#: oldp/apps/search/views.py:293
+#: oldp/apps/search/views.py:312
 msgid ""
 "Search timed out. The first request after a cold start can be slow — please "
 "try again."
 msgstr ""
 
-#: oldp/apps/search/views.py:298
+#: oldp/apps/search/views.py:317
 #, fuzzy
 #| msgid "Search service is currently not available."
 msgid "Search is currently unavailable. Please try again later."
@@ -2240,3 +2255,16 @@ msgstr "Englisch"
 #: oldp/settings.py:259
 msgid "German"
 msgstr "Deutsch"
+
+#~ msgid "Related Cases"
+#~ msgstr "Verwandte Urteile"
+
+#~ msgid "empty_related_content"
+#~ msgstr "Keine verwandten Inhalte vorhanden."
+
+#~ msgid "Related Laws"
+#~ msgstr "Verwandte Gesetze"
+
+#, python-format
+#~ msgid "%(count)s citing cases."
+#~ msgstr "%(count)s zitierende Entscheidungen."


### PR DESCRIPTION
## Summary

Two changes shipped together since they share the same search-form rewrite:

1. **Combined citation+keyword+facets** — PR #224 added ES-backed citation deep links (`/search/?cited_law_book=bgb&cited_law_section=823`), but combining citation params with keyword (`?q=`) or selected facets silently dropped one of them. Now every combination intersects correctly on the web, REST, and MCP surfaces.
2. **Sort by date** — new `?order_by=relevance|date` toggle in the facets sidebar (auto-submits on change); the active sort is rendered in the results-count label.

Also rolled in as small visual fixes/parity items:
- Citation chip aligns horizontally with the search input on both desktop and mobile (`px-3` on the wrapper).
- REST `SearchFilter` and MCP `search_cases` gain citation kwargs; OpenAPI schema updated.

## Root causes fixed

- `SearchQueryBuilder.__init__` used truthy fallback — `EmptySearchQuerySet` is falsy, so any `.narrow()` clauses were silently dropped when the form passed an empty SQS in.
- `CustomSearchForm.search` called `super().search()`, which returns Empty whenever `q` is empty. Chaining `.filter()` onto Empty stays Empty, so facets-only / citation-only / facets+citation requests with no `q` returned zero results post-chain.
- The facets-sidebar form's hidden inputs preserved only `q` / `start_date` / `end_date`, dropping citation params and `selected_facets` on submit. Same gap in the per-year-tile `<a href>`.

## Test plan

- [x] `make lint-check`
- [x] `make test` — 1195 tests pass
- [x] `DJANGO_MOCK_ES_TESTS=False ... --tag es` against podman ES 7.17.12 — 23 real-ES tests pass (7 new in `test_combined_search_es.py`)
- [x] Manual browser walkthrough at 1280×900 and 390×844 via Chrome MCP — citation chip + keyword input both visible, facets + citation chip both active after year-tile click, sort radio auto-submits and the count label reflects the active order
- [x] No index schema change — no reindex required on deploy