### PR TITLE
fix(security): sanitize ingested case/law HTML before rendering

### DIFF
--- a/oldp/apps/cases/templates/cases/case.html
+++ b/oldp/apps/cases/templates/cases/case.html
@@ -2,6 +2,7 @@
 
 {% load static %}
 {% load i18n %}
+{% load html_filters %}
 
 {% block search_form %}
     {% with sidebar=1 sidebar_toggle_icon='fa-info-circle' %}
@@ -168,9 +169,7 @@
 
             <div class="read-more-container">
                 <div class="read-more-inner">
-                {% autoescape off %}
-                    {{ content }}
-                {% endautoescape %}
+                {{ content|sanitize_html }}
                 </div>
                 <div class="read-more">
                     <button class="btn btn-success">

--- a/oldp/apps/cases/tests/test_views.py
+++ b/oldp/apps/cases/tests/test_views.py
@@ -3,6 +3,7 @@ from django.test import Client, override_settings, tag
 from django.urls import reverse
 
 from oldp.apps.cases.models import Case
+from oldp.apps.lib.html_sanitizer import sanitize_html
 from oldp.apps.lib.tests import ExtendedLiveServerTestCase
 
 
@@ -88,7 +89,11 @@ class CasesViewsTestCase(ExtendedLiveServerTestCase):
 
         res = self.client.get(item.get_absolute_url())
 
-        self.assertContains(res, item.get_content_as_html(), count=1, status_code=200)
+        # Content is rendered through the HTML sanitizer, so compare against the
+        # sanitized form the template actually emits.
+        self.assertContains(
+            res, sanitize_html(item.get_content_as_html()), count=1, status_code=200
+        )
 
     def test_private_detail(self):
         private_item = Case.objects.get(pk=2)
@@ -118,8 +123,11 @@ class CasesViewsTestCase(ExtendedLiveServerTestCase):
         res = self.client.get(item.get_absolute_url())
         res_staff = self.staff_client.get(item.get_absolute_url())
 
-        anon_content = item.get_content_as_html(request=res.wsgi_request)
-        user_content = item.get_content_as_html(request=res_staff.wsgi_request)
+        # Rendered through the HTML sanitizer.
+        anon_content = sanitize_html(item.get_content_as_html(request=res.wsgi_request))
+        user_content = sanitize_html(
+            item.get_content_as_html(request=res_staff.wsgi_request)
+        )
 
         self.assertContains(res, anon_content, count=1, status_code=200)
         self.assertEqual(

--- a/oldp/apps/laws/templates/laws/law.html
+++ b/oldp/apps/laws/templates/laws/law.html
@@ -2,6 +2,7 @@
 
 {% load static %}
 {% load i18n %}
+{% load html_filters %}
 
 {% block search_form %}
     {% with sidebar=1 sidebar_toggle_icon='fa-info-circle' %}
@@ -103,9 +104,7 @@
 
     {% if not item.is_disabled %}
         <article class="text-justify">
-            {% autoescape off %}
-                {{ item.get_html_content }}
-            {% endautoescape %}
+            {{ item.get_html_content|sanitize_html }}
         </article>
 
         {% if item.get_footnotes %}

--- a/oldp/apps/lib/html_sanitizer.py
+++ b/oldp/apps/lib/html_sanitizer.py
@@ -1,0 +1,118 @@
+"""Allowlist HTML sanitizer for ingested case/law content.
+
+``Case.content`` / ``Law.content`` are HTML from external scrapers and the write
+API and are rendered raw in the detail templates. Without sanitization a stored
+``<script>`` / ``<img onerror>`` / ``<a onclick>`` executes in a viewer's browser
+(notably a staff reviewer previewing pending content) — stored XSS.
+
+We sanitize the *final* rendered HTML — i.e. after the reference/annotation
+markers have been spliced in by :func:`oldp.apps.lib.markers.insert_markers`.
+Sanitizing before marker insertion is not viable: markers are offset-based and
+annotation markers do not re-anchor, so shifting the content would misplace them.
+Sanitizing after insertion means the trusted marker markup must survive the
+allowlist, which is why the reference marker no longer carries an inline
+``onclick`` (it is bound via event delegation in main.js) — inline event handlers
+are stripped here by design.
+"""
+
+import nh3
+
+# Tags legitimately used in German court decisions / statutes, plus the elements
+# the reference (``<a class="ref">``) and annotation (``<span class="marker">``)
+# markers inject at render time. Everything else (script, iframe, style, form,
+# object, embed, ...) is dropped.
+ALLOWED_TAGS = {
+    "p",
+    "br",
+    "hr",
+    "div",
+    "span",
+    "h1",
+    "h2",
+    "h3",
+    "h4",
+    "h5",
+    "h6",
+    "b",
+    "strong",
+    "i",
+    "em",
+    "u",
+    "s",
+    "sub",
+    "sup",
+    "small",
+    "mark",
+    "ul",
+    "ol",
+    "li",
+    "dl",
+    "dt",
+    "dd",
+    "table",
+    "thead",
+    "tbody",
+    "tfoot",
+    "tr",
+    "th",
+    "td",
+    "caption",
+    "colgroup",
+    "col",
+    "a",
+    "blockquote",
+    "pre",
+    "code",
+    "cite",
+    "abbr",
+    "q",
+}
+
+# Per-tag attribute allowlist. ``data-marker-id`` + ``class`` back the reference
+# markers; ``id``/``class``/``style`` back the annotation markers. No event
+# handlers (``on*``) are ever allowed.
+ALLOWED_ATTRIBUTES = {
+    # ``rel`` is managed by nh3 via ``link_rel`` below, so it must not be listed
+    # here (nh3 rejects that combination).
+    "a": {"href", "title", "class", "name", "target", "data-marker-id"},
+    "span": {"class", "id", "style", "data-marker-id"},
+    "div": {"class", "id"},
+    "ol": {"style", "type", "start"},
+    "ul": {"type"},
+    "li": {"value"},
+    "table": {"class"},
+    "td": {"colspan", "rowspan"},
+    "th": {"colspan", "rowspan", "scope"},
+    "col": {"span"},
+    "colgroup": {"span"},
+}
+
+# Only these CSS properties survive inside a ``style`` attribute (annotation
+# highlight colour; legacy list styling). Everything else is stripped, so a
+# ``style`` cannot be used for CSS-based UI redressing / data exfiltration.
+ALLOWED_STYLE_PROPERTIES = {"background-color", "list-style-type"}
+
+# Absolute URLs are limited to these schemes; relative links (``/case/123``) and
+# fragments (``#refs``) are preserved. ``javascript:`` / ``data:`` are rejected.
+ALLOWED_URL_SCHEMES = {"http", "https", "mailto"}
+
+
+def sanitize_html(value: str) -> str:
+    """Return ``value`` with all non-allowlisted HTML removed.
+
+    Strips scripts, event handlers, ``javascript:`` URLs and disallowed
+    tags/attributes/CSS while preserving legitimate legal-document markup and the
+    trusted reference/annotation marker elements. Safe to call on empty/None-ish
+    input (returned unchanged).
+    """
+    if not value:
+        return value
+    return nh3.clean(
+        value,
+        tags=ALLOWED_TAGS,
+        attributes=ALLOWED_ATTRIBUTES,
+        filter_style_properties=ALLOWED_STYLE_PROPERTIES,
+        url_schemes=ALLOWED_URL_SCHEMES,
+        link_rel="noopener noreferrer",
+        strip_comments=True,
+    )

--- a/oldp/apps/lib/templatetags/html_filters.py
+++ b/oldp/apps/lib/templatetags/html_filters.py
@@ -1,0 +1,20 @@
+from django import template
+from django.utils.safestring import mark_safe
+
+from oldp.apps.lib.html_sanitizer import sanitize_html as _sanitize_html
+
+register = template.Library()
+
+
+@register.filter(name="sanitize_html", is_safe=True)
+def sanitize_html(value):
+    """Sanitize untrusted HTML and mark the result safe for rendering.
+
+    Drop-in replacement for wrapping ingested case/law content in
+    ``{% autoescape off %}``: it strips any stored ``<script>``/``onerror``/
+    ``onclick``/``javascript:`` payload before rendering while preserving
+    legitimate markup and the reference/annotation markers.
+
+    Usage: ``{{ content|sanitize_html }}``
+    """
+    return mark_safe(_sanitize_html(value or ""))

--- a/oldp/apps/lib/tests/test_html_sanitizer.py
+++ b/oldp/apps/lib/tests/test_html_sanitizer.py
@@ -1,0 +1,109 @@
+"""Tests for the ingested-content HTML sanitizer."""
+
+from django.template import Context, Template
+from django.test import SimpleTestCase
+from django.utils.safestring import SafeString
+
+from oldp.apps.lib.html_sanitizer import sanitize_html
+from oldp.apps.lib.templatetags.html_filters import sanitize_html as sanitize_filter
+
+
+class SanitizeHtmlTest(SimpleTestCase):
+    # --- strips script execution vectors ---
+
+    def test_strips_script_tag(self):
+        self.assertNotIn("<script", sanitize_html("<p>ok</p><script>alert(1)</script>"))
+
+    def test_strips_event_handler(self):
+        out = sanitize_html('<img src=x onerror="alert(1)">')
+        self.assertNotIn("onerror", out)
+        self.assertNotIn("<img", out)  # img not on the allowlist
+
+    def test_strips_anchor_onclick(self):
+        out = sanitize_html('<a href="/x" onclick="evil()">link</a>')
+        self.assertNotIn("onclick", out)
+        self.assertIn("link", out)
+
+    def test_strips_javascript_url(self):
+        out = sanitize_html('<a href="javascript:alert(1)">x</a>')
+        self.assertNotIn("javascript:", out)
+
+    def test_strips_iframe_and_style_tag(self):
+        out = sanitize_html("<iframe src=//evil></iframe><style>*{x:y}</style><p>t</p>")
+        self.assertNotIn("<iframe", out)
+        self.assertNotIn("<style", out)
+        self.assertIn("<p>t</p>", out)
+
+    # --- preserves legitimate legal-document markup ---
+
+    def test_keeps_structural_markup(self):
+        html = (
+            "<h2>Tenor</h2><p>Text</p>"
+            "<table><thead><tr><th>A</th></tr></thead>"
+            "<tbody><tr><td colspan='2'>B</td></tr></tbody></table>"
+            "<ol><li>x</li></ol><blockquote>q</blockquote>"
+        )
+        out = sanitize_html(html)
+        for frag in ("<h2>", "<table>", "<th>", 'colspan="2"', "<ol>", "<blockquote>"):
+            self.assertIn(frag, out)
+
+    def test_keeps_relative_and_fragment_hrefs(self):
+        out = sanitize_html('<a href="/case/123">c</a><a href="#refs">r</a>')
+        self.assertIn('href="/case/123"', out)
+        self.assertIn('href="#refs"', out)
+
+    # --- preserves the trusted marker markup, drops unsafe style ---
+
+    def test_keeps_reference_marker_anchor(self):
+        html = '<a href="#refs" data-marker-id="abc-1" class="ref">§ 1</a>'
+        out = sanitize_html(html)
+        self.assertIn('data-marker-id="abc-1"', out)
+        self.assertIn('class="ref"', out)
+        self.assertIn('href="#refs"', out)
+
+    def test_keeps_annotation_background_color_only(self):
+        html = '<span class="marker" style="background-color: #ff0000">x</span>'
+        self.assertIn("background-color", sanitize_html(html))
+
+    def test_strips_dangerous_style_properties(self):
+        html = '<span style="position: fixed; top: 0; background-color: red">x</span>'
+        out = sanitize_html(html)
+        self.assertNotIn("position", out)
+        self.assertNotIn("fixed", out)
+        self.assertIn("background-color", out)
+
+    def test_empty_input_unchanged(self):
+        self.assertEqual(sanitize_html(""), "")
+        self.assertEqual(sanitize_html(None), None)
+
+    def test_mark_then_sanitize_pipeline(self):
+        """Real render order: insert reference markers, then sanitize the final
+        HTML. The trusted marker anchor survives; an injected <script> does not.
+        """
+        from oldp.apps.references.models import ReferenceMarker
+
+        raw = "See [ref=abc-1]§ 1 BGB[/ref]<script>alert(1)</script> here"
+        marked = ReferenceMarker.make_markers_clickable(raw)
+        out = sanitize_html(marked)
+
+        self.assertIn('data-marker-id="abc-1"', out)
+        self.assertIn('class="ref"', out)
+        self.assertIn("§ 1 BGB", out)
+        self.assertNotIn("<script", out)
+        self.assertNotIn("onclick", out)
+
+
+class SanitizeHtmlFilterTest(SimpleTestCase):
+    def test_filter_returns_safe_string(self):
+        self.assertIsInstance(sanitize_filter("<p>x</p>"), SafeString)
+
+    def test_filter_in_template_strips_script(self):
+        tpl = Template("{% load html_filters %}{{ body|sanitize_html }}")
+        rendered = tpl.render(Context({"body": "<p>hi</p><script>alert(1)</script>"}))
+        self.assertIn("<p>hi</p>", rendered)
+        self.assertNotIn("<script", rendered)
+
+    def test_filter_does_not_double_escape(self):
+        tpl = Template("{% load html_filters %}{{ body|sanitize_html }}")
+        rendered = tpl.render(Context({"body": "<p>a &amp; b</p>"}))
+        self.assertNotIn("&amp;amp;", rendered)

--- a/oldp/apps/references/models.py
+++ b/oldp/apps/references/models.py
@@ -243,7 +243,10 @@ class ReferenceMarker(models.Model, BaseMarker):
         return self.text
 
     def get_marker_open_format(self):
-        return '<a href="#refs" onclick="clickRefMarker(this);" data-marker-id="{id}" class="ref">'
+        # No inline ``onclick`` — the HTML sanitizer strips event handlers from
+        # rendered content. The click behaviour is bound via event delegation on
+        # ``a.ref[data-marker-id]`` in main.js.
+        return '<a href="#refs" data-marker-id="{id}" class="ref">'
 
     def get_marker_close_format(self):
         return "</a>"
@@ -269,7 +272,8 @@ class ReferenceMarker(models.Model, BaseMarker):
         """TODO Replace ref marker number with db id"""
         return re.sub(
             r"\[ref=([-a-z0-9]+)\](.*?)\[\/ref\]",
-            r'<a href="#refs" onclick="clickRefMarker(this);" data-marker-id="\1" class="ref">\2</a>',
+            # No inline onclick — bound via event delegation in main.js.
+            r'<a href="#refs" data-marker-id="\1" class="ref">\2</a>',
             value,
         )
 

--- a/oldp/apps/references/tests/test_reference_methods.py
+++ b/oldp/apps/references/tests/test_reference_methods.py
@@ -304,7 +304,8 @@ class ReferenceMarkerMakeClickableTestCase(TestCase):
         result = ReferenceMarker.make_markers_clickable(value)
 
         self.assertIn('href="#refs"', result)
-        self.assertIn("onclick=", result)
+        # No inline onclick — click is bound via event delegation.
+        self.assertNotIn("onclick", result)
         self.assertIn('data-marker-id="abc123"', result)
         self.assertIn('class="ref"', result)
         self.assertIn("§ 123 BGB", result)

--- a/oldp/apps/search/templates/search/search.html
+++ b/oldp/apps/search/templates/search/search.html
@@ -1,6 +1,7 @@
 {% extends 'base.html' %}
 {% load i18n %}
 {% load search %}
+{% load html_filters %}
 
 {% block search_form %}
     {% with sidebar=1 sidebar_toggle_icon='fa-filter' search_form_class=' d-md-none' %}
@@ -115,9 +116,7 @@
                                     <h4><strong>{{ result.title }}</strong>{% if result.model_type %} ({% trans result.model_type %}){% endif %}</h4>
 
                                     <p class="search-snippet">
-                                        {% autoescape off %}
-                                            {{ result|get_search_snippet:query }}
-                                        {% endautoescape %}
+                                        {{ result|get_search_snippet:query|sanitize_html }}
                                     </p>
                                 </a>
                             </li>

--- a/oldp/assets/static/js/main.js
+++ b/oldp/assets/static/js/main.js
@@ -51,7 +51,19 @@
   
       return false;
     };
-  
+
+    // Reference markers render as <a class="ref" data-marker-id="..."> WITHOUT
+    // an inline onclick (inline handlers are stripped by the HTML sanitizer).
+    // Bind the click behaviour via event delegation so it works for any ref
+    // anchor present now or added later.
+    document.addEventListener('click', function(e) {
+      const link = e.target.closest && e.target.closest('a.ref[data-marker-id]');
+      if (link) {
+        e.preventDefault();
+        window.clickRefMarker(link);
+      }
+    });
+
     // Toggle entity markers on/off
     window.toggleEntityMarkers = function(type) {
       document

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -26,6 +26,9 @@ dependencies = [
 "requests-toolbelt>=0.7.1",
 "whitenoise>=4.1.3",
 "beautifulsoup4>=4.7.1",
+# HTML sanitizer for ingested case/law content (oldp.apps.lib.html_sanitizer).
+# Pinned to the 0.3.x line: nh3 is pre-1.0, so bound it to avoid breaking changes.
+"nh3>=0.3.0,<0.4",
 "msgpack>=0.3.0,<0.6",  # See spacy issue: https://github.com/explosion/spaCy/issues/2995
 
 # Django
@@ -80,7 +83,7 @@ dependencies = [
 # ``from mcp.server import FastMCP``) -> import error; and mcp 1.28+ changed the
 # OAuth Dynamic Client Registration surface so the DCR endpoint 404s (see
 # oldp.apps.mcp.tests.test_oauth_views). 1.27.x is the version dev runs and
-# tests pass on. See internal-tools#20; revisit when adopting a newer MCP SDK.
+# tests pass on; revisit when adopting a newer MCP SDK.
 "mcp>=1.8.0,<1.28",
 
 # OAuth2 for MCP connector authentication
@@ -88,8 +91,8 @@ dependencies = [
 # Cap below 3.3: 3.3+ added its own RFC 7591 ``register/`` route inside
 # ``oauth2_provider.urls``, which shadows oldp's ``oauth/register/`` DCR view
 # (included first in oldp/apps/mcp/urls.py) and 404s the DCR tests. 3.2.x is
-# what dev runs. See internal-tools#20; when adopting 3.3+, drop oldp's own DCR
-# view and reorder/rename the route to use the library's endpoint.
+# what dev runs; when adopting 3.3+, drop oldp's own DCR view and reorder/rename
+# the route to use the library's endpoint.
 "django-oauth-toolkit>=3.0.1,<3.3",
 ]
 
@@ -97,7 +100,7 @@ dependencies = [
 dev = [
   # Pin below 0.15: ruff 0.15+ reformats Python code blocks inside Markdown,
   # which flags 7 pre-existing docs and breaks `make lint-check` on an unpinned
-  # (latest) install. See internal-tools#20. Bump deliberately + reformat docs.
+  # (latest) install. Bump deliberately + reformat docs.
   "ruff>=0.11.6,<0.15",
   "selenium==3.141.0",
   "coverage>=4.5.1",


### PR DESCRIPTION
## Problem
`Case.content` / `Law.content` — HTML from external scrapers and the write API — is rendered raw via `{% autoescape off %}`, with **no HTML sanitization anywhere** in the codebase. A stored `<script>` / `<img onerror>` / `<a onclick>` executes in a viewer's browser — notably a **staff reviewer** previewing pending, contributor-submitted content. Stored XSS.

## Fix
- New **nh3 allowlist sanitizer** (`oldp/apps/lib/html_sanitizer.py`) tuned for German legal-document markup (headings, tables, lists, dl, blockquote, formatting) plus the reference/annotation marker elements.
- Exposed as a `sanitize_html` template filter (`oldp/apps/lib/templatetags/html_filters.py`).
- Applied at the **three raw sinks**, replacing `{% autoescape off %}`:
  - `cases/case.html` → `{{ content|sanitize_html }}`
  - `laws/law.html` → `{{ item.get_html_content|sanitize_html }}`
  - `search/search.html` → sanitizes the highlight snippet
- Strips scripts, event handlers, `javascript:` URLs, and non-allowlisted tags/attributes. `style` is allowed but **restricted to `background-color`/`list-style-type`** via nh3's `filter_style_properties`, so it can't be used for CSS-based UI redressing/exfiltration.

## Design: mark-then-sanitize (and why the marker changed)
Reference/annotation markers are **offset-based** on the raw content, and annotation markers don't re-anchor — so sanitizing *before* marker insertion would misplace them. We therefore sanitize the **final** HTML (after markers). That means the trusted marker markup must survive the allowlist — so the **reference marker no longer emits an inline `onclick`** (any XSS sanitizer must strip event handlers). Its click is now bound via **event delegation** on `a.ref[data-marker-id]` in `main.js`. (`clickRefMarker` is unchanged; inline handlers were an anti-pattern anyway.)

## Tests
- Sanitizer unit tests: strips `<script>`/`onerror`/`onclick`/`javascript:`/`<iframe>`/`<style>` and dangerous CSS; **keeps** legal structure, reference-marker anchor (`data-marker-id`/`class`/`href`), annotation `background-color`, and relative/fragment hrefs.
- Filter tests (returns `SafeString`, strips script in-template, no double-escaping).
- **Mark-then-sanitize pipeline test**: real `make_markers_clickable` output survives sanitization while an injected `<script>` is removed.
- Updated the reference-marker test (onclick removal) and case-detail view tests (compare against sanitized render). Full affected suite (cases/laws/references/search/lib) green.

## Deployment
New dependency **`nh3>=0.3.0,<0.4`** (bounded — nh3 is pre-1.0). Image rebuild installs it. No migration. Existing stored content is sanitized at render, so the fix is retroactive with no data migration.

## Follow-up
This closes the render-time XSS. Sanitizing on **ingest** as well (defense-in-depth, so the DB never stores active content) is a reasonable future hardening but needs a careful backfill of existing rows + marker-offset handling — out of scope here.