### PR TITLE
fix(docs): drop buffer_size kwarg for sphinx-polyversion 3.x

### DIFF
--- a/poly.py
+++ b/poly.py
@@ -76,7 +76,9 @@ DefaultDriver(
     vcs=Git(
         branch_regex=BRANCH_REGEX,
         tag_regex=TAG_REGEX,
-        buffer_size=1 * 10**9,
+        # sphinx-polyversion 3.0 dropped `buffer_size` (switched to `git worktree
+        # add --detach` for revision checkout). Keep this constructor call
+        # compatible with the version range in pyproject.toml (>=2.0.0).
         predicate=file_predicate([src]),
     ),
     builder=SphinxBuilder(src, args=SPHINX_ARGS),


### PR DESCRIPTION
## Summary
Docs workflow on `main` is red since sphinx-polyversion 3.0.0 shipped (2026-08-27 run):
```
File "/home/runner/work/oldp/oldp/poly.py", line 76, in <module>
    vcs=Git(
        ^^^^
TypeError: Git.__init__() got an unexpected keyword argument 'buffer_size'
```
`buffer_size` was removed in [sphinx-polyversion 3.0.0](https://github.com/real-yfprojects/sphinx-polyversion/releases/tag/3.0.0) — the checkout path switched to `git worktree add --detach`, so the previous diff-tree buffer no longer applies.

Since `.github/workflows/docs.yml` installs sphinx-polyversion unpinned and `pyproject.toml` allows `>=2.0.0`, both 2.x and 3.x can be picked up. In 2.x the kwarg is optional (defaults to 4 KiB), so **dropping it keeps this file compatible with the whole `>=2.0.0` range** without needing a version pin bump.

## Test plan
- [x] `python -c "import ast; ast.parse(open('poly.py').read())"` passes
- [ ] Docs workflow (`build` job) turns green on this PR
- [ ] Verify multi-version site still renders on `main` after merge