### PR TITLE
fix(settings): move transport-security settings to BaseConfiguration (they were inert in prod)

### DIFF
--- a/oldp/settings.py
+++ b/oldp/settings.py
@@ -423,6 +423,21 @@ class BaseConfiguration(Configuration):
     # Honor the 'X-Forwarded-Proto' header for request.is_secure()
     SECURE_PROXY_SSL_HEADER = ("HTTP_X_FORWARDED_PROTO", "https")
 
+    # Transport security — MUST live on BaseConfiguration, not ProdConfiguration.
+    # The deployed config is ProdDEConfiguration(BaseDEConfiguration,
+    # ProdConfiguration): django-configurations injects Django's defaults onto
+    # the DE classes, which sit before ProdConfiguration in the MRO and shadow
+    # any value set there (so settings on ProdConfiguration silently resolve to
+    # Django's default). Values on BaseConfiguration DO propagate to the DE
+    # configs. Secure by default (only send session/CSRF cookies over HTTPS and
+    # redirect to HTTPS) but env-overridable so a plain-HTTP deployment (local
+    # dev, an HTTP stage) can opt out via DJANGO_SESSION_COOKIE_SECURE etc.
+    # HSTS is intentionally not emitted (disabled at the Cloudflare edge).
+    # TestConfiguration overrides these to False so the test client is not 301'd.
+    SESSION_COOKIE_SECURE = values.BooleanValue(True)
+    CSRF_COOKIE_SECURE = values.BooleanValue(True)
+    SECURE_SSL_REDIRECT = values.BooleanValue(True)
+
     # Static files (CSS, JavaScript, Images)
     # https://docs.djangoproject.com/en/1.9/howto/static-files/
     STATIC_ROOT = PACKAGE_DIR / "assets/static-dist"
@@ -891,6 +906,14 @@ class TestConfiguration(BaseConfiguration):
 
     DEBUG = True
 
+    # The BaseConfiguration transport-security defaults are True; disable them
+    # for tests so the test client isn't 301-redirected to https / cookies work
+    # over the test's plain-HTTP requests. Single inheritance here, so these
+    # apply directly (unlike the ProdConfiguration diamond).
+    SESSION_COOKIE_SECURE = False
+    CSRF_COOKIE_SECURE = False
+    SECURE_SSL_REDIRECT = False
+
     COMPRESS_OFFLINE = False
     COMPRESS_ENABLED = False
     COMPRESS_PRECOMPILERS = []  # Disable SCSS compilation in tests
@@ -996,24 +1019,10 @@ class ProdConfiguration(BaseConfiguration):
 
     ADMINS = values.SingleNestedTupleValue()
 
-    # Transport security. Only send the session and CSRF cookies over HTTPS so
-    # they are never attached to a plaintext request and cannot be captured by a
-    # network MITM. ``SECURE_SSL_REDIRECT`` is defence-in-depth on top of the
-    # nginx :80 -> :443 redirect and the Cloudflare "Always Use HTTPS" edge
-    # setting; it detects TLS via the already-configured ``SECURE_PROXY_SSL_HEADER``
-    # (nginx sets X-Forwarded-Proto), so it does not loop and there is no
-    # plain-HTTP app health check to break. HSTS is intentionally NOT emitted
-    # here — it is disabled at the Cloudflare edge, and Secure cookies make it
-    # unnecessary for this threat.
-    #
-    # Secure-by-default but env-overridable (DJANGO_SESSION_COOKIE_SECURE etc.):
-    # a non-HTTPS deployment (e.g. the plain-HTTP stage endpoint) must be able to
-    # turn these off, otherwise SECURE_SSL_REDIRECT loops it to a dead https URL.
-    # Prod sets none of them, so they stay True; disabling requires an explicit
-    # opt-out per environment.
-    SESSION_COOKIE_SECURE = values.BooleanValue(True)
-    CSRF_COOKIE_SECURE = values.BooleanValue(True)
-    SECURE_SSL_REDIRECT = values.BooleanValue(True)
+    # NOTE: the transport-security settings (SESSION_COOKIE_SECURE,
+    # CSRF_COOKIE_SECURE, SECURE_SSL_REDIRECT) live on BaseConfiguration, NOT
+    # here — on ProdConfiguration they are shadowed for the deployed
+    # ProdDEConfiguration and silently resolve to Django's insecure defaults.
 
     # Override logging to set INFO level for production
     @property

--- a/oldp/utils/tests/test_prod_security.py
+++ b/oldp/utils/tests/test_prod_security.py
@@ -1,37 +1,54 @@
 """Regression tests for production transport-security settings.
 
-Asserts the production configuration marks the session and CSRF cookies Secure
-and redirects to HTTPS by default, so authenticated cookies are never sent over
-plaintext. The settings are ``values.BooleanValue(True)`` — secure by default,
-but env-overridable (``DJANGO_SESSION_COOKIE_SECURE`` etc.) so a non-HTTPS
-deployment (the plain-HTTP stage) can opt out; disabling requires an explicit
-per-environment override. HSTS is intentionally not set (disabled at the
-Cloudflare edge).
+The Secure-cookie / SSL-redirect settings MUST be defined on
+``BaseConfiguration``, not ``ProdConfiguration``. The deployed config is
+``ProdDEConfiguration(BaseDEConfiguration, ProdConfiguration)``; django-
+configurations injects Django's (insecure) defaults onto the DE classes, which
+precede ``ProdConfiguration`` in the MRO and shadow anything set there — so on
+``ProdConfiguration`` these silently resolve to ``False`` for the deployed app.
+Values on ``BaseConfiguration`` propagate correctly. See the note in
+``oldp/settings.py``. (The effective ``True`` in the deployed ProdDE config is
+verified during deployment; here we lock in the source-of-truth + test safety.)
 """
 
-from configurations.values import BooleanValue
+import inspect
+
+from django.conf import settings
 from django.test import SimpleTestCase
 
-from oldp.settings import ProdConfiguration
+from oldp.settings import BaseConfiguration, ProdConfiguration
+
+_SETTINGS = ("SESSION_COOKIE_SECURE", "CSRF_COOKIE_SECURE", "SECURE_SSL_REDIRECT")
 
 
-class ProdTransportSecurityTest(SimpleTestCase):
-    def test_session_cookie_secure_by_default(self):
-        value = ProdConfiguration.SESSION_COOKIE_SECURE
-        self.assertIsInstance(value, BooleanValue)  # env-overridable
-        self.assertIs(value.default, True)  # ...but secure by default
+class TransportSecurityTest(SimpleTestCase):
+    def test_defined_secure_on_baseconfiguration(self):
+        src = inspect.getsource(BaseConfiguration)
+        for name in _SETTINGS:
+            self.assertIn(
+                f"{name} = values.BooleanValue(True)",
+                src,
+                f"{name} must be a secure-by-default BooleanValue on BaseConfiguration",
+            )
 
-    def test_csrf_cookie_secure_by_default(self):
-        value = ProdConfiguration.CSRF_COOKIE_SECURE
-        self.assertIsInstance(value, BooleanValue)
-        self.assertIs(value.default, True)
+    def test_not_assigned_on_prodconfiguration(self):
+        # On ProdConfiguration they are shadowed/inert for the deployed DE config.
+        src = inspect.getsource(ProdConfiguration)
+        for name in _SETTINGS:
+            self.assertNotIn(
+                f"{name} =",
+                src,
+                f"{name} must not be assigned on ProdConfiguration (it would be inert)",
+            )
 
-    def test_ssl_redirect_enabled_by_default(self):
-        value = ProdConfiguration.SECURE_SSL_REDIRECT
-        self.assertIsInstance(value, BooleanValue)
-        self.assertIs(value.default, True)
+    def test_disabled_under_testconfiguration(self):
+        # Tests run under TestConfiguration; these must be off so the test client
+        # isn't 301-redirected to https and cookies work over plain HTTP.
+        for name in _SETTINGS:
+            self.assertIs(
+                getattr(settings, name), False, f"{name} must be False in tests"
+            )
 
-    def test_hsts_not_emitted_from_django(self):
-        # HSTS is disabled at the Cloudflare edge; Django must not emit it
-        # either. Default is 0 / unset.
-        self.assertIn(getattr(ProdConfiguration, "SECURE_HSTS_SECONDS", 0), (0, None))
+    def test_hsts_not_emitted(self):
+        # HSTS is disabled at the Cloudflare edge; Django must not emit it.
+        self.assertIn(getattr(settings, "SECURE_HSTS_SECONDS", 0), (0, None))


### PR DESCRIPTION
## The bug (caught on stage)
The prod Secure-cookie / SSL-redirect settings were placed on `ProdConfiguration`, but the deployed config is `ProdDEConfiguration(BaseDEConfiguration, ProdConfiguration)`. django-configurations injects Django's **insecure defaults** onto the DE config classes, which precede `ProdConfiguration` in the MRO and **shadow** anything set there. Result — on the actual running app:
```
SECURE_SSL_REDIRECT   = False
SESSION_COOKIE_SECURE = False
CSRF_COOKIE_SECURE    = False
```
Neither the code default nor an explicit `DJANGO_…=True` env var could change it. **The transport-security fix was completely inert in prod** (and its unit test passed against `ProdConfiguration`, giving false confidence).

## The fix
Move the three settings to **`BaseConfiguration`** as env-overridable `BooleanValue(True)` (secure by default). Values on `BaseConfiguration` *do* propagate to the DE configs — proven, and re-verified on the stage image: `ProdDEConfiguration` now resolves **all three to `True`** (were `False`).
- `TestConfiguration` overrides them to `False` (single inheritance, applies) so the test client isn't 301'd and cookies work over the test's plain HTTP.
- Dev env (`oldp-de-dev.env`) disables them — dev is served over plain HTTP.
- Stage (over the new `:8443` HTTPS) and prod get the secure `True` defaults.

## Tests
`test_prod_security.py` rewritten to assert the settings are defined on `BaseConfiguration` (secure default), **not** on `ProdConfiguration` (where they'd be inert), and are `False` under `TestConfiguration`. Full run green (transport + pages + case-view tests, no redirects). Lint clean.

## Why it matters
This is the difference between the Secure-cookies hardening actually applying in prod vs. silently doing nothing. Found only because we deployed to stage and inspected the resolved settings before releasing.