### PR TITLE
fix(pages): <section> wrapper for markdown pages + MCP doc links

### DIFF
--- a/docs/templates/mcp.html
+++ b/docs/templates/mcp.html
@@ -1,0 +1,18 @@
+<!doctype html>
+<html>
+  <head>
+    <title>Open Legal Data Platform — MCP Documentation</title>
+    <meta charset="utf-8" />
+    {% if latest %}
+    <meta http-equiv="refresh" content="0; url=./{{ latest.name }}/mcp.html" />
+    <link rel="canonical" href="./{{ latest.name }}/mcp.html" />
+    {% endif %}
+  </head>
+  <body>
+    {% if latest %}
+    <p>Redirecting to <a href="./{{ latest.name }}/mcp.html">MCP documentation for the latest version ({{ latest.name }})</a>&hellip;</p>
+    {% else %}
+    <p>No documentation versions are available yet.</p>
+    {% endif %}
+  </body>
+</html>

--- a/oldp/apps/accounts/templates/accounts/personal_api_tokens.html
+++ b/oldp/apps/accounts/templates/accounts/personal_api_tokens.html
@@ -75,6 +75,9 @@
         <a class="btn btn-outline-secondary" href="{{ site_api_docs_url }}" target="_blank">
             📖 {% trans 'API Documentation' %}
         </a>
+        <a class="btn btn-outline-secondary" href="{{ site_mcp_docs_url }}" target="_blank">
+            🔌 {% trans 'MCP Documentation' %}
+        </a>
     </div>
 
     <div class="alert alert-warning">

--- a/oldp/apps/lib/context_processors.py
+++ b/oldp/apps/lib/context_processors.py
@@ -27,6 +27,7 @@ def global_context_processor(request):
         "site_linkedin_url": settings.SITE_LINKEDIN_URL,
         "site_discord_url": settings.SITE_DISCORD_URL,
         "site_api_docs_url": settings.SITE_API_DOCS_URL,
+        "site_mcp_docs_url": settings.SITE_MCP_DOCS_URL,
         "matomo_url": settings.MATOMO_URL,
         "matomo_site_id": settings.MATOMO_SITE_ID,
         "canonical": "",

--- a/oldp/apps/pages/templates/pages/detail.html
+++ b/oldp/apps/pages/templates/pages/detail.html
@@ -3,7 +3,8 @@
 {% block head_title %}{{ page.title }}{% endblock %}
 
 {% block content %}
-<article class="markdown-page">
+{# Wrap in <section> (like the DB flatpages) so it gets the theme content-card styling. #}
+<section class="markdown-page">
     {{ page.html }}
-</article>
+</section>
 {% endblock %}

--- a/oldp/assets/templates/footer.html
+++ b/oldp/assets/templates/footer.html
@@ -17,6 +17,7 @@
                 <li><a href="{% report_content_url %}" rel="nofollow">{% trans 'Report content' %}</a></li>
 
                 <li><a href="{{ api_info_url }}">API</a></li>
+                <li><a href="{{ site_mcp_docs_url }}" target="_blank" rel="noopener">MCP</a></li>
                 <li><a href="{% url 'cases:stats' %}"><i class="fa-solid fa-chart-bar" aria-hidden="true"></i> {% trans 'Statistics' %}</a></li>
 
                 <li><a href="{{ site_blog_url }}">Blog</a></li>

--- a/oldp/assets/templates/header.html
+++ b/oldp/assets/templates/header.html
@@ -89,6 +89,7 @@
     </ul>
 
     <a class="btn btn-bd-download d-none d-lg-inline-block mb-3 mb-md-0 ml-md-3" href="{% url 'flatpages' url='/api/' %}">API</a>
+    <a class="btn btn-bd-download d-none d-lg-inline-block mb-3 mb-md-0 ml-md-3" href="{{ site_mcp_docs_url }}" target="_blank" rel="noopener">MCP</a>
 </header>
 
 {% endblock %}

--- a/oldp/locale/de/LC_MESSAGES/django.po
+++ b/oldp/locale/de/LC_MESSAGES/django.po
@@ -1147,6 +1147,10 @@ msgstr "Token erneuern"
 msgid "API Documentation"
 msgstr "API-Dokumentation"
 
+#: oldp/apps/accounts/templates/accounts/personal_api_tokens.html:79
+msgid "MCP Documentation"
+msgstr "MCP-Dokumentation"
+
 #: oldp/apps/accounts/templates/accounts/personal_api_tokens.html:81
 msgid "Security Warning:"
 msgstr "Sicherheitshinweis:"

--- a/oldp/locale/en/LC_MESSAGES/django.po
+++ b/oldp/locale/en/LC_MESSAGES/django.po
@@ -1055,6 +1055,10 @@ msgstr ""
 msgid "API Documentation"
 msgstr ""
 
+#: oldp/apps/accounts/templates/accounts/personal_api_tokens.html:79
+msgid "MCP Documentation"
+msgstr ""
+
 #: oldp/apps/accounts/templates/accounts/personal_api_tokens.html:81
 msgid "Security Warning:"
 msgstr ""

--- a/oldp/settings.py
+++ b/oldp/settings.py
@@ -60,6 +60,10 @@ class BaseConfiguration(Configuration):
 
     SITE_BLOG_URL = values.Value("//openlegaldata.io/blog")
     SITE_API_DOCS_URL = values.Value("https://openlegaldata.github.io/oldp/")
+    # Version-less deep link: gh-pages serves a root ``mcp.html`` (see
+    # ``docs/templates/mcp.html``) that redirects to the newest release's MCP
+    # page, so this never needs bumping per release.
+    SITE_MCP_DOCS_URL = values.Value("https://openlegaldata.github.io/oldp/mcp.html")
 
     # Matomo analytics (self-hosted, cookieless). The tracking snippet renders
     # only when BOTH values are set, so it stays inert in dev/test by default.


### PR DESCRIPTION
Two related front-end changes.

## 1. Markdown pages: `<section>` wrapper

After migrating legal pages (Impressum/Datenschutz/AGB) from DB flatpages to markdown, they rendered without the theme's content-card styling (box-shadow/border/background) that the old flatpages got from a top-level `<section>`. The template used a bare `<article class="markdown-page">`. Fixed by wrapping the rendered markdown in `<section class="markdown-page">`, matching the flatpage markup.

## 2. MCP documentation links

Adds an **MCP** link/button next to the existing **API** links:
- header **MCP** button next to the **API** button
- footer **MCP** link next to **API**
- **🔌 MCP Documentation** button on the personal API-tokens page (with German translation)

All point at a new version-less setting `SITE_MCP_DOCS_URL` = `https://openlegaldata.github.io/oldp/mcp.html`.

### Always-latest docs URL

To keep that URL resolving to the newest release (instead of hardcoding e.g. `/v0.13.0/mcp.html`), `docs/templates/mcp.html` is rendered by sphinx-polyversion to the gh-pages **root** and redirects to `./{{ latest.name }}/mcp.html` — mirroring the existing `index.html` landing redirect. `latest` resolves to the newest release tag, so no per-release bump is needed.

> Note: the root `mcp.html` redirect stub is published the next time the **Docs** workflow runs (on merge to `main` / next tag). Per-version pages like `v0.13.0/mcp.html` already exist.

The German-theme footer override lives in oldp-de and is updated in **openlegaldata/oldp-de#5**.

## Verification

Deployed to stage and verified: `<section>` wraps page content (no comment leak); header/footer render the MCP link at the docs URL; the API-tokens page shows the MCP button rendered as `MCP-Dokumentation` in German; the docs redirect template renders `url=./v0.13.0/mcp.html`.

https://claude.ai/code/session_01T12X7CSfqFAtka8mkByhSo