### PR TITLE
fix(api): enforce staff/token authz on content write endpoints (closes internal-tools #14, #15)

### DIFF
--- a/oldp/api/tests/test_write_authz.py
+++ b/oldp/api/tests/test_write_authz.py
@@ -1,0 +1,116 @@
+"""End-to-end authorization tests for content write endpoints.
+
+Regression tests for the API write-authz hardening (internal-tools #14 & #15):
+
+* #14 — a website **session**-authenticated user (no API token) must not be able
+  to perform token-gated writes; ``HasTokenPermission`` previously allowed any
+  non-token authenticated request.
+* #15 — mutating a law / law book / court (including flipping ``review_status``
+  to publish) is a moderation action and must be **staff-only**, mirroring the
+  guard already present on ``CaseViewSet``.
+"""
+
+from datetime import date
+
+from django.contrib.auth import get_user_model
+from django.test import override_settings
+from rest_framework import status
+from rest_framework.test import APIClient, APITestCase
+
+from oldp.apps.accounts.models import (
+    APIToken,
+    APITokenPermission,
+    APITokenPermissionGroup,
+)
+from oldp.apps.laws.models import Law, LawBook
+
+User = get_user_model()
+
+
+@override_settings(
+    CACHES={"default": {"BACKEND": "django.core.cache.backends.dummy.DummyCache"}}
+)
+class ContentWriteAuthzTestCase(APITestCase):
+    """Session users must not bypass token-gated / staff-only content writes."""
+
+    def setUp(self):
+        self.user = User.objects.create_user("writer", "w@example.com", "pass")
+        self.staff = User.objects.create_user(
+            "moderator", "mod@example.com", "pass", is_staff=True
+        )
+        self.book = LawBook.objects.create(
+            code="test",
+            title="Test Book",
+            slug="test-book",
+            revision_date=date(2020, 1, 1),
+            review_status="accepted",
+            latest=True,
+        )
+        self.law = Law.objects.create(
+            book=self.book,
+            title="§ 1 Test",
+            slug="test-1",
+            section="1",
+            content="<p>original</p>",
+            review_status="accepted",
+            order=0,
+        )
+
+    # --- #14: session auth (no token) must not perform token-gated writes ---
+
+    def test_session_user_cannot_patch_law(self):
+        client = APIClient()
+        client.force_authenticate(user=self.user)  # no token -> request.auth is None
+        res = client.patch(f"/api/laws/{self.law.id}/", {"review_status": "pending"})
+        self.assertEqual(res.status_code, status.HTTP_403_FORBIDDEN)
+        self.law.refresh_from_db()
+        self.assertEqual(self.law.review_status, "accepted")  # unchanged
+
+    def test_session_user_cannot_patch_law_book(self):
+        client = APIClient()
+        client.force_authenticate(user=self.user)
+        res = client.patch(
+            f"/api/law_books/{self.book.id}/", {"review_status": "pending"}
+        )
+        self.assertEqual(res.status_code, status.HTTP_403_FORBIDDEN)
+
+    def test_session_user_cannot_delete_law(self):
+        client = APIClient()
+        client.force_authenticate(user=self.user)
+        res = client.delete(f"/api/laws/{self.law.id}/")
+        self.assertEqual(res.status_code, status.HTTP_403_FORBIDDEN)
+        self.assertTrue(Law.objects.filter(id=self.law.id).exists())
+
+    def test_session_user_can_still_read_law(self):
+        client = APIClient()
+        client.force_authenticate(user=self.user)
+        res = client.get(f"/api/laws/{self.law.id}/")
+        self.assertEqual(res.status_code, status.HTTP_200_OK)
+
+    # --- #15: even a write-scoped token may not mutate/publish (staff-only) ---
+
+    def test_write_token_cannot_patch_law(self):
+        write_perm, _ = APITokenPermission.objects.get_or_create(
+            resource="laws", action="write"
+        )
+        group = APITokenPermissionGroup.objects.create(name="laws_write_test")
+        group.permissions.add(write_perm)
+        token = APIToken.objects.create(
+            user=self.user, name="write-token", permission_group=group
+        )
+        client = APIClient()
+        client.force_authenticate(user=self.user, token=token)
+        res = client.patch(f"/api/laws/{self.law.id}/", {"review_status": "pending"})
+        self.assertEqual(res.status_code, status.HTTP_403_FORBIDDEN)
+        self.law.refresh_from_db()
+        self.assertEqual(self.law.review_status, "accepted")  # not flipped
+
+    # --- #15: staff may moderate ---
+
+    def test_staff_user_can_patch_law_review_status(self):
+        client = APIClient()
+        client.force_authenticate(user=self.staff)
+        res = client.patch(f"/api/laws/{self.law.id}/", {"review_status": "pending"})
+        self.assertEqual(res.status_code, status.HTTP_200_OK)
+        self.law.refresh_from_db()
+        self.assertEqual(self.law.review_status, "pending")

--- a/oldp/api/views.py
+++ b/oldp/api/views.py
@@ -4,6 +4,7 @@ from django.views.decorators.cache import cache_page
 from django.views.decorators.vary import vary_on_headers
 from django_filters.rest_framework import DjangoFilterBackend
 from rest_framework import status, viewsets
+from rest_framework.exceptions import PermissionDenied
 from rest_framework.filters import SearchFilter
 from rest_framework.permissions import IsAuthenticated
 from rest_framework.response import Response
@@ -58,6 +59,18 @@ class CourtViewSet(ReviewStatusFilterMixin, viewsets.ModelViewSet):
         if getattr(self, "action", None) == "create":
             return CourtCreateSerializer
         return CourtSerializer
+
+    def update(self, request, *args, **kwargs):
+        """Update a court. Requires staff (moderation action). Mirrors CaseViewSet."""
+        if not request.user.is_staff:
+            raise PermissionDenied("Only staff users can update courts.")
+        return super().update(request, *args, **kwargs)
+
+    def partial_update(self, request, *args, **kwargs):
+        """Partially update a court. Requires staff (moderation action)."""
+        if not request.user.is_staff:
+            raise PermissionDenied("Only staff users can update courts.")
+        return super().partial_update(request, *args, **kwargs)
 
     def get_queryset(self):
         return super().get_queryset().select_related("created_by_token")

--- a/oldp/apps/accounts/permissions.py
+++ b/oldp/apps/accounts/permissions.py
@@ -42,17 +42,23 @@ class HasTokenPermission(permissions.BasePermission):
         if request.user.is_superuser:
             return True
 
-        # Check if request is authenticated with an API token
-        if not hasattr(request, "auth") or not request.auth:
-            # If authenticated but not via token, allow (handled by other permissions)
-            return True
+        # Determine the action based on the HTTP method
+        action = self._get_action(request.method)
 
-        # Get the token from the request
+        # Requests not authenticated with an API token -- i.e. website session
+        # auth or a legacy DRF Token -- cannot be evaluated against the
+        # fine-grained token permission groups. Allow safe/read methods, but
+        # require staff for writes so session auth cannot bypass the
+        # deny-by-default write gating the token model enforces. Previously this
+        # branch returned True unconditionally, which let any logged-in user
+        # perform token-gated writes via the browsable API / session (see
+        # internal-tools #14).
         from oldp.apps.accounts.models import APIToken
 
-        if not isinstance(request.auth, APIToken):
-            # Not using our custom token authentication
-            return True
+        if not isinstance(getattr(request, "auth", None), APIToken):
+            if action == "read":
+                return True
+            return bool(request.user.is_staff)
 
         token = request.auth
 
@@ -61,9 +67,6 @@ class HasTokenPermission(permissions.BasePermission):
         if not resource:
             # No resource specified, deny by default
             return False
-
-        # Determine the action based on the HTTP method
-        action = self._get_action(request.method)
 
         # Check if the token has the required permission
         return token.has_permission(resource, action)

--- a/oldp/apps/accounts/tests/test_permissions.py
+++ b/oldp/apps/accounts/tests/test_permissions.py
@@ -331,3 +331,44 @@ class HasTokenPermissionTestCase(TestCase):
         self.assertEqual(permission._get_action("PUT"), "write")
         self.assertEqual(permission._get_action("PATCH"), "write")
         self.assertEqual(permission._get_action("DELETE"), "delete")
+
+    # --- Session / non-token auth is deny-by-default for writes (internal-tools #14) ---
+
+    def test_session_auth_read_allowed(self):
+        """Session-authenticated (non-token) GET is allowed."""
+        request = self.factory.get("/api/cases/")
+        request.user = self.user
+        request.auth = None  # session auth carries no APIToken
+        view = type("View", (), {"token_resource": "cases"})()
+        self.assertTrue(self.permission.has_permission(request, view))
+
+    def test_session_auth_write_denied_for_non_staff(self):
+        """Session-authenticated non-staff writes are denied — previously allowed."""
+        for method in ("post", "put", "patch", "delete"):
+            request = getattr(self.factory, method)("/api/cases/")
+            request.user = self.user
+            request.auth = None
+            view = type("View", (), {"token_resource": "cases"})()
+            self.assertFalse(
+                self.permission.has_permission(request, view),
+                f"{method.upper()} via session auth should be denied for a non-staff user",
+            )
+
+    def test_session_auth_write_allowed_for_staff(self):
+        """Session-authenticated staff may write (moderation path)."""
+        staff = User.objects.create_user(
+            "staff_writer", "sw@example.com", "password", is_staff=True
+        )
+        request = self.factory.patch("/api/cases/1/")
+        request.user = staff
+        request.auth = None
+        view = type("View", (), {"token_resource": "cases"})()
+        self.assertTrue(self.permission.has_permission(request, view))
+
+    def test_non_apitoken_auth_write_denied_for_non_staff(self):
+        """A non-APIToken auth object (e.g. a legacy DRF Token) is treated as session auth."""
+        request = self.factory.post("/api/cases/")
+        request.user = self.user
+        request.auth = object()  # not an APIToken instance
+        view = type("View", (), {"token_resource": "cases"})()
+        self.assertFalse(self.permission.has_permission(request, view))

--- a/oldp/apps/laws/api_views.py
+++ b/oldp/apps/laws/api_views.py
@@ -9,6 +9,7 @@ from django_filters.rest_framework import DjangoFilterBackend
 from drf_yasg.utils import swagger_auto_schema
 from rest_framework import serializers, status, viewsets
 from rest_framework.decorators import action
+from rest_framework.exceptions import PermissionDenied
 from rest_framework.generics import GenericAPIView
 from rest_framework.mixins import ListModelMixin
 from rest_framework.permissions import AllowAny, IsAuthenticated
@@ -90,6 +91,18 @@ class LawViewSet(ReviewStatusFilterMixin, viewsets.ModelViewSet):
             # content. Mirrors the Case list/detail split.
             return LawListSerializer
         return LawSerializer
+
+    def update(self, request, *args, **kwargs):
+        """Update a law. Requires staff (moderation action). Mirrors CaseViewSet."""
+        if not request.user.is_staff:
+            raise PermissionDenied("Only staff users can update laws.")
+        return super().update(request, *args, **kwargs)
+
+    def partial_update(self, request, *args, **kwargs):
+        """Partially update a law. Requires staff (moderation action)."""
+        if not request.user.is_staff:
+            raise PermissionDenied("Only staff users can update laws.")
+        return super().partial_update(request, *args, **kwargs)
 
     @method_decorator(cache_page(settings.CACHE_TTL))
     @method_decorator(vary_on_headers("Authorization", "Accept-Language", "Host"))
@@ -312,6 +325,18 @@ class LawBookViewSet(ReviewStatusFilterMixin, viewsets.ModelViewSet):
         if getattr(self, "action", None) == "create":
             return LawBookCreateSerializer
         return LawBookSerializer
+
+    def update(self, request, *args, **kwargs):
+        """Update a law book. Requires staff (moderation action). Mirrors CaseViewSet."""
+        if not request.user.is_staff:
+            raise PermissionDenied("Only staff users can update law books.")
+        return super().update(request, *args, **kwargs)
+
+    def partial_update(self, request, *args, **kwargs):
+        """Partially update a law book. Requires staff (moderation action)."""
+        if not request.user.is_staff:
+            raise PermissionDenied("Only staff users can update law books.")
+        return super().partial_update(request, *args, **kwargs)
 
     @method_decorator(cache_page(settings.CACHE_TTL))
     @method_decorator(vary_on_headers("Authorization", "Accept-Language", "Host"))

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -75,6 +75,11 @@ dependencies = [
 # MCP (Model Context Protocol) server
 # https://github.com/gts360/django-mcp-server
 "django-mcp-server>=0.5.7",
+# Cap the MCP SDK below 2.0: mcp 2.0 moved ``FastMCP`` out of ``mcp.server``
+# (django-mcp-server does ``from mcp.server import FastMCP``), so an unpinned
+# (latest) install breaks at import in CI. Pin to the 1.x line that ships that
+# symbol. See internal-tools#20. Lift when django-mcp-server supports mcp 2.x.
+"mcp>=1.8.0,<2",
 
 # OAuth2 for MCP connector authentication
 # https://django-oauth-toolkit.readthedocs.io/

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -83,7 +83,10 @@ dependencies = [
 
 [project.optional-dependencies]
 dev = [
-  "ruff>=0.11.6",
+  # Pin below 0.15: ruff 0.15+ reformats Python code blocks inside Markdown,
+  # which flags 7 pre-existing docs and breaks `make lint-check` on an unpinned
+  # (latest) install. See internal-tools#20. Bump deliberately + reformat docs.
+  "ruff>=0.11.6,<0.15",
   "selenium==3.141.0",
   "coverage>=4.5.1",
   "coveralls>=1.5.0",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -85,7 +85,12 @@ dependencies = [
 
 # OAuth2 for MCP connector authentication
 # https://django-oauth-toolkit.readthedocs.io/
-"django-oauth-toolkit>=3.0.1",
+# Cap below 3.3: 3.3+ added its own RFC 7591 ``register/`` route inside
+# ``oauth2_provider.urls``, which shadows oldp's ``oauth/register/`` DCR view
+# (included first in oldp/apps/mcp/urls.py) and 404s the DCR tests. 3.2.x is
+# what dev runs. See internal-tools#20; when adopting 3.3+, drop oldp's own DCR
+# view and reorder/rename the route to use the library's endpoint.
+"django-oauth-toolkit>=3.0.1,<3.3",
 ]
 
 [project.optional-dependencies]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -75,11 +75,13 @@ dependencies = [
 # MCP (Model Context Protocol) server
 # https://github.com/gts360/django-mcp-server
 "django-mcp-server>=0.5.7",
-# Cap the MCP SDK below 2.0: mcp 2.0 moved ``FastMCP`` out of ``mcp.server``
-# (django-mcp-server does ``from mcp.server import FastMCP``), so an unpinned
-# (latest) install breaks at import in CI. Pin to the 1.x line that ships that
-# symbol. See internal-tools#20. Lift when django-mcp-server supports mcp 2.x.
-"mcp>=1.8.0,<2",
+# Cap the MCP SDK to the 1.27.x line. Two independent breakages otherwise:
+# mcp 2.0 moved ``FastMCP`` out of ``mcp.server`` (django-mcp-server does
+# ``from mcp.server import FastMCP``) -> import error; and mcp 1.28+ changed the
+# OAuth Dynamic Client Registration surface so the DCR endpoint 404s (see
+# oldp.apps.mcp.tests.test_oauth_views). 1.27.x is the version dev runs and
+# tests pass on. See internal-tools#20; revisit when adopting a newer MCP SDK.
+"mcp>=1.8.0,<1.28",
 
 # OAuth2 for MCP connector authentication
 # https://django-oauth-toolkit.readthedocs.io/


### PR DESCRIPTION
Fixes the two linked HIGH authorization findings from the security review: **internal-tools #14** (session-auth permission bypass) and **internal-tools #15** (non-staff can edit/delete/publish laws, books, courts).

## The problem

The REST API's write authorization was broken for **session-authenticated** users:

1. **#14 — root cause.** `HasTokenPermission.has_permission` returned `True` for any authenticated request whose `request.auth` was **not** an `APIToken` — i.e. every logged-in browser **session** user (DRF `SessionAuthentication` sets `request.auth = None`). The deny-by-default token permission model was fully bypassed; the effective write gate collapsed to `IsAuthenticated`.
2. **#15 — impact.** `LawViewSet`, `LawBookViewSet`, `CourtViewSet` had **no** staff guard on `update`/`partial_update` and reused the full model serializer with a writable `review_status` — unlike `CaseViewSet`. So a caller could edit or **publish** arbitrary published laws/books/courts (self-approve by `PATCH {"review_status":"accepted"}`), or delete them.

## The fix

**Layer 1 — `oldp/apps/accounts/permissions.py` (#14).** Non-token auth (session / legacy DRF Token) is now allowed for **read** methods only; **writes require `is_staff`**. Superusers keep the existing short-circuit; APIToken auth is unchanged and still evaluated against the fine-grained permission groups. This also closes the session-auth **create** and **delete** paths.

**Layer 2 — the three viewsets (#15).** Added the same staff-only `update`/`partial_update` guard `CaseViewSet` already has, so even a `*:write`-scoped token cannot mutate or publish existing content. DELETE via session is covered by Layer 1; DELETE via token still requires an admin-granted `*:delete` scope (unchanged, same as `CaseViewSet`).

## Resulting policy
| Caller | Read | Create | Update / publish | Delete |
|---|---|---|---|---|
| Anonymous | ✅ (accepted only) | ❌ | ❌ | ❌ |
| Session, non-staff | ✅ | ❌ | ❌ | ❌ |
| API token `*:write` | ✅ | ✅ (→ pending) | ❌ | ❌ |
| API token `*:delete` | ✅ | — | ❌ | ✅ |
| Staff / superuser | ✅ | ✅ | ✅ | ✅ |

## Tests
- **Unit** (`test_permissions.py`): session read allowed; session write denied for non-staff, allowed for staff; non-`APIToken` auth object treated as session.
- **End-to-end** (`oldp/api/tests/test_write_authz.py`): session user cannot `PATCH`/`DELETE` a law or book (and the value is unchanged), can still `GET`; a write-scoped token cannot `PATCH`; staff can moderate.
- Full suite green: **580 tests, 0 failures**; `ruff format --check .` + `ruff check` clean.

## Notes
- `CaseViewSet` was already protected and is unchanged (its `destroy` remains token-`delete`-gated; this PR keeps the three other viewsets consistent with that).
- Content creation via the public API is effectively staff/write-token-only, which matches the intended token model (self-service tokens are read-only by default).

Closes the two HIGH items; the remaining review findings are tracked in internal-tools #16 (stored XSS / sanitization), #17 (annotation IDOR), #18/#19 (transport hardening + Cloudflare verification).

https://claude.ai/code/session_01XYQMLr4tUe15hMrg1mtLd2