### PR TITLE
chore(deps): bump oldp-de 0.1.5 → 0.1.6 (footer MCP link)

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -113,7 +113,7 @@ theme-de = [
   # https://github.com/openlegaldata/oldp-de
   # Pinned: stage/prod images bake in this exact version. Bump in lock-step
   # with a published oldp-de release (PyPI) when picking up theme changes.
-  "oldp-de==0.1.5"
+  "oldp-de==0.1.6"
 ]
 prod = [
   "gunicorn>=19.9.0",


### PR DESCRIPTION
Picks up the theme footer template that adds the MCP documentation link — parity with header.html and the tokens page shipped in #266 (v0.13.1).

## Root cause
Django template resolution finds `oldp_de/assets/templates/footer.html` (theme override in the pinned `oldp-de` package) before the base `oldp/oldp/assets/templates/footer.html`. The base footer has the MCP `<li>`; the 0.1.5 theme footer doesn't:

```
docker exec oldp-prod-app grep -iE 'mcp|API' \
  /usr/local/lib/python3.12/site-packages/oldp_de/assets/templates/footer.html
    <li><a href="{% url 'flatpages' url='/api/' %}">API</a></li>
    (no MCP entry)
```

`oldp-de==0.1.6` adds the MCP `<li>` in its theme footer.

## Test plan
- [ ] After merge → run patch release (Publish workflow, `patch` → v0.13.2)
- [ ] Bump prod compose to `v0.13.2`, `make up-app`
- [ ] Verify footer on de.openlegaldata.io renders the MCP link