### PR TITLE
fix(i18n): render active language in <html lang> instead of hardcoded en

### DIFF
--- a/oldp/assets/templates/layout.html
+++ b/oldp/assets/templates/layout.html
@@ -1,5 +1,5 @@
-{% load static %}{% load i18n %}{% load compress %}<!DOCTYPE html>
-<html lang="en">
+{% load static %}{% load i18n %}{% load compress %}{% get_current_language as LANGUAGE_CODE %}<!DOCTYPE html>
+<html lang="{{ LANGUAGE_CODE }}">
 <head>
     <title>{% if title %}{{ title }}{% else %}{% block head_title %}{% endblock %}{% endif %} - {{ site_title }}</title>
 

--- a/oldp/assets/templates/micro_layout.html
+++ b/oldp/assets/templates/micro_layout.html
@@ -1,5 +1,5 @@
-{% load static %}{% load i18n %}{% load compress %}<!DOCTYPE html>
-<html lang="en">
+{% load static %}{% load i18n %}{% load compress %}{% get_current_language as LANGUAGE_CODE %}<!DOCTYPE html>
+<html lang="{{ LANGUAGE_CODE }}">
 <head>
     <title>{% if title %}{{ title }}{% else %}{% block head_title %}{% endblock %}{% endif %} - {{ site_title }}</title>
 


### PR DESCRIPTION
## Problem
`layout.html` and `micro_layout.html` hardcoded `<html lang="en">`, so **every** page reported English in the `lang` attribute — even when the content is rendered in German (e.g. all of `de.openlegaldata.io`). That's wrong for accessibility (screen readers), SEO, and browser translation.

## Fix
Emit the **active** translation language:
```django
{% get_current_language as LANGUAGE_CODE %}
<html lang="{{ LANGUAGE_CODE }}">
```
Used the `{% get_current_language %}` tag (both templates already `{% load i18n %}`) because the `i18n` context processor isn't enabled, so `{{ LANGUAGE_CODE }}` alone would be empty.

## Verified
On the German stage host, the homepage and the markdown pages now render `<html lang="de">` (Content-Language `de`); English requests render `lang="en"`. Mechanism confirmed via `get_current_language` under `translation.override('de'/'en')`.