### PR TITLE
fix(settings): mark prod session/CSRF cookies Secure + SSL redirect

### DIFF
--- a/oldp/settings.py
+++ b/oldp/settings.py
@@ -988,6 +988,19 @@ class ProdConfiguration(BaseConfiguration):
 
     ADMINS = values.SingleNestedTupleValue()
 
+    # Transport security. Only send the session and CSRF cookies over HTTPS so
+    # they are never attached to a plaintext request and cannot be captured by a
+    # network MITM. ``SECURE_SSL_REDIRECT`` is defence-in-depth on top of the
+    # nginx :80 -> :443 redirect and the Cloudflare "Always Use HTTPS" edge
+    # setting; it detects TLS via the already-configured ``SECURE_PROXY_SSL_HEADER``
+    # (nginx sets X-Forwarded-Proto), so it does not loop and there is no
+    # plain-HTTP app health check to break. HSTS is intentionally NOT emitted
+    # here — it is disabled at the Cloudflare edge, and Secure cookies make it
+    # unnecessary for this threat.
+    SESSION_COOKIE_SECURE = True
+    CSRF_COOKIE_SECURE = True
+    SECURE_SSL_REDIRECT = True
+
     # Override logging to set INFO level for production
     @property
     def LOGGING(self):

--- a/oldp/utils/tests/test_prod_security.py
+++ b/oldp/utils/tests/test_prod_security.py
@@ -1,0 +1,28 @@
+"""Regression tests for production transport-security settings.
+
+Asserts the production configuration marks the session and CSRF cookies Secure
+and redirects to HTTPS, so authenticated cookies are never sent over plaintext.
+These are plain class attributes (not env-configurable ``values.Value``s) so they
+cannot be accidentally disabled per-deployment. HSTS is intentionally not set
+(disabled at the Cloudflare edge).
+"""
+
+from django.test import SimpleTestCase
+
+from oldp.settings import ProdConfiguration
+
+
+class ProdTransportSecurityTest(SimpleTestCase):
+    def test_session_cookie_secure(self):
+        self.assertIs(ProdConfiguration.SESSION_COOKIE_SECURE, True)
+
+    def test_csrf_cookie_secure(self):
+        self.assertIs(ProdConfiguration.CSRF_COOKIE_SECURE, True)
+
+    def test_ssl_redirect_enabled(self):
+        self.assertIs(ProdConfiguration.SECURE_SSL_REDIRECT, True)
+
+    def test_hsts_not_emitted_from_django(self):
+        # HSTS is disabled at the Cloudflare edge; Django must not emit it
+        # either. Default is 0 / unset.
+        self.assertIn(getattr(ProdConfiguration, "SECURE_HSTS_SECONDS", 0), (0, None))


### PR DESCRIPTION
## Problem
`ProdConfiguration` set none of `SESSION_COOKIE_SECURE`, `CSRF_COOKIE_SECURE`, or `SECURE_SSL_REDIRECT`, so authenticated **session and CSRF cookies were issued without the `Secure` flag** — a network MITM inducing any plaintext request could capture them (session hijack, up to admin).

## Fix
In `ProdConfiguration` (inherited by `ProdDEConfiguration`, which prod + stage run):
```python
SESSION_COOKIE_SECURE = True
CSRF_COOKIE_SECURE = True
SECURE_SSL_REDIRECT = True
```
Hardcoded `True` (not env-configurable) so they can't be disabled per-deployment.

- **`SECURE_SSL_REDIRECT`** is defence-in-depth on top of the existing nginx `:80 → :443` redirect and the Cloudflare "Always Use HTTPS" edge setting. It detects TLS via the already-configured `SECURE_PROXY_SSL_HEADER` (nginx sets `X-Forwarded-Proto`), so it does **not** loop, and there is no plain-HTTP app health check to break (verified in the prod compose — only ssh-proxy/db have health checks).
- **HSTS is intentionally omitted.** It's disabled at the Cloudflare edge; Secure cookies close this threat without it. Django emits no `Strict-Transport-Security`.

## Tests
New `oldp/utils/tests/test_prod_security.py` asserts the three flags are `True` and that Django emits no HSTS. `ruff format --check .` + `ruff check` clean.