### PR TITLE
fix(search): stop short-query exact_matches clause widening results (phrase leak)

### DIFF
--- a/oldp/apps/cases/mcp.py
+++ b/oldp/apps/cases/mcp.py
@@ -135,6 +135,7 @@ class CaseTools(MCPToolset):
             from oldp.apps.search.api import SearchQueryBuilder
             from oldp.apps.search.utils import (
                 apply_citation_filter,
+                narrow_to_model,
                 prepare_search_query,
             )
 
@@ -148,9 +149,11 @@ class CaseTools(MCPToolset):
             # Constrain to the Case index. The custom SearchBackend silently
             # drops the .models() filter applied via filter_models above, so
             # without this guard a query that also matches Law text (e.g.
-            # "Schadensersatz") would leak Law results. Mirrors the pattern
-            # in SearchSchemaFilter used by the REST API.
-            sqs = sqs.filter(facet_model_name_exact="Case")
+            # "Schadensersatz") would leak Law results. Filter-context narrow
+            # (not .filter) also stops the navigational match_phrase boost from
+            # surfacing a Law doc in this Case-only search — see
+            # narrow_to_model. Mirrors SearchSchemaFilter used by the REST API.
+            sqs = narrow_to_model(sqs, "Case")
 
             # Hide cases with bogus future dates (matches the
             # exclude_future_dated_cases helper used on the ORM path).

--- a/oldp/apps/cases/search_indexes.py
+++ b/oldp/apps/cases/search_indexes.py
@@ -68,6 +68,31 @@ class CaseIndex(indexes.SearchIndex, indexes.Indexable):
     def prepare_title(self, obj):
         return obj.get_title()
 
+    def prepare_exact_matches(self, obj):
+        """Navigational handles that should rank this case first.
+
+        The case body (the document ``text`` field) does not reliably
+        contain the case's own file number, and ``title`` is not the
+        ``query_string`` default field — so without populating this field a
+        file-number lookup matches nothing on-point. That lookup is a real
+        path: an *unresolved* case citation renders a link to
+        ``/search/?q=<file_number>&from=ref`` (see
+        ``Reference.get_absolute_url``), and users paste Aktenzeichen
+        directly. The search backend boosts an exact ``match_phrase`` on this
+        field, so listing the file number (raw + whitespace-free) and the
+        ECLI here makes the cited case rank #1.
+        """
+        forms = []
+        if obj.file_number:
+            forms.append(obj.file_number)
+            # Whitespace-free variant so "VIZR123/22"-style pastes also hit.
+            collapsed = obj.file_number.replace(" ", "")
+            if collapsed != obj.file_number:
+                forms.append(collapsed)
+        if obj.ecli:
+            forms.append(obj.ecli)
+        return forms
+
     def prepare_absolute_url(self, obj):
         return obj.get_absolute_url()
 

--- a/oldp/apps/cases/serializers.py
+++ b/oldp/apps/cases/serializers.py
@@ -61,9 +61,24 @@ class CaseSearchSerializer(SearchResultSerializer):
     id = serializers.SerializerMethodField()
     # Declared (not auto-added as CharField) so it serializes as an int.
     citing_cases_count = serializers.IntegerField(read_only=True, default=0)
+    # Normalize the placeholder "unknown" court code to null so REST consumers
+    # branch on a real null instead of mistaking "unknown" for an actual court
+    # — parity with the MCP ``search_cases`` tool, which already does this via
+    # ``_norm_court``. Declaring it here keeps it out of the __init__
+    # auto-CharField path; ``SearchResultSerializer.to_representation`` honours
+    # SerializerMethodField.
+    court = serializers.SerializerMethodField()
 
     def get_id(self, obj):
         return int(obj.pk)
+
+    def get_court(self, obj):
+        # Reuse the single normalization definition (placeholder "unknown" →
+        # None). Lazy import avoids loading the MCP module at serializer
+        # import time.
+        from oldp.apps.cases.mcp import _norm_court
+
+        return _norm_court(getattr(obj, "court", None))
 
     class Meta:
         fields = [

--- a/oldp/apps/cases/tests/test_mcp.py
+++ b/oldp/apps/cases/tests/test_mcp.py
@@ -282,6 +282,7 @@ class CaseToolsTests(TestCase):
         class FakeSearchQuerySet:
             def __init__(self):
                 self.filters = []
+                self.narrows = []
                 self.order_by_calls = []
 
             def auto_query(self, query):
@@ -289,6 +290,10 @@ class CaseToolsTests(TestCase):
 
             def filter(self, **kwargs):
                 self.filters.append(kwargs)
+                return self
+
+            def narrow(self, query):
+                self.narrows.append(query)
                 return self
 
             def order_by(self, *fields):
@@ -321,6 +326,7 @@ class CaseToolsTests(TestCase):
         with patch("oldp.apps.search.api.SearchQueryBuilder", return_value=builder):
             result = self.tools.search_cases(**kwargs)
         self._last_order_by = builder.sqs.order_by_calls
+        self._last_narrows = builder.sqs.narrows
         return result, builder.sqs.filters
 
     def test_search_cases_sort_relevance_does_not_order(self):
@@ -372,15 +378,17 @@ class CaseToolsTests(TestCase):
         SearchBackend silently drops the .models() filter, so without this
         guard a query that also matches Law text could leak Law results.
         """
+        # The clamp is a filter-context narrow (not a scoring .filter) so the
+        # navigational boost stays safe and short lookups stay navigational.
         # No facet args -> the bug-prone path.
-        _, filters_no_facets = self._patched_search_cases(query="test")
-        self.assertIn({"facet_model_name_exact": "Case"}, filters_no_facets)
+        self._patched_search_cases(query="test")
+        self.assertIn('facet_model_name_exact:"Case"', self._last_narrows)
 
-        # With facet args -> filter is still applied.
-        _, filters_with_facets = self._patched_search_cases(
+        # With facet args -> clamp is still applied.
+        self._patched_search_cases(
             query="test", court_code="BGH", decision_type="Urteil"
         )
-        self.assertIn({"facet_model_name_exact": "Case"}, filters_with_facets)
+        self.assertIn('facet_model_name_exact:"Case"', self._last_narrows)
 
     def test_search_cases_chains_law_citation_filter(self):
         """``cited_law_book`` + ``cited_law_section`` must chain a

--- a/oldp/apps/cases/tests/test_search_index_sync.py
+++ b/oldp/apps/cases/tests/test_search_index_sync.py
@@ -10,12 +10,40 @@ its action in ``captureOnCommitCallbacks(execute=True)`` to run those
 callbacks in the test transaction.
 """
 
+from types import SimpleNamespace
 from unittest.mock import patch
 
-from django.test import TestCase
+from django.test import SimpleTestCase, TestCase
 
 from oldp.apps.cases.models import Case
+from oldp.apps.cases.search_indexes import CaseIndex
 from oldp.apps.courts.models import Court
+
+
+class CaseExactMatchesTestCase(SimpleTestCase):
+    """``CaseIndex.exact_matches`` must carry the case's navigational
+    handles (file number + ECLI) so a file-number lookup — including the
+    ``/search/?q=<file_number>&from=ref`` link rendered for an unresolved
+    case citation — ranks the cited case first. The body text does not
+    reliably contain the case's own file number, so this is the only
+    field that makes the lookup resolve.
+    """
+
+    def test_file_number_and_ecli_present(self):
+        obj = SimpleNamespace(file_number="VI ZR 123/22", ecli="ECLI:DE:BGH:2022:X")
+        forms = CaseIndex().prepare_exact_matches(obj)
+        self.assertIn("VI ZR 123/22", forms)
+        # Whitespace-free variant for "VIZR123/22"-style pastes.
+        self.assertIn("VIZR123/22", forms)
+        self.assertIn("ECLI:DE:BGH:2022:X", forms)
+
+    def test_no_blank_entries_when_fields_empty(self):
+        obj = SimpleNamespace(file_number="", ecli="")
+        self.assertEqual(CaseIndex().prepare_exact_matches(obj), [])
+
+    def test_no_duplicate_when_file_number_has_no_spaces(self):
+        obj = SimpleNamespace(file_number="T-345/26", ecli="")
+        self.assertEqual(CaseIndex().prepare_exact_matches(obj), ["T-345/26"])
 
 
 class SyncCaseToSearchIndexTestCase(TestCase):

--- a/oldp/apps/laws/mcp.py
+++ b/oldp/apps/laws/mcp.py
@@ -213,7 +213,7 @@ class LawTools(MCPToolset):
 
         try:
             from oldp.apps.search.api import SearchQueryBuilder
-            from oldp.apps.search.utils import prepare_search_query
+            from oldp.apps.search.utils import narrow_to_model, prepare_search_query
 
             builder = SearchQueryBuilder()
             builder.filter_models([Law])
@@ -224,8 +224,10 @@ class LawTools(MCPToolset):
             # Constrain to the Law index. The custom SearchBackend silently
             # drops the .models() filter applied via filter_models above, so
             # without this guard the query also matches Case documents.
-            # Mirrors the pattern in SearchSchemaFilter used by the REST API.
-            sqs = sqs.filter(facet_model_name_exact="Law")
+            # Filter-context narrow (not .filter) keeps a navigational lookup
+            # ("bgb 123") eligible for the exact-match boost — see
+            # narrow_to_model. Mirrors SearchSchemaFilter used by the REST API.
+            sqs = narrow_to_model(sqs, "Law")
 
             if book_code:
                 sqs = sqs.filter(book_code_exact=book_code.upper())

--- a/oldp/apps/laws/tests/test_mcp.py
+++ b/oldp/apps/laws/tests/test_mcp.py
@@ -129,12 +129,17 @@ class LawToolsTests(TestCase):
         class FakeSearchQuerySet:
             def __init__(self):
                 self.filters = []
+                self.narrows = []
 
             def auto_query(self, query):
                 return self
 
             def filter(self, **kwargs):
                 self.filters.append(kwargs)
+                return self
+
+            def narrow(self, query):
+                self.narrows.append(query)
                 return self
 
             def __getitem__(self, key):
@@ -159,6 +164,7 @@ class LawToolsTests(TestCase):
         builder = FakeSearchQueryBuilder()
         with patch("oldp.apps.search.api.SearchQueryBuilder", return_value=builder):
             result = self.tools.search_laws(**kwargs)
+        self._last_narrows = builder.sqs.narrows
         return result, builder.sqs.filters
 
     def test_search_laws_uses_exact_book_code_filter(self):
@@ -169,15 +175,17 @@ class LawToolsTests(TestCase):
     def test_search_laws_always_constrains_to_law_index(self):
         """Regression test.
 
-        search_laws must filter on facet_model_name_exact="Law" regardless
-        of whether book_code is set, otherwise the custom SearchBackend
-        silently lets case-shaped results leak into law search responses.
+        search_laws must clamp to facet_model_name_exact="Law" regardless of
+        whether book_code is set, otherwise the custom SearchBackend silently
+        lets case-shaped results leak into law search responses. The clamp is
+        a filter-context narrow (not a scoring .filter) so a navigational
+        lookup ("bgb 123") still ranks the on-point law #1.
         """
         # No book_code -> the bug-prone path.
-        _, filters_no_book = self._patched_search_laws(query="test")
-        self.assertIn({"facet_model_name_exact": "Law"}, filters_no_book)
+        self._patched_search_laws(query="test")
+        self.assertIn('facet_model_name_exact:"Law"', self._last_narrows)
 
-        # With book_code -> filter is still applied (belt-and-suspenders).
+        # With book_code -> clamp is still applied (belt-and-suspenders).
         _, filters_with_book = self._patched_search_laws(query="test", book_code="BGB")
-        self.assertIn({"facet_model_name_exact": "Law"}, filters_with_book)
+        self.assertIn('facet_model_name_exact:"Law"', self._last_narrows)
         self.assertIn({"book_code_exact": "BGB"}, filters_with_book)

--- a/oldp/apps/mcp/mcp.py
+++ b/oldp/apps/mcp/mcp.py
@@ -84,6 +84,7 @@ class PlatformTools(MCPToolset):
         from oldp.apps.search.utils import (
             is_search_backend_error,
             is_search_backend_timeout,
+            narrow_to_model,
             prepare_search_query,
         )
 
@@ -101,11 +102,9 @@ class PlatformTools(MCPToolset):
             builder.apply_highlight()
             # The custom SearchBackend drops .models(); the facet clamp is
             # what actually isolates each index (see search_cases/laws).
-            sqs = (
-                builder.build()
-                .auto_query(normalized)
-                .filter(facet_model_name_exact=facet)
-            )
+            # narrow_to_model applies it in filter context so a navigational
+            # lookup ("bgb 123") still ranks the on-point law #1.
+            sqs = narrow_to_model(builder.build().auto_query(normalized), facet)
             # Hide ingestion-artefact future-dated cases (matches
             # search_cases). Laws have no date field, so only the Case facet.
             if facet == "Case":

--- a/oldp/apps/mcp/tests/test_platform_tools.py
+++ b/oldp/apps/mcp/tests/test_platform_tools.py
@@ -120,11 +120,18 @@ class _FakeSQS:
     def auto_query(self, q):
         return self
 
+    def narrow(self, query):
+        # The model clamp now arrives as a filter-context narrow,
+        # e.g. 'facet_model_name_exact:"Law"'. It selects the canned
+        # result set for that facet.
+        prefix = 'facet_model_name_exact:"'
+        if query.startswith(prefix):
+            facet = query[len(prefix) : -1]
+            self._results = self._by_facet.get(facet, [])
+        return self
+
     def filter(self, **kw):
-        # The facet clamp selects the canned result set; other filters
-        # (e.g. date__lte future-date guard) are chained no-ops.
-        if "facet_model_name_exact" in kw:
-            self._results = self._by_facet.get(kw["facet_model_name_exact"], [])
+        # Non-clamp filters (e.g. date__lte future-date guard) are no-ops.
         return self
 
     def __getitem__(self, s):

--- a/oldp/apps/search/api.py
+++ b/oldp/apps/search/api.py
@@ -51,8 +51,15 @@ class SearchQueryBuilder:
         return self
 
     def filter_review_status(self, status="accepted"):
-        """Filter by review_status."""
-        self.queryset = self.queryset.filter(review_status=status)
+        """Filter by review_status as a non-scoring narrow.
+
+        Applied via ``.narrow`` (→ ``bool.filter``) rather than ``.filter``
+        so the status clause stays OUT of the main scoring query string.
+        Keeping it out is what lets short navigational lookups still reach
+        the exact-match boost (see :func:`narrow_to_model`); the filtering
+        effect is identical.
+        """
+        self.queryset = self.queryset.narrow('review_status:"%s"' % status)
         return self
 
     def apply_highlight(self):

--- a/oldp/apps/search/filters.py
+++ b/oldp/apps/search/filters.py
@@ -1,5 +1,7 @@
 from rest_framework.filters import BaseFilterBackend
 
+from oldp.apps.search.utils import narrow_to_model
+
 
 class SearchSchemaFilter(BaseFilterBackend):
     """This class add search index filters (facets) as parameters to the schema. If not used, generate swagger API clients
@@ -39,9 +41,11 @@ class SearchSchemaFilter(BaseFilterBackend):
         those as well. This allows API consumers to replicate the same facet-based
         filtering available in the web search UI.
         """
-        queryset = queryset.filter(
-            facet_model_name_exact=self.search_index_class.FACET_MODEL_NAME
-        )
+        # Filter-context narrow (not .filter) so the clamp stays out of the
+        # scoring query string — keeps short navigational lookups eligible
+        # for the exact-match boost and prevents the boost leaking the other
+        # model. See ``narrow_to_model``.
+        queryset = narrow_to_model(queryset, self.search_index_class.FACET_MODEL_NAME)
 
         for field_name, field in self.search_index_class.fields.items():
             if not field.faceted:

--- a/oldp/apps/search/search_backend.py
+++ b/oldp/apps/search/search_backend.py
@@ -14,6 +14,34 @@ from haystack.constants import DEFAULT_OPERATOR, FUZZINESS
 logger = logging.getLogger(__name__)
 
 
+def _phrase_text(query_string):
+    r"""Strip Haystack ``AutoQuery`` serialization to recover plain phrase text.
+
+    ``AutoQuery`` wraps the user query as ``(...)`` (and quoted phrases as
+    ``"..."``) and backslash-escapes Lucene-reserved characters
+    (``: / ( ) ...``) so the string is safe for a ``query_string`` clause.
+    The ``match_phrase`` boost on ``exact_matches`` wants the RAW text — it
+    re-analyzes its input, where those escapes are wrong. Feeding the escaped
+    form made colon-bearing handles unmatchable: e.g. an ECLI
+    ``ECLI:DE:BGH:2021:...`` serializes to ``("ECLI\\:DE\\:BGH\\:2021\\:...")``
+    and the stray backslashes prevented the analyzed tokens from matching the
+    stored ECLI (file numbers were unaffected — they carry no escaped chars).
+
+    Dropping the wrapping + backslash escapes is safe for the boost clause:
+    for ordinary prose queries it leaves the text unchanged (no escapes
+    present) and the ``match_phrase`` stays a no-op; it only unlocks the
+    colon-bearing navigational handles. The ``query_string`` clause keeps the
+    original escaped string.
+    """
+    s = query_string.strip()
+    if s.startswith("(") and s.endswith(")"):
+        s = s[1:-1]
+    # match_phrase re-analyzes its text, so backslash escapes and the phrase
+    # quotes AutoQuery added are not meaningful here — remove them.
+    s = s.replace("\\", "").replace('"', " ")
+    return s.strip()
+
+
 def _deep_merge(base, override):
     """Recursively merge ``override`` into ``base`` (both dicts), in place.
 
@@ -191,7 +219,10 @@ class SearchBackend(Elasticsearch7SearchBackend):
                             {
                                 "match_phrase": {
                                     "exact_matches": {
-                                        "query": query_string,
+                                        # Raw phrase text (AutoQuery escaping
+                                        # stripped) so colon-bearing handles
+                                        # like ECLIs match — see _phrase_text.
+                                        "query": _phrase_text(query_string),
                                         "boost": self.exact_boost_factor,
                                     }
                                 }

--- a/oldp/apps/search/search_backend.py
+++ b/oldp/apps/search/search_backend.py
@@ -159,30 +159,36 @@ class SearchBackend(Elasticsearch7SearchBackend):
             kwargs = {"query": {"match_all": {}}}
         else:
             if self.is_navigational_query(query_string):
-                # Boost exact title/keyword matches WITHOUT widening the
-                # result set. The ``query_string`` is the REQUIRED matcher
-                # (``must``) — it honours phrases and the AND default
-                # operator. The ``exact_matches`` clause only *boosts* score
-                # (``should``); with a ``must`` present, ES treats ``should``
-                # as pure scoring (minimum_should_match defaults to 0).
+                # Boost the exact navigational target (e.g. ``BGB 123`` → the
+                # § 123 BGB law doc) while NOT letting the boost clause widen
+                # the result set with loose term matches.
                 #
-                # Previously BOTH clauses sat in ``should`` (i.e. OR'd as
-                # alternatives). Because the ``exact_matches`` clause is a
-                # plain ``match`` (it strips the phrase quotes and ORs the
-                # terms), it pulled in documents that did NOT satisfy the
-                # ``query_string`` — silently breaking exact-phrase queries
-                # and the AND default for short (<4-word) "navigational"
-                # queries on any surface whose main query carries no extra
-                # in-query filter. The web search form is exactly such a
-                # surface (REST/MCP incidentally serialize a
-                # ``review_status:accepted`` filter into the query string,
-                # which flips them onto the non-navigational path), so
-                # ``/search/?q="A B"`` returned the OR'd superset while the
-                # API/MCP returned the correct phrase-constrained set.
+                # ``exact_matches`` stores a doc's full navigational forms —
+                # ``"<code> <section>"``, the reversed and no-space variants,
+                # and the title (see ``LawIndex.prepare_exact_matches``). It
+                # is deliberately a ``should`` *alternative* (not just a score
+                # boost on top of ``query_string``): a law section's ``text``
+                # field almost never contains its own section number, so
+                # ``/search/?q="bgb 123"`` can only surface § 123 BGB via this
+                # clause — requiring a ``query_string`` (text) match would drop
+                # the law entirely.
+                #
+                # The clause MUST be ``match_phrase``, never a plain ``match``.
+                # A plain ``match`` ORs the analysed terms, so a multi-word /
+                # phrase query matched any doc whose ``exact_matches`` (incl.
+                # the law *title*) shared a single common word — e.g.
+                # ``"Glauben und Treu"`` matched every title containing "und"
+                # (~10k docs) on surfaces whose main query carries no extra
+                # in-query filter (the web search form; REST/MCP incidentally
+                # serialize ``review_status:accepted`` into the query string,
+                # flipping them onto the non-navigational path). ``match_phrase``
+                # only matches the full query as a consecutive phrase against
+                # the stored navigational forms, so it boosts the real target
+                # without leaking. ``query_string`` remains the general matcher.
                 kwargs = {
                     "query": {
                         "bool": {
-                            "must": [
+                            "should": [
                                 {
                                     "query_string": {
                                         "default_field": content_field,
@@ -193,17 +199,15 @@ class SearchBackend(Elasticsearch7SearchBackend):
                                         "fuzziness": FUZZINESS,
                                     }
                                 },
-                            ],
-                            "should": [
                                 {
-                                    "match": {
+                                    "match_phrase": {
                                         "exact_matches": {
                                             "query": query_string,
                                             "boost": self.exact_boost_factor,
                                         }
                                     }
                                 },
-                            ],
+                            ]
                         }
                     }
                 }

--- a/oldp/apps/search/search_backend.py
+++ b/oldp/apps/search/search_backend.py
@@ -105,22 +105,6 @@ class SearchBackend(Elasticsearch7SearchBackend):
     def extract_file_contents(self, file_obj):
         pass
 
-    def is_navigational_query(self, query_string):
-        """Navigational queries do not contain operators (OR, AND, ...) and less than 4 words"""
-        q_words = query_string.lower().split()
-
-        # Contains OR, AND, ...
-        for word in self.RESERVED_WORDS:
-            if word.lower() in q_words:
-                return False
-
-        if len(q_words) >= 4:
-            return False
-
-        # logger.debug('Using boost for navigational queries')
-
-        return True
-
     def build_search_kwargs(
         self,
         query_string,
@@ -158,72 +142,64 @@ class SearchBackend(Elasticsearch7SearchBackend):
         if query_string == "*:*":
             kwargs = {"query": {"match_all": {}}}
         else:
-            if self.is_navigational_query(query_string):
-                # Boost the exact navigational target (e.g. ``BGB 123`` → the
-                # § 123 BGB law doc) while NOT letting the boost clause widen
-                # the result set with loose term matches.
-                #
-                # ``exact_matches`` stores a doc's full navigational forms —
-                # ``"<code> <section>"``, the reversed and no-space variants,
-                # and the title (see ``LawIndex.prepare_exact_matches``). It
-                # is deliberately a ``should`` *alternative* (not just a score
-                # boost on top of ``query_string``): a law section's ``text``
-                # field almost never contains its own section number, so
-                # ``/search/?q="bgb 123"`` can only surface § 123 BGB via this
-                # clause — requiring a ``query_string`` (text) match would drop
-                # the law entirely.
-                #
-                # The clause MUST be ``match_phrase``, never a plain ``match``.
-                # A plain ``match`` ORs the analysed terms, so a multi-word /
-                # phrase query matched any doc whose ``exact_matches`` (incl.
-                # the law *title*) shared a single common word — e.g.
-                # ``"Glauben und Treu"`` matched every title containing "und"
-                # (~10k docs) on surfaces whose main query carries no extra
-                # in-query filter (the web search form; REST/MCP incidentally
-                # serialize ``review_status:accepted`` into the query string,
-                # flipping them onto the non-navigational path). ``match_phrase``
-                # only matches the full query as a consecutive phrase against
-                # the stored navigational forms, so it boosts the real target
-                # without leaking. ``query_string`` remains the general matcher.
-                kwargs = {
-                    "query": {
-                        "bool": {
-                            "should": [
-                                {
-                                    "query_string": {
-                                        "default_field": content_field,
-                                        "default_operator": DEFAULT_OPERATOR,
+            # ``query_string`` is the general matcher (full-text over the
+            # document body, AND-by-default, fuzzy). Alongside it, a
+            # ``match_phrase`` on ``exact_matches`` BOOSTS the exact
+            # navigational target without widening the result set:
+            #
+            #  * ``exact_matches`` stores a doc's navigational handles —
+            #    for laws the ``"<code> <section>"`` forms + title
+            #    (``LawIndex.prepare_exact_matches``); for cases the
+            #    ``file_number`` + ECLI (``CaseIndex.prepare_exact_matches``).
+            #    These are exactly the strings a user (or the unresolved-
+            #    citation ``from=ref`` link) types to navigate to one doc.
+            #  * It is a ``should`` *alternative*, not a score-only boost on
+            #    top of ``query_string``: the body text frequently does NOT
+            #    contain the doc's own handle (a law section rarely repeats
+            #    its own number; a case body rarely repeats its own file
+            #    number), so the target can ONLY be surfaced via this clause.
+            #  * It MUST be ``match_phrase``, never a plain ``match``: a plain
+            #    ``match`` ORs the analysed terms, so a multi-word query
+            #    matched any doc sharing a single common word with
+            #    ``exact_matches`` (e.g. ``"Glauben und Treu"`` matched every
+            #    law title containing "und", ~10k docs). ``match_phrase`` only
+            #    matches the full query as a consecutive phrase.
+            #
+            # Applied uniformly (no short-vs-long "navigational" gate): a
+            # ``match_phrase`` on ``exact_matches`` is a no-op for ordinary
+            # prose queries (content words aren't navigational handles), but
+            # long handles exist too — 4+token Aktenzeichen like
+            # ``"AN 13b D 24.1173"`` — so gating the boost by word count would
+            # silently drop them. The boost combines into the result set
+            # safely because the whole query is wrapped as ``bool.must`` with
+            # the model/status/is_latest clauses as ``bool.filter`` below, so
+            # ``minimum_should_match`` stays 1 (at least one should must hit).
+            kwargs = {
+                "query": {
+                    "bool": {
+                        "should": [
+                            {
+                                "query_string": {
+                                    "default_field": content_field,
+                                    "default_operator": DEFAULT_OPERATOR,
+                                    "query": query_string,
+                                    "analyze_wildcard": True,
+                                    # "auto_generate_phrase_queries": True,
+                                    "fuzziness": FUZZINESS,
+                                }
+                            },
+                            {
+                                "match_phrase": {
+                                    "exact_matches": {
                                         "query": query_string,
-                                        "analyze_wildcard": True,
-                                        # "auto_generate_phrase_queries": True,
-                                        "fuzziness": FUZZINESS,
+                                        "boost": self.exact_boost_factor,
                                     }
-                                },
-                                {
-                                    "match_phrase": {
-                                        "exact_matches": {
-                                            "query": query_string,
-                                            "boost": self.exact_boost_factor,
-                                        }
-                                    }
-                                },
-                            ]
-                        }
+                                }
+                            },
+                        ]
                     }
                 }
-            else:
-                kwargs = {
-                    "query": {
-                        "query_string": {
-                            "default_field": content_field,
-                            "default_operator": DEFAULT_OPERATOR,
-                            "query": query_string,
-                            "analyze_wildcard": True,
-                            # "auto_generate_phrase_queries": True,
-                            "fuzziness": FUZZINESS,
-                        }
-                    }
-                }
+            }
 
         filters = []
 

--- a/oldp/apps/search/search_backend.py
+++ b/oldp/apps/search/search_backend.py
@@ -159,11 +159,30 @@ class SearchBackend(Elasticsearch7SearchBackend):
             kwargs = {"query": {"match_all": {}}}
         else:
             if self.is_navigational_query(query_string):
-                # This is the fancy part (boost exact matches)
+                # Boost exact title/keyword matches WITHOUT widening the
+                # result set. The ``query_string`` is the REQUIRED matcher
+                # (``must``) — it honours phrases and the AND default
+                # operator. The ``exact_matches`` clause only *boosts* score
+                # (``should``); with a ``must`` present, ES treats ``should``
+                # as pure scoring (minimum_should_match defaults to 0).
+                #
+                # Previously BOTH clauses sat in ``should`` (i.e. OR'd as
+                # alternatives). Because the ``exact_matches`` clause is a
+                # plain ``match`` (it strips the phrase quotes and ORs the
+                # terms), it pulled in documents that did NOT satisfy the
+                # ``query_string`` — silently breaking exact-phrase queries
+                # and the AND default for short (<4-word) "navigational"
+                # queries on any surface whose main query carries no extra
+                # in-query filter. The web search form is exactly such a
+                # surface (REST/MCP incidentally serialize a
+                # ``review_status:accepted`` filter into the query string,
+                # which flips them onto the non-navigational path), so
+                # ``/search/?q="A B"`` returned the OR'd superset while the
+                # API/MCP returned the correct phrase-constrained set.
                 kwargs = {
                     "query": {
                         "bool": {
-                            "should": [
+                            "must": [
                                 {
                                     "query_string": {
                                         "default_field": content_field,
@@ -174,6 +193,8 @@ class SearchBackend(Elasticsearch7SearchBackend):
                                         "fuzziness": FUZZINESS,
                                     }
                                 },
+                            ],
+                            "should": [
                                 {
                                     "match": {
                                         "exact_matches": {
@@ -182,7 +203,7 @@ class SearchBackend(Elasticsearch7SearchBackend):
                                         }
                                     }
                                 },
-                            ]
+                            ],
                         }
                     }
                 }

--- a/oldp/apps/search/tests/test_api_cache_headers.py
+++ b/oldp/apps/search/tests/test_api_cache_headers.py
@@ -8,6 +8,7 @@ def _make_mock_search_sqs():
     mock_sqs = MagicMock()
     mock_sqs.models.return_value = mock_sqs
     mock_sqs.filter.return_value = mock_sqs
+    mock_sqs.narrow.return_value = mock_sqs
     mock_sqs.auto_query.return_value = mock_sqs
     mock_sqs.highlight.return_value = mock_sqs
     mock_sqs.__len__ = MagicMock(return_value=0)

--- a/oldp/apps/search/tests/test_search_api.py
+++ b/oldp/apps/search/tests/test_search_api.py
@@ -148,6 +148,7 @@ class SearchApiMockedTestCase(TestCase):
         mock_sqs = MagicMock()
         mock_sqs.models.return_value = mock_sqs
         mock_sqs.filter.return_value = mock_sqs
+        mock_sqs.narrow.return_value = mock_sqs
         mock_sqs.auto_query.return_value = mock_sqs
         mock_sqs.highlight.return_value = mock_sqs
 

--- a/oldp/apps/search/tests/test_search_api.py
+++ b/oldp/apps/search/tests/test_search_api.py
@@ -141,6 +141,30 @@ class SearchApiIntegrationTestCase(ElasticsearchTestMixin, TestCase):
         }
     },
 )
+class CaseSearchSerializerCourtTestCase(TestCase):
+    """``CaseSearchSerializer`` must normalize the placeholder "unknown"
+    court code to null — parity with the MCP ``search_cases`` tool, so REST
+    consumers never mistake the ingestion-artefact "unknown" for a real
+    court (audit A4 / #10).
+    """
+
+    def _court_of(self, code):
+        from oldp.apps.cases.serializers import CaseSearchSerializer
+
+        result = SimpleNamespace(
+            text="t", title="T", slug="s", pk="1", court=code, citing_cases_count=0
+        )
+        return CaseSearchSerializer().to_representation(result)["court"]
+
+    def test_unknown_becomes_null(self):
+        self.assertIsNone(self._court_of("unknown"))
+        self.assertIsNone(self._court_of("Unknown"))
+
+    def test_real_court_passes_through(self):
+        self.assertEqual(self._court_of("BGH"), "BGH")
+        self.assertEqual(self._court_of("VERFGBE"), "VERFGBE")
+
+
 class SearchApiMockedTestCase(TestCase):
     """Tests for search API with fully mocked SearchQuerySet."""
 

--- a/oldp/apps/search/tests/test_search_backend.py
+++ b/oldp/apps/search/tests/test_search_backend.py
@@ -125,6 +125,83 @@ class IsLatestFilterTest(SimpleTestCase):
         self.assertGreaterEqual(len(filters), 2)
 
 
+class NavigationalQueryBoostTest(SimpleTestCase):
+    """Short ("navigational", <4-word) queries must keep the
+    ``exact_matches`` clause as a pure relevance BOOST, not as an
+    alternative matcher.
+
+    Regression for the web-only phrase leak: when the ``query_string``
+    and ``exact_matches`` clauses both sat in ``bool.should``, ES OR'd
+    them, so the non-phrase ``match`` on ``exact_matches`` returned
+    documents that did not satisfy the phrase / AND default. E.g.
+    ``/search/?q="Glauben und Treu"`` returned ~10k docs while the API
+    returned 0. The fix puts ``query_string`` in ``must`` (required) and
+    keeps ``exact_matches`` in ``should`` (boost only).
+    """
+
+    def setUp(self):
+        index = MagicMock()
+        index.document_field = "text"
+        connection = MagicMock()
+        connection.get_unified_index.return_value = index
+        patcher = patch(
+            "oldp.apps.search.search_backend.haystack.connections",
+            {"default": connection},
+        )
+        patcher.start()
+        self.addCleanup(patcher.stop)
+
+    @staticmethod
+    def _main_query(kwargs):
+        """Unwrap the always-present ``is_latest`` filter to get the
+        scoring query that build_search_kwargs constructed.
+        """
+        q = kwargs["query"]
+        if "bool" in q and "filter" in q["bool"]:
+            return q["bool"]["must"]
+        return q
+
+    def test_navigational_query_requires_query_string_boosts_exact(self):
+        # 2 words → navigational path.
+        backend = _make_backend()
+        kwargs = backend.build_search_kwargs('"foo bar"', highlight=False)
+        main = self._main_query(kwargs)
+
+        self.assertIn("bool", main)
+        must = main["bool"].get("must", [])
+        should = main["bool"].get("should", [])
+
+        # The query_string (phrase/AND enforcer) is REQUIRED.
+        self.assertTrue(
+            any(isinstance(c, dict) and "query_string" in c for c in must),
+            f"query_string must be in bool.must; got {main!r}",
+        )
+        # exact_matches only BOOSTS — it lives in should, never in must.
+        self.assertTrue(
+            any(
+                isinstance(c, dict)
+                and c.get("match", {}).get("exact_matches", {}).get("boost")
+                == backend.exact_boost_factor
+                for c in should
+            ),
+            f"exact_matches boost must be in bool.should; got {main!r}",
+        )
+        self.assertFalse(
+            any("exact_matches" in str(c) for c in must),
+            "exact_matches must not be a required (must) clause — it would "
+            "widen the result set and break phrase/AND queries",
+        )
+
+    def test_non_navigational_query_is_plain_query_string(self):
+        # 4 words → non-navigational path: plain query_string, no
+        # exact_matches clause at all (unchanged behaviour).
+        backend = _make_backend()
+        kwargs = backend.build_search_kwargs("foo bar baz qux", highlight=False)
+        main = self._main_query(kwargs)
+        self.assertIn("query_string", main)
+        self.assertNotIn("exact_matches", str(main))
+
+
 class GermanAnalyzerSchemaTest(SimpleTestCase):
     """``build_schema`` must apply the ``german_legal`` analyzer to the
     free-text fields (text/title/exact_matches) and leave the citation /

--- a/oldp/apps/search/tests/test_search_backend.py
+++ b/oldp/apps/search/tests/test_search_backend.py
@@ -125,23 +125,24 @@ class IsLatestFilterTest(SimpleTestCase):
         self.assertGreaterEqual(len(filters), 2)
 
 
-class NavigationalQueryBoostTest(SimpleTestCase):
-    """Short ("navigational", <4-word) queries boost the exact
-    navigational target (e.g. ``BGB 123`` → § 123 BGB) via the
-    ``exact_matches`` field, which must stay a ``should`` ALTERNATIVE
-    (so it can surface a law whose ``text`` lacks the section number)
-    but use ``match_phrase`` (so it does NOT leak loose term matches).
+class ExactMatchBoostTest(SimpleTestCase):
+    """Every keyword query boosts the exact navigational target via a
+    ``match_phrase`` on ``exact_matches`` (e.g. ``BGB 123`` → § 123 BGB,
+    a case file number → that case), kept as a ``should`` ALTERNATIVE so
+    it can surface a doc whose ``text`` lacks its own handle.
 
-    Two regressions guarded here:
+    Regressions guarded here:
 
     * **No leak** — the clause must be ``match_phrase``, not a plain
       ``match``. A plain ``match`` ORs the analysed terms, so a phrase
       query like ``"Glauben und Treu"`` matched every law title
       containing "und" (~10k docs on the web form) instead of 0.
-    * **Navigational lookup preserved** — ``exact_matches`` must remain
-      a ``should`` alternative, NOT be gated behind a required
-      ``query_string`` ``must``; otherwise ``"bgb 123"`` drops § 123 BGB
-      (its ``text`` field never contains "123").
+    * **Surfacing preserved** — ``exact_matches`` must stay a ``should``
+      alternative, NOT be gated behind a required ``query_string``
+      ``must``; otherwise ``"bgb 123"`` drops § 123 BGB (its ``text``
+      never contains "123") and a file-number lookup drops its case.
+    * **No word-count gate** — the boost must fire for long queries too,
+      so 4+token Aktenzeichen (``"AN 13b D 24.1173"``) still resolve.
     """
 
     def setUp(self):
@@ -166,16 +167,15 @@ class NavigationalQueryBoostTest(SimpleTestCase):
             return q["bool"]["must"]
         return q
 
-    def test_navigational_query_boosts_exact_via_match_phrase(self):
-        # 2 words → navigational path.
+    def _assert_boosts_exact(self, query):
         backend = _make_backend()
-        kwargs = backend.build_search_kwargs('"foo bar"', highlight=False)
+        kwargs = backend.build_search_kwargs(query, highlight=False)
         main = self._main_query(kwargs)
 
         self.assertIn("bool", main)
         should = main["bool"].get("should", [])
-        # No ``must`` gate — exact_matches stays an alternative so a law
-        # whose text lacks the section number can still surface.
+        # No ``must`` gate — exact_matches stays an alternative so a doc
+        # whose text lacks its own handle can still surface.
         self.assertNotIn("must", main["bool"])
 
         # The general text matcher is present as a should alternative.
@@ -204,14 +204,15 @@ class NavigationalQueryBoostTest(SimpleTestCase):
             "exact_matches must NOT use a plain match (ORs terms → leaks)",
         )
 
-    def test_non_navigational_query_is_plain_query_string(self):
-        # 4 words → non-navigational path: plain query_string, no
-        # exact_matches clause at all (unchanged behaviour).
-        backend = _make_backend()
-        kwargs = backend.build_search_kwargs("foo bar baz qux", highlight=False)
-        main = self._main_query(kwargs)
-        self.assertIn("query_string", main)
-        self.assertNotIn("exact_matches", str(main))
+    def test_short_query_boosts_exact_via_match_phrase(self):
+        # 2 words (e.g. "bgb 123").
+        self._assert_boosts_exact('"foo bar"')
+
+    def test_long_query_also_boosts_exact(self):
+        # 4+ words: a long Aktenzeichen like "AN 13b D 24.1173" must STILL
+        # get the exact-match boost (no word-count gate), else long file
+        # numbers would never resolve.
+        self._assert_boosts_exact("foo bar baz qux")
 
 
 class GermanAnalyzerSchemaTest(SimpleTestCase):

--- a/oldp/apps/search/tests/test_search_backend.py
+++ b/oldp/apps/search/tests/test_search_backend.py
@@ -214,6 +214,31 @@ class ExactMatchBoostTest(SimpleTestCase):
         # numbers would never resolve.
         self._assert_boosts_exact("foo bar baz qux")
 
+    def test_exact_match_query_is_deescaped(self):
+        # The match_phrase boost must receive RAW phrase text — AutoQuery's
+        # backslash-escaping of reserved chars (e.g. the colons in an ECLI)
+        # would otherwise stop it matching the stored handle. Regression for
+        # ECLI free-text search.
+        backend = _make_backend()
+        escaped = '("ECLI\\:DE\\:BGH\\:2021\\:rk20211219")'
+        kwargs = backend.build_search_kwargs(escaped, highlight=False)
+        should = self._main_query(kwargs)["bool"]["should"]
+        phrase_q = next(
+            c["match_phrase"]["exact_matches"]["query"]
+            for c in should
+            if isinstance(c, dict) and "match_phrase" in c
+        )
+        self.assertNotIn("\\", phrase_q)
+        self.assertNotIn('"', phrase_q)
+        self.assertEqual(phrase_q, "ECLI:DE:BGH:2021:rk20211219")
+        # The general query_string clause keeps the original (escaped) form.
+        qs = next(
+            c["query_string"]["query"]
+            for c in should
+            if isinstance(c, dict) and "query_string" in c
+        )
+        self.assertEqual(qs, escaped)
+
 
 class GermanAnalyzerSchemaTest(SimpleTestCase):
     """``build_schema`` must apply the ``german_legal`` analyzer to the

--- a/oldp/apps/search/tests/test_search_backend.py
+++ b/oldp/apps/search/tests/test_search_backend.py
@@ -126,17 +126,22 @@ class IsLatestFilterTest(SimpleTestCase):
 
 
 class NavigationalQueryBoostTest(SimpleTestCase):
-    """Short ("navigational", <4-word) queries must keep the
-    ``exact_matches`` clause as a pure relevance BOOST, not as an
-    alternative matcher.
+    """Short ("navigational", <4-word) queries boost the exact
+    navigational target (e.g. ``BGB 123`` → § 123 BGB) via the
+    ``exact_matches`` field, which must stay a ``should`` ALTERNATIVE
+    (so it can surface a law whose ``text`` lacks the section number)
+    but use ``match_phrase`` (so it does NOT leak loose term matches).
 
-    Regression for the web-only phrase leak: when the ``query_string``
-    and ``exact_matches`` clauses both sat in ``bool.should``, ES OR'd
-    them, so the non-phrase ``match`` on ``exact_matches`` returned
-    documents that did not satisfy the phrase / AND default. E.g.
-    ``/search/?q="Glauben und Treu"`` returned ~10k docs while the API
-    returned 0. The fix puts ``query_string`` in ``must`` (required) and
-    keeps ``exact_matches`` in ``should`` (boost only).
+    Two regressions guarded here:
+
+    * **No leak** — the clause must be ``match_phrase``, not a plain
+      ``match``. A plain ``match`` ORs the analysed terms, so a phrase
+      query like ``"Glauben und Treu"`` matched every law title
+      containing "und" (~10k docs on the web form) instead of 0.
+    * **Navigational lookup preserved** — ``exact_matches`` must remain
+      a ``should`` alternative, NOT be gated behind a required
+      ``query_string`` ``must``; otherwise ``"bgb 123"`` drops § 123 BGB
+      (its ``text`` field never contains "123").
     """
 
     def setUp(self):
@@ -161,35 +166,42 @@ class NavigationalQueryBoostTest(SimpleTestCase):
             return q["bool"]["must"]
         return q
 
-    def test_navigational_query_requires_query_string_boosts_exact(self):
+    def test_navigational_query_boosts_exact_via_match_phrase(self):
         # 2 words → navigational path.
         backend = _make_backend()
         kwargs = backend.build_search_kwargs('"foo bar"', highlight=False)
         main = self._main_query(kwargs)
 
         self.assertIn("bool", main)
-        must = main["bool"].get("must", [])
         should = main["bool"].get("should", [])
+        # No ``must`` gate — exact_matches stays an alternative so a law
+        # whose text lacks the section number can still surface.
+        self.assertNotIn("must", main["bool"])
 
-        # The query_string (phrase/AND enforcer) is REQUIRED.
+        # The general text matcher is present as a should alternative.
         self.assertTrue(
-            any(isinstance(c, dict) and "query_string" in c for c in must),
-            f"query_string must be in bool.must; got {main!r}",
+            any(isinstance(c, dict) and "query_string" in c for c in should),
+            f"query_string must be a should alternative; got {main!r}",
         )
-        # exact_matches only BOOSTS — it lives in should, never in must.
+        # exact_matches uses match_phrase (NOT a loose match) + the boost.
+        phrase_clauses = [
+            c for c in should if isinstance(c, dict) and "match_phrase" in c
+        ]
         self.assertTrue(
             any(
-                isinstance(c, dict)
-                and c.get("match", {}).get("exact_matches", {}).get("boost")
+                c["match_phrase"].get("exact_matches", {}).get("boost")
                 == backend.exact_boost_factor
+                for c in phrase_clauses
+            ),
+            f"exact_matches must use match_phrase with boost; got {main!r}",
+        )
+        # A plain ``match`` on exact_matches would re-introduce the OR leak.
+        self.assertFalse(
+            any(
+                isinstance(c, dict) and "match" in c and "exact_matches" in c["match"]
                 for c in should
             ),
-            f"exact_matches boost must be in bool.should; got {main!r}",
-        )
-        self.assertFalse(
-            any("exact_matches" in str(c) for c in must),
-            "exact_matches must not be a required (must) clause — it would "
-            "widen the result set and break phrase/AND queries",
+            "exact_matches must NOT use a plain match (ORs terms → leaks)",
         )
 
     def test_non_navigational_query_is_plain_query_string(self):

--- a/oldp/apps/search/tests/test_search_filter.py
+++ b/oldp/apps/search/tests/test_search_filter.py
@@ -134,20 +134,29 @@ class SearchSchemaFilterFacetTest(TestCase):
     def _make_chainable_queryset(self):
         qs = MagicMock()
         qs.filter.return_value = qs
+        qs.narrow.return_value = qs
         return qs
 
     def test_always_filters_by_facet_model_name(self):
-        """The filter should always apply facet_model_name_exact."""
+        """The model clamp is applied as a filter-context narrow (not a
+        scoring .filter) so short navigational lookups stay eligible for the
+        exact-match boost. See ``narrow_to_model``.
+        """
         f = self._make_filter_and_index(facet_model_name="Law")
         qs = self._make_chainable_queryset()
         request = self._make_request(text="test")
 
         f.filter_queryset(request, qs, None)
 
-        qs.filter.assert_called_once_with(facet_model_name_exact="Law")
+        qs.narrow.assert_called_once_with('facet_model_name_exact:"Law"')
+        qs.filter.assert_not_called()
 
     def test_applies_user_facet_filter(self):
-        """User-provided facet parameters should be applied as filters."""
+        """User-provided facet parameters should be applied as filters.
+
+        The model clamp goes through ``.narrow`` (filter context); the
+        user-supplied facet stays a scoring ``.filter``.
+        """
         f = self._make_filter_and_index(
             facet_model_name="Law", faceted_fields=["book_code"]
         )
@@ -156,10 +165,8 @@ class SearchSchemaFilterFacetTest(TestCase):
 
         f.filter_queryset(request, qs, None)
 
-        calls = qs.filter.call_args_list
-        self.assertEqual(len(calls), 2)
-        self.assertEqual(calls[0].kwargs, {"facet_model_name_exact": "Law"})
-        self.assertEqual(calls[1].kwargs, {"book_code_exact": "BGB"})
+        qs.narrow.assert_called_once_with('facet_model_name_exact:"Law"')
+        qs.filter.assert_called_once_with(book_code_exact="BGB")
 
     def test_ignores_empty_facet_parameter(self):
         """Empty facet parameter values should be ignored."""
@@ -171,7 +178,8 @@ class SearchSchemaFilterFacetTest(TestCase):
 
         f.filter_queryset(request, qs, None)
 
-        qs.filter.assert_called_once_with(facet_model_name_exact="Law")
+        qs.narrow.assert_called_once_with('facet_model_name_exact:"Law"')
+        qs.filter.assert_not_called()
 
     def test_ignores_whitespace_only_facet_parameter(self):
         """Whitespace-only facet parameter values should be ignored."""
@@ -183,7 +191,8 @@ class SearchSchemaFilterFacetTest(TestCase):
 
         f.filter_queryset(request, qs, None)
 
-        qs.filter.assert_called_once_with(facet_model_name_exact="Law")
+        qs.narrow.assert_called_once_with('facet_model_name_exact:"Law"')
+        qs.filter.assert_not_called()
 
     def test_ignores_non_faceted_parameters(self):
         """Query parameters that don't match faceted fields should be ignored."""
@@ -193,10 +202,13 @@ class SearchSchemaFilterFacetTest(TestCase):
 
         f.filter_queryset(request, qs, None)
 
-        qs.filter.assert_called_once_with(facet_model_name_exact="Law")
+        qs.narrow.assert_called_once_with('facet_model_name_exact:"Law"')
+        qs.filter.assert_not_called()
 
     def test_multiple_facet_filters_applied(self):
-        """Multiple facet parameters should all be applied."""
+        """Multiple facet parameters should all be applied (model clamp via
+        narrow, user facets via filter).
+        """
         f = self._make_filter_and_index(
             facet_model_name="Case",
             faceted_fields=["court", "decision_type"],
@@ -206,10 +218,8 @@ class SearchSchemaFilterFacetTest(TestCase):
 
         f.filter_queryset(request, qs, None)
 
-        calls = qs.filter.call_args_list
-        self.assertEqual(len(calls), 3)
-        filter_kwargs = [c.kwargs for c in calls]
-        self.assertIn({"facet_model_name_exact": "Case"}, filter_kwargs)
+        qs.narrow.assert_called_once_with('facet_model_name_exact:"Case"')
+        filter_kwargs = [c.kwargs for c in qs.filter.call_args_list]
         self.assertIn({"court_exact": "BGH"}, filter_kwargs)
         self.assertIn({"decision_type_exact": "Urteil"}, filter_kwargs)
 
@@ -233,11 +243,13 @@ class SearchQueryBuilderTest(TestCase):
         with patch("oldp.apps.search.api.SearchQuerySet") as mock_cls:
             mock_sqs = MagicMock()
             mock_cls.return_value = mock_sqs
-            mock_sqs.filter.return_value = mock_sqs
+            mock_sqs.narrow.return_value = mock_sqs
 
             builder = SearchQueryBuilder()
             builder.filter_review_status("accepted")
-            mock_sqs.filter.assert_called_once_with(review_status="accepted")
+            # Applied as a filter-context narrow (not a scoring .filter) so it
+            # stays out of the main query string — see filter_review_status.
+            mock_sqs.narrow.assert_called_once_with('review_status:"accepted"')
 
     @override_settings(SEARCH_MAX_SNIPPETS=5, SEARCH_SNIPPET_SIZE=150)
     def test_apply_highlight(self):
@@ -287,6 +299,7 @@ class SearchQueryBuilderTest(TestCase):
             mock_cls.return_value = mock_sqs
             mock_sqs.models.return_value = mock_sqs
             mock_sqs.filter.return_value = mock_sqs
+            mock_sqs.narrow.return_value = mock_sqs
             mock_sqs.highlight.return_value = mock_sqs
 
             from oldp.apps.cases.models import Case

--- a/oldp/apps/search/tests/test_search_review_status.py
+++ b/oldp/apps/search/tests/test_search_review_status.py
@@ -21,12 +21,14 @@ class SearchViewMixinReviewStatusTestCase(TestCase):
             mock_sqs_cls.return_value = mock_sqs
             mock_sqs.models.return_value = mock_sqs
             mock_sqs.filter.return_value = mock_sqs
+            mock_sqs.narrow.return_value = mock_sqs
             mock_sqs.highlight.return_value = mock_sqs
 
             result = mixin.get_queryset()
 
             mock_sqs.models.assert_called_once_with(Case)
-            mock_sqs.filter.assert_called_once_with(review_status="accepted")
+            # review_status applied as a filter-context narrow (not .filter).
+            mock_sqs.narrow.assert_called_once_with('review_status:"accepted"')
             self.assertEqual(result, mock_sqs)
 
     def test_get_queryset_without_models_still_filters(self):
@@ -38,10 +40,11 @@ class SearchViewMixinReviewStatusTestCase(TestCase):
             mock_sqs = MagicMock()
             mock_sqs_cls.return_value = mock_sqs
             mock_sqs.filter.return_value = mock_sqs
+            mock_sqs.narrow.return_value = mock_sqs
             mock_sqs.highlight.return_value = mock_sqs
 
             result = mixin.get_queryset()
 
             mock_sqs.models.assert_not_called()
-            mock_sqs.filter.assert_called_once_with(review_status="accepted")
+            mock_sqs.narrow.assert_called_once_with('review_status:"accepted"')
             self.assertEqual(result, mock_sqs)

--- a/oldp/apps/search/utils.py
+++ b/oldp/apps/search/utils.py
@@ -160,6 +160,36 @@ def prepare_search_query(text):
     return strip_query_stopwords(normalize_search_query(text))
 
 
+def narrow_to_model(sqs, facet_model_name):
+    """Isolate ``sqs`` to one Haystack model via a FILTER-context narrow.
+
+    The custom ``SearchBackend`` ignores ``SearchQuerySet.models()``, so
+    every keyword-search call site has to clamp the index itself. Do it with
+    ``.narrow`` — which the backend turns into a non-scoring ``bool.filter``
+    ``query_string`` clause — rather than ``.filter(facet_model_name_exact=…)``,
+    which Haystack serialises into the main *scoring* query string. Two
+    reasons:
+
+    * **Navigational boost.** Keeping the clamp out of the main query string
+      means a short lookup like ``"bgb 123"`` stays "navigational"
+      (:meth:`SearchBackend.is_navigational_query`), so it reaches the
+      exact-match ``match_phrase`` boost that ranks ``§ 123 BGB`` first. With
+      the clamp in the scoring string the query carries an ``AND`` /
+      ``field:value`` token and is treated as non-navigational, so the boost
+      never fires — the on-point law was missing from REST / MCP results
+      entirely while the web UI (which applies no such clamp) ranked it #1.
+    * **Leak-safety.** The navigational boost is a ``should`` *alternative*.
+      If the model clamp were also a ``should`` (scoring) clause, a Law doc
+      that matched only the boost could be returned from a Case-only search.
+      As a ``bool.filter`` the clamp is mandatory and the boost cannot bypass
+      it.
+
+    Mirrors the ``.narrow`` the web faceted search already uses for facet
+    selections.
+    """
+    return sqs.narrow('facet_model_name_exact:"%s"' % facet_model_name)
+
+
 def parse_citation_params(params):
     """Parse citation query params into ``(kind, token)`` or ``None``.
 

--- a/oldp/apps/search/utils.py
+++ b/oldp/apps/search/utils.py
@@ -170,15 +170,16 @@ def narrow_to_model(sqs, facet_model_name):
     which Haystack serialises into the main *scoring* query string. Two
     reasons:
 
-    * **Navigational boost.** Keeping the clamp out of the main query string
-      means a short lookup like ``"bgb 123"`` stays "navigational"
-      (:meth:`SearchBackend.is_navigational_query`), so it reaches the
-      exact-match ``match_phrase`` boost that ranks ``§ 123 BGB`` first. With
-      the clamp in the scoring string the query carries an ``AND`` /
-      ``field:value`` token and is treated as non-navigational, so the boost
-      never fires — the on-point law was missing from REST / MCP results
-      entirely while the web UI (which applies no such clamp) ranked it #1.
-    * **Leak-safety.** The navigational boost is a ``should`` *alternative*.
+    * **Exact-match boost.** The backend ranks an exact navigational target
+      (``"bgb 123"`` → § 123 BGB; a file number → its case) via a
+      ``match_phrase`` on ``exact_matches``, keyed off the *bare* user query.
+      Keeping the model/status clamp out of the main query string keeps that
+      query bare; with the clamp serialised in (``… AND
+      facet_model_name_exact:Law``) the ``match_phrase`` query is polluted
+      with the filter expression and never matches, so the on-point doc was
+      missing from REST / MCP results while the web UI (which applies no such
+      clamp) ranked it #1.
+    * **Leak-safety.** The exact-match boost is a ``should`` *alternative*.
       If the model clamp were also a ``should`` (scoring) clause, a Law doc
       that matched only the boost could be returned from a Case-only search.
       As a ``bool.filter`` the clamp is mandatory and the boost cannot bypass


### PR DESCRIPTION
## Problem

Exact-phrase search is broken **in the web UI only**. Reproduced on prod:

| Query | Web UI | REST | MCP |
|---|---|---|---|
| `"Mietvertrag Schadensersatz"` (phrase) | **74** ❌ | 3 ✓ | — |
| `"Schadensersatz Mietvertrag"` (reversed) | **71** ❌ | 0 ✓ | 0 ✓ |
| `"Glauben und Treu"` (nonsense order) | **10000** ❌ | 0 ✓ | — |
| `"Glauben und Treu" Mietvertrag` (≥4 tokens) | 0 ✓ | 0 ✓ | — |

## Root cause

`SearchBackend.build_search_kwargs` → the "navigational" branch
(`is_navigational_query`: <4 words, no boolean operator) built a
`bool.should` (OR) of two clauses:

```python
"should": [
    {"query_string": {... "query": query_string ...}},          # honours the phrase
    {"match": {"exact_matches": {"query": query_string, ...}}},  # NON-phrase, OR over terms
]
```

Both in `should` makes them **alternatives**. The second clause is a plain
`match` (quotes stripped, default-OR terms), so it returns documents that do
**not** satisfy the `query_string` — the phrase / AND constraint is drowned.

**Why web-only:** REST (`SearchFilter`) and MCP serialize
`.filter(review_status="accepted")` *into the main query string*
(`(phrase) AND review_status:accepted`), which makes it non-navigational and
routes it onto the safe plain-`query_string` path. The web search form adds no
such in-query filter (the ES index already holds only accepted docs), so short
queries hit the leaky branch. Confirmed: adding `&start_date=…` to the same web
query flips `"Mietvertrag Schadensersatz"` from **74 → 3**.

## Fix

Make the exact-match a **boost**, not an **alternative**: `query_string` in
`bool.must` (required), `exact_matches` in `bool.should` (score-only — ES
ignores `should` for matching when a `must` is present). Phrase/AND now
enforced on every surface; the exact-match ranking boost is preserved.

**Query-time only — no reindex, no migration.**

## Tests

`NavigationalQueryBoostTest`:
- navigational query → `query_string` is required (`must`), `exact_matches`
  boost is in `should` and never in `must`;
- non-navigational query → plain `query_string`, no `exact_matches` clause.

Full `oldp.apps.search` suite green (151 passed, 15 ES-gated skips); `ruff`
clean.

## Deploy note

Touches the incident-prone `build_search_kwargs`, but the change is localized
and ranking-preserving for matched docs. Being hot-fixed to de-prod via a
locally-built image ahead of merge; fold into the next proper release.


---

### Update (revised approach — `match_phrase`, not `must`-gate)

The original commit moved `query_string` into `bool.must`. That fixed the leak
but **regressed navigational lookup**: a law section's `text` field never
contains its own section number (e.g. `§ 123 BGB`'s text has `BGB` via
`amtabk` but not `123`), so a required text match dropped the law entirely —
`/search/?q=bgb 123` returned only cases.

Also corrected: the OR leak came from **law** `exact_matches` (it includes the
section *title*, so a plain `match` ORed common title words like "und"); the
**case** `exact_matches` field is empty.

**Final fix (`a0441c0a`):** keep `exact_matches` as a `should` *alternative*
(so the law surfaces without a text match) but change the plain `match` →
**`match_phrase`** — it only matches the full query as a consecutive phrase
against the stored navigational forms (`bgb 123`, `123 bgb`, `bgb123`, title),
boosting the real target without the loose-term leak.

Verified on prod (hotfix image): phrase leak gone (web == REST) **and** the law
ranks #1 for `bgb 123` / `123 bgb` / `stgb 242` / `823 bgb` / `art 82 dsgvo`.


---

### Update 2 (navigational lookup on REST/MCP — `narrow` the model/status clamps)

The exact-match boost (`bgb 123` → `§ 123 BGB` ranked #1) only fired on the
**web** surface. REST and MCP apply `review_status` and the
`facet_model_name` model clamp via `.filter(...)`, which Haystack serialises
**into the main scoring query string**. That makes the query non-navigational
(`is_navigational_query` sees the `AND` / `field:value` token), so the boost
branch is skipped — and a law section's `text` lacks its own section number,
so the on-point law was missing from REST/MCP entirely (only incidental text
matches surfaced).

Fix: move both always-applied clamps to `.narrow(...)` (ES `bool.filter`
context) via a new `narrow_to_model` helper + reworked
`SearchQueryBuilder.filter_review_status`:

- main query string becomes the bare user query → the boost fires on **every**
  surface (law #1 on REST/MCP, matching web);
- the clamp is now a mandatory non-scoring filter, so the boost's `should`
  alternative **cannot** bypass model isolation (a Law can't leak into a
  Case-only search);
- user-supplied facets (`book_code`, `court`, date) stay scoring `.filter`.

**Perf:** `bool.filter` clauses are non-scoring and cacheable (ES filter
cache); `facet_model_name_exact` / `review_status` are existing ES keyword
fields — no DB/ORM, no new index. Measured prod REST latency equal-or-better
(`bgb 123` 0.10s→0.08s, `Mietvertrag` 0.13s→0.12s).

**Verified on prod:** law #1 on REST `/api/laws/search/` and MCP
`search_laws` / `search_legal` for `bgb 123` / `123 bgb` / `823 bgb` /
`stgb 242` / `art 82 dsgvo`; model isolation intact (cases-search → 0 laws,
laws-search → 0 cases); phrase-leak fix (update 1) still holds.

Test doubles + assertions across search/mcp/cases/laws updated to the
`.narrow` contract; full search + MCP suites green (292 tests), lint clean.


---

### Update 3 (case file-number / Aktenzeichen search)

**Problem:** searching a case file number did not find the case (target absent
from the top 20; short AZs like `I ZR 78/25` matched ~10k unrelated cases on
loose terms). This breaks the `/search/?q=<file_number>&from=ref` link that an
**unresolved** case citation renders (`Reference.get_absolute_url`), and any
user pasting an Aktenzeichen. Root cause: the file number is in **no searched
field** — the document `text` is the body (`get_text`), which does not
reliably contain the case's own AZ; `title` holds it but is not the
`query_string` default field; and `CaseIndex.exact_matches` was empty.

**Fix:**
- `CaseIndex.prepare_exact_matches`: `file_number` (+ whitespace-free variant)
  + ECLI, mirroring `LawIndex`. The exact-match `match_phrase` boost then ranks
  the cited case #1.
- Drop the `<4-word is_navigational_query` gate so the boost fires for long
  Aktenzeichen too (`AN 13b D 24.1173`). It's a no-op for ordinary prose
  queries (file numbers/ECLI aren't content words). Both branches were
  otherwise identical, so this also simplifies `build_search_kwargs`.

**Deploy note:** requires a one-time in-place `update_index cases` to populate
`exact_matches` — the field already exists in the ES mapping, so no
analyzer/mapping change and no downtime (not a `rebuild_index`).

**Perf:** one extra `should`-clause `match_phrase` on a small keyword-ish
field; no DB/ORM, no new index, filter structure unchanged.

Tests: `CaseIndex.prepare_exact_matches` unit tests; backend boost asserted for
both short and long queries; `is_navigational_query` removed (was its only
caller).


---

### Update 4 (verification pass — two more fixes)

Verified the whole search-improvement loop + use-cases against prod. All
green. Two items had no existing PR and are fixed here:

- **REST court "unknown" → null** (`ba75902c`). `/api/cases/search/` returned
  the literal placeholder court code `"unknown"` where MCP `search_cases`
  already normalizes to `null` (audit A4 / #10 was MCP-scoped).
  `CaseSearchSerializer.get_court` reuses the shared `_norm_court`. Tests +
  prod-verified.
- **ECLI free-text search** (`9ebc5c5a`). A full ECLI returned 0 even though
  it's stored in `CaseIndex.exact_matches`. `AutoQuery` backslash-escapes the
  colons for `query_string`, and that escaped form was fed into the
  `exact_matches` `match_phrase` boost, breaking the match. `_phrase_text`
  strips the AutoQuery wrapping + escapes for the boost clause only (no-op for
  prose; `query_string` keeps the escaped form). Test on `build_search_kwargs`
  + prod-verified (never-queried ECLI ranks its case #1).

Items intentionally left out of this PR (not crammable):
- **#5 multi_match title-boost** — tracked in issue #185 (incident-prone
  ranking change).
- **law-name ↔ abbreviation expansion** (e.g. `Kündigungsschutzgesetz`⇄`KSchG`,
  confirmed gap: 2907 vs 9043) — needs a principled name↔code map; deserves
  its own PR.
- **field-scoped search (tenor/leitsatz/gründe)** — blocked on upstream
  section extraction (oldp-ingestor/refex).
