### PR TITLE
fix(cases): wrap serializers.deserialize in try/except for Django 5.2

### DIFF
--- a/oldp/apps/cases/models.py
+++ b/oldp/apps/cases/models.py
@@ -438,11 +438,14 @@ class Case(
     @staticmethod
     def from_json_file(file_path):
         with open(file_path) as f:
-            out = serializers.deserialize("json", f.read())  # , ignorenonexistent=True)
-            # print(len(out))
-
+            # Django 5.2 made the JSON deserializer eager: json.loads now runs
+            # in Deserializer.__init__ instead of on first iteration, so an
+            # invalid payload raises DeserializationError from the
+            # `serializers.deserialize(...)` call itself, not from the loop
+            # below. Wrap the whole construct+iterate so both behaviours funnel
+            # into the ProcessingError below.
             try:
-                for o in out:
+                for o in serializers.deserialize("json", f.read()):
                     return o.object
             except DeserializationError:
                 pass


### PR DESCRIPTION
## Summary
Unblocks dependabot PR #257 (django 5.1.15 → 5.2.16, security fixes for CVE-2026-53877 / -53878 / -48588).

Django 5.2 turned the JSON deserializer into a class whose `__init__` eagerly calls `json.loads(stream_or_string)` and raises `DeserializationError` at construction time. In 5.1 the parse was lazy — the error only surfaced when iterating the returned generator.

`Case.from_json_file` constructed the generator *outside* the try/except and only guarded the iteration, so under 5.2 an invalid payload propagates `DeserializationError` up the stack instead of being converted to the expected `ProcessingError`. That turns `test_raise_error_from_json_file` red, which is the sole failing test blocking #257.

The fix moves `serializers.deserialize(...)` inside the try. It works on both 5.1 (deferred parse — same code path as before) and 5.2 (eager parse — new code path).

Traceback from #257's CI run:
```
File "django/core/serializers/json.py", line 71, in __init__
    objects = json.loads(stream_or_string)
json.decoder.JSONDecodeError: Invalid \escape: line 12 column 7103 (char 12878)

The above exception was the direct cause of the following exception:

File "oldp/apps/cases/models.py", line 441, in from_json_file
    out = serializers.deserialize("json", f.read())
django.core.serializers.base.DeserializationError
```

## Test plan
- [x] django==5.1.15: manage.py test oldp.apps.cases.tests.test_models → green (14 tests, 3 skipped)
- [x] django==5.2.16: manage.py test oldp.apps.cases.tests.test_models → green (14 tests, 3 skipped) — previously failed
- [x] django==5.2.16: manage.py test oldp.apps.cases.tests.test_models.CasesModelsTestCase.test_raise_error_from_json_file → OK
- [ ] After merge: rebase #257 (@dependabot rebase) and verify all CI green