### PR TITLE
fix(laws): don't 500 on an invalid ?revision_date=

### DIFF
--- a/oldp/apps/laws/tests/test_views.py
+++ b/oldp/apps/laws/tests/test_views.py
@@ -45,6 +45,58 @@ class LawsViewsTestCase(LiveServerTestCase):
 
         self.assertContains(res, "Grundgesetz")
 
+    def test_book_absent_revision_falls_back_to_latest(self):
+        """A well-formed but non-existent revision serves the latest revision."""
+        res = self.client.get(
+            reverse("laws:book", args=("gg",)) + "?revision_date=1990-01-01"
+        )
+
+        self.assertEqual(res.status_code, 200)
+        self.assertContains(res, "Grundgesetz")
+
+    def test_book_invalid_revision_date_does_not_500(self):
+        """An unparseable ``revision_date`` must not raise a 500.
+
+        Regression test: ``DateField.to_python()`` raised
+        ``ValidationError`` while building the query, escaping the view as an
+        Internal Server Error. A scanner fuzzing this parameter produced 457
+        500s in a single day. Bad input must degrade to the latest revision.
+        """
+        for bad_value in (
+            "not-a-date",
+            "2026-13-99",
+            "K5QfQ0BQrHHinLNzUpZV",
+            "2026-02-04' EXTRACTVALUE(5203,CONCAT(0x5c,0x71))-- -",
+            "2026-02-04 UNION ALL SELECT 'qqx',NULL,NULL#",
+        ):
+            with self.subTest(revision_date=bad_value):
+                res = self.client.get(
+                    reverse("laws:book", args=("gg",)),
+                    {"revision_date": bad_value},
+                )
+
+                self.assertEqual(res.status_code, 200)
+                self.assertContains(res, "Grundgesetz")
+
+    def test_law_invalid_revision_date_does_not_500(self):
+        """The law detail view shares ``get_law_book`` and must degrade too."""
+        res = self.client.get(
+            reverse("laws:law", args=("gg", "artikel-1")),
+            {"revision_date": "not-a-date"},
+        )
+
+        self.assertEqual(res.status_code, 200)
+
+    def test_invalid_revision_date_is_escaped_in_message(self):
+        """The echoed revision_date must not inject markup into the page."""
+        res = self.client.get(
+            reverse("laws:book", args=("gg",)),
+            {"revision_date": "<script>alert(1)</script>"},
+        )
+
+        self.assertEqual(res.status_code, 200)
+        self.assertNotContains(res, "<script>alert(1)</script>")
+
     def test_law(self):
         res = self.client.get(reverse("laws:law", args=("gg", "artikel-1")))
 

--- a/oldp/apps/laws/views.py
+++ b/oldp/apps/laws/views.py
@@ -7,6 +7,7 @@ from django.core.paginator import EmptyPage, PageNotAnInteger, Paginator
 from django.http import Http404
 from django.shortcuts import get_object_or_404, render
 from django.urls import reverse
+from django.utils.dateparse import parse_date
 from django.utils.http import urlencode
 from django.utils.translation import gettext_lazy as _
 
@@ -98,13 +99,31 @@ def get_latest_law_book(request, book_slug):
 
 
 def get_law_book(request, book_slug):
-    """Law book by slug and optional revision_date"""
+    """Law book by slug and optional ``revision_date``.
+
+    An unparseable ``revision_date`` is treated exactly like a valid-but-absent
+    one: warn the user and fall back to the latest revision. ``revision_date``
+    comes straight from the query string, so it must be parsed *before* it
+    reaches the ORM -- ``DateField.to_python()`` raises ``ValidationError``
+    while building the query, which used to escape the view as a 500 (a single
+    scanner turned that into 457 errors in one day).
+    """
     revision_date = request.GET.get("revision_date")
 
-    if revision_date:
+    if not revision_date:
+        return get_latest_law_book(request, book_slug)
+
+    try:
+        # Returns None when the value doesn't look like a date at all, and
+        # raises ValueError when it parses but is out of range ("2026-13-99").
+        parsed_revision_date = parse_date(revision_date)
+    except ValueError:
+        parsed_revision_date = None
+
+    if parsed_revision_date is not None:
         try:
             return LawBook.get_queryset(request).get(
-                slug=book_slug, revision_date=revision_date
+                slug=book_slug, revision_date=parsed_revision_date
             )
         except LawBook.DoesNotExist:
             logger.debug(
@@ -112,16 +131,27 @@ def get_law_book(request, book_slug):
                 book_slug,
                 revision_date,
             )
-            messages.warning(
-                request,
-                _(
-                    "The requested revision (%s) was not found. Showing instead the latest revision."
-                    % revision_date
-                ),
+        except LawBook.MultipleObjectsReturned:
+            # Shouldn't happen (slug+revision_date is effectively unique), but
+            # a duplicate row must not 500 the page either.
+            logger.warning(
+                "Multiple books for book=%s, revision_date=%s; using latest",
+                book_slug,
+                revision_date,
             )
-            return get_latest_law_book(request, book_slug)
     else:
-        return get_latest_law_book(request, book_slug)
+        logger.debug(
+            "Unparseable revision_date for book=%s: %r", book_slug, revision_date
+        )
+
+    messages.warning(
+        request,
+        _(
+            "The requested revision (%s) was not found. Showing instead the latest revision."
+        )
+        % revision_date,
+    )
+    return get_latest_law_book(request, book_slug)
 
 
 @cache_per_role(settings.CACHE_TTL)


### PR DESCRIPTION
## Problem

`get_law_book()` passed the raw `?revision_date=` query value straight into the ORM and only caught `LawBook.DoesNotExist`. For an unparseable value, Django's `DateField.to_python()` raises `ValidationError` while *building* the query — so it escaped the view as an **HTTP 500** with a full logged traceback.

Reachable by anyone typing a bad revision date, but in practice one scanner fuzzing this parameter produced **457 500s on 2026-06-24** (307× `/law/hgb/`, 150× `/law/bgb/`) — the entire 5xx spike for that day.

```
GET /law/hgb/?revision_date=not-a-date   ->  500
GET /law/bgb/?revision_date=2026-13-99   ->  500
```

## Fix

Parse the value up front with `django.utils.dateparse.parse_date()` and treat a bad one exactly like a valid-but-absent revision: warn the user, fall back to the latest revision.

Two distinct failure modes, both handled — `parse_date()` returns `None` for a non-date, and raises `ValueError` for an in-format but out-of-range value like `2026-13-99` (my first pass missed the second; the test caught it).

Also catches `MultipleObjectsReturned` defensively so a duplicate row can't 500 the page either.

## Drive-by i18n fix

The warning interpolated **inside** `gettext`:

```python
_("The requested revision (%s) was not found. ..." % revision_date)
```

so the msgid varied per input and never matched the catalogue entry — the string could never be translated. Moved the `%` outside. The `.po` msgid already uses `%s`, confirming the intent.

## Escaping

The echoed value is rendered via `{{ message }}` in `messages.html`, which is autoescaped — verified, and pinned with a test so the reflected value can't inject markup.

## Tests

- Unparseable, out-of-range, and the actual SQLi-fuzz payloads from the logs → **200** on both the book and law views
- Valid-but-absent revision still falls back to latest
- Reflected value is escaped

Full laws suite green (**212 tests**), `ruff check`/`format` clean.
