### PR TITLE
chore: bump legal-reference-extraction to 0.5.3

### DIFF
--- a/oldp/apps/references/tests/test_processing_extract_refs.py
+++ b/oldp/apps/references/tests/test_processing_extract_refs.py
@@ -40,11 +40,15 @@ class ExtractReferencesTestCase(TransactionTestCase):
         # `Art.` / Grundgesetz citation patterns (CHANGELOG Stream E).
         # The fixture now yields 5 additional Art. GG markers for 3 new
         # target groups (GG/2, GG/14, GG/34) compared to v0.4.x.
-        self.assertEqual(33, len(processed.get_references()))
+        # 0.5.3 (D6/D7 recall fixes) additionally recovers one `§ 91 ZPO`
+        # citation the 0.5.2 regex missed (33 -> 34; new ZPO/91 group).
+        self.assertEqual(34, len(processed.get_references()))
 
         groups = processed.get_grouped_references()
 
-        self.assertEqual(16, len(groups))
+        # +1 vs 0.5.2: the recovered `§ 91 ZPO` is a new target (distinct
+        # `to_hash` from the existing ZPO §§708/709/711), so it adds a group.
+        self.assertEqual(17, len(groups))
 
 
 @tag("processing")

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -70,7 +70,7 @@ dependencies = [
 # django-extensions #>=2.1.9
 
 # https://github.com/openlegaldata/legal-reference-extraction
-"legal-reference-extraction==0.5.2",
+"legal-reference-extraction==0.5.3",
 
 # MCP (Model Context Protocol) server
 # https://github.com/gts360/django-mcp-server


### PR DESCRIPTION
## Summary

Bumps the `legal-reference-extraction` pin `0.5.2` → `0.5.3` (now on PyPI).

0.5.3 pulls the **D1/D6/D7** extraction fixes (legal-reference-extraction#23):
- case-extraction recall (4-digit years, EU courts, comma-grouped joined proceedings, roman chamber + trailing letter)
- law book-code & `i.V.m.` resolution (possessive-regex miscompilation)
- `law_book_codes.txt` pseudo-code cleanup + generic-fallback Roman guard

plus refex #21 (whitespace-tag guard / ac backtracking) and #22 (benchmark HF fallback).

API-compatible patch over the 0.5.0 refactor that oldp already runs on `0.5.2` — **no oldp code changes**, only the pin. The bundled `law_book_codes.txt` was already dropped in #181, so oldp relies on refex for codes; this pulls the cleaned set.

## Deploy note

After release/image build, **re-extract references** over the corpus to apply the improved extraction (D8). Validated on the stage stack (real dev data) before merge.

## Test plan

- [ ] CI green (build + tests resolve refex 0.5.3 from PyPI)
- [ ] Stage: oldp image builds with 0.5.3, `extract_refs` runs, sample re-extraction unchanged-or-improved vs 0.5.2