### PR TITLE
fix(settings): make prod transport-security settings env-overridable

### DIFF
--- a/oldp/settings.py
+++ b/oldp/settings.py
@@ -1005,9 +1005,15 @@ class ProdConfiguration(BaseConfiguration):
     # plain-HTTP app health check to break. HSTS is intentionally NOT emitted
     # here — it is disabled at the Cloudflare edge, and Secure cookies make it
     # unnecessary for this threat.
-    SESSION_COOKIE_SECURE = True
-    CSRF_COOKIE_SECURE = True
-    SECURE_SSL_REDIRECT = True
+    #
+    # Secure-by-default but env-overridable (DJANGO_SESSION_COOKIE_SECURE etc.):
+    # a non-HTTPS deployment (e.g. the plain-HTTP stage endpoint) must be able to
+    # turn these off, otherwise SECURE_SSL_REDIRECT loops it to a dead https URL.
+    # Prod sets none of them, so they stay True; disabling requires an explicit
+    # opt-out per environment.
+    SESSION_COOKIE_SECURE = values.BooleanValue(True)
+    CSRF_COOKIE_SECURE = values.BooleanValue(True)
+    SECURE_SSL_REDIRECT = values.BooleanValue(True)
 
     # Override logging to set INFO level for production
     @property

--- a/oldp/utils/tests/test_prod_security.py
+++ b/oldp/utils/tests/test_prod_security.py
@@ -1,26 +1,35 @@
 """Regression tests for production transport-security settings.
 
 Asserts the production configuration marks the session and CSRF cookies Secure
-and redirects to HTTPS, so authenticated cookies are never sent over plaintext.
-These are plain class attributes (not env-configurable ``values.Value``s) so they
-cannot be accidentally disabled per-deployment. HSTS is intentionally not set
-(disabled at the Cloudflare edge).
+and redirects to HTTPS by default, so authenticated cookies are never sent over
+plaintext. The settings are ``values.BooleanValue(True)`` — secure by default,
+but env-overridable (``DJANGO_SESSION_COOKIE_SECURE`` etc.) so a non-HTTPS
+deployment (the plain-HTTP stage) can opt out; disabling requires an explicit
+per-environment override. HSTS is intentionally not set (disabled at the
+Cloudflare edge).
 """
 
+from configurations.values import BooleanValue
 from django.test import SimpleTestCase
 
 from oldp.settings import ProdConfiguration
 
 
 class ProdTransportSecurityTest(SimpleTestCase):
-    def test_session_cookie_secure(self):
-        self.assertIs(ProdConfiguration.SESSION_COOKIE_SECURE, True)
+    def test_session_cookie_secure_by_default(self):
+        value = ProdConfiguration.SESSION_COOKIE_SECURE
+        self.assertIsInstance(value, BooleanValue)  # env-overridable
+        self.assertIs(value.default, True)  # ...but secure by default
 
-    def test_csrf_cookie_secure(self):
-        self.assertIs(ProdConfiguration.CSRF_COOKIE_SECURE, True)
+    def test_csrf_cookie_secure_by_default(self):
+        value = ProdConfiguration.CSRF_COOKIE_SECURE
+        self.assertIsInstance(value, BooleanValue)
+        self.assertIs(value.default, True)
 
-    def test_ssl_redirect_enabled(self):
-        self.assertIs(ProdConfiguration.SECURE_SSL_REDIRECT, True)
+    def test_ssl_redirect_enabled_by_default(self):
+        value = ProdConfiguration.SECURE_SSL_REDIRECT
+        self.assertIsInstance(value, BooleanValue)
+        self.assertIs(value.default, True)
 
     def test_hsts_not_emitted_from_django(self):
         # HSTS is disabled at the Cloudflare edge; Django must not emit it


### PR DESCRIPTION
## Why
`SESSION_COOKIE_SECURE`, `CSRF_COOKIE_SECURE`, and `SECURE_SSL_REDIRECT` were hardcoded `True` in `ProdConfiguration`. That breaks any deployment that runs the prod config over **plain HTTP** — specifically the **stage** endpoint (`http://oldp-de-stage.dev.ostendorff.org:8080/`): its proxy forwards `X-Forwarded-Proto: http`, so `SECURE_SSL_REDIRECT` 301-redirects every request to an `https://` URL that isn't served → stage becomes unreachable.

## What
Change the three to `values.BooleanValue(True)`:
- **Still secure by default** — prod sets no override, so all three stay `True`.
- **Overridable per environment** via `DJANGO_SESSION_COOKIE_SECURE` / `DJANGO_CSRF_COOKIE_SECURE` / `DJANGO_SECURE_SSL_REDIRECT`, so the HTTP stage can opt out.
- Weakening now requires an **explicit** per-env opt-out (it was previously impossible; now it's deliberate, not accidental).

## Tests
`test_prod_security.py` updated to assert each is a `BooleanValue` with a `True` default (secure-by-default **and** env-overridable). Passes; lint clean.

## Context
Follow-up to the prod Secure-cookies change. Needed so the new image can be deployed to the HTTP stage for verification before the prod (HTTPS) release; prod keeps the secure defaults.