### PR TITLE
perf(api): resolve citing_laws via slug pair, drop the sibling-id scan

### DIFF
--- a/oldp/apps/laws/api_views.py
+++ b/oldp/apps/laws/api_views.py
@@ -278,16 +278,14 @@ class LawViewSet(ReviewStatusFilterMixin, viewsets.ModelViewSet):
         Returns paginated summary records (``LawListSerializer``) —
         ``content`` is omitted; fetch ``/api/laws/<id>/`` if the full
         body of a citing law is needed.
+
+        Resolved from the ``(book_slug, section_slug)`` pair, which is
+        stable across book revisions — so cross-revision lookup is
+        implicit and no sibling-id expansion is needed (same rationale
+        as :meth:`citing_cases`).
         """
         law = self.get_object()
-        sibling_ids = list(
-            Law.objects.filter(
-                book__code__iexact=law.book.code,
-                section__iexact=law.section,
-                review_status="accepted",
-            ).values_list("id", flat=True)
-        )
-        qs = citing_laws_for_law(sibling_ids or [law.id])
+        qs = citing_laws_for_law((law.book.slug, law.slug))
         page = self.paginate_queryset(qs)
         serializer = LawListSerializer(page if page is not None else qs, many=True)
         if page is not None:

--- a/oldp/apps/references/tests/test_api.py
+++ b/oldp/apps/references/tests/test_api.py
@@ -185,6 +185,65 @@ class CitationApiTestCase(ESCitingCasesShimMixin, TestCase):
         self.assertEqual(resp.json()["count"], 1)
         self.assertEqual(resp.json()["results"][0]["id"], self.law_823.id)
 
+    def test_law_citing_laws_does_not_scan_for_sibling_ids(self):
+        """``citing_laws`` must resolve via the slug pair, not a sibling scan.
+
+        The action used to expand ``(book.code, section)`` into every
+        matching ``Law`` id with a case-insensitive filter:
+
+            Law.objects.filter(book__code__iexact=…, section__iexact=…)
+
+        ``iexact`` is unindexable, so that scanned ``laws_law`` joined to
+        ``laws_lawbook`` on every request — and the resulting id list was
+        then collapsed straight back to a single ``(book_slug,
+        section_slug)`` pair by ``_law_to_slug_pair``, i.e. the scan was
+        pure waste. Under bot load these calls reached 55s in production.
+
+        Pin the query shape so the scan can't come back.
+        """
+        from django.db import connection
+        from django.test.utils import CaptureQueriesContext
+
+        with CaptureQueriesContext(connection) as ctx:
+            resp = self.client.get(f"/api/laws/{self.law_249.id}/citing_laws/")
+
+        self.assertEqual(resp.status_code, 200)
+        sql = " ".join(q["sql"].lower() for q in ctx.captured_queries)
+        # `iexact` compiles to LIKE (sqlite/mysql) or UPPER(...) comparisons.
+        self.assertNotIn("upper(", sql)
+        self.assertNotIn(" like ", sql)
+
+    def test_law_citing_laws_resolves_across_book_revisions(self):
+        """A citation recorded against an older revision is still returned.
+
+        ``Reference`` rows pin to the ``Law`` row that existed when
+        extraction ran, which may live on a superseded book revision. The
+        ``(book_slug, section_slug)`` pair is stable across revisions, so
+        dropping the sibling-id expansion must not lose those citations.
+        """
+        # Older revision of the same book, same slug, different revision_date.
+        old_bgb = LawBook.objects.create(
+            code="BGB",
+            title="BGB",
+            slug="bgb",
+            latest=False,
+            revision_date="2020-01-01",
+            review_status="accepted",
+        )
+        old_249 = _make_law(old_bgb, "§ 249", "249")
+        # A law citing the *old* revision's row.
+        citing = _make_law(self.gg, "Artikel 2", "artikel-2")
+        _attach_law_law_ref(citing, old_249, "§ 249")
+
+        resp = self.client.get(f"/api/laws/{self.law_249.id}/citing_laws/")
+
+        self.assertEqual(resp.status_code, 200)
+        ids = {r["id"] for r in resp.json()["results"]}
+        # Both the current-revision citation (law_823) and the one recorded
+        # against the older revision (citing) must be present.
+        self.assertIn(self.law_823.id, ids)
+        self.assertIn(citing.id, ids)
+
     # --- Flat ReferenceViewSet ------------------------------------------
 
     def test_flat_filter_by_cited_by_case_id(self):


### PR DESCRIPTION
## Problem

`/api/laws/<id>/citing_laws/` expanded `(book.code, section)` into every matching `Law` id before looking up citations:

```python
sibling_ids = list(
    Law.objects.filter(
        book__code__iexact=law.book.code,
        section__iexact=law.section,
        review_status="accepted",
    ).values_list("id", flat=True)
)
qs = citing_laws_for_law(sibling_ids or [law.id])
```

Two problems:

1. **`iexact` is unindexable** — this scanned `laws_law` joined to `laws_lawbook` on every request.
2. **The result was immediately thrown away.** `citing_laws_for_law()`'s first step is `_law_to_slug_pair()`, which collapses the id list straight back to a single `(book_slug, section_slug)` pair.

So the endpoint ran **two extra queries — the expensive one unindexed — to derive something already on hand** as `(law.book.slug, law.slug)`.

`citing_laws` is high-volume (~15.4k hits/week) and its slow tail reached **55s** under bot load, contributing to app/ES CPU saturation in production.

## Fix

Pass the slug pair directly:

```python
qs = citing_laws_for_law((law.book.slug, law.slug))
```

That's the input shape `citing_laws_for_law` documents as preferred. The sibling expansion was a leftover from before the slug-pair refactor — `citing_cases` was already migrated and documents exactly this rationale.

## Latent correctness bug also removed

`_law_to_slug_pair()` returns `None` when the id list spans more than one `(book_slug, slug)` pair, and `citing_laws_for_law` maps `None` → `Law.objects.none()`. So a book whose revisions disagreed on slug would **silently return zero citing laws**.

## Behaviour

Unchanged. The `(book_slug, section_slug)` pair is stable across book revisions, so cross-revision lookup stays implicit — covered by a new test that records a citation against a *superseded* revision and asserts it's still returned.

## Tests

- Query-shape pin: no `UPPER(`/`LIKE` in the executed SQL, so the scan can't come back
- Cross-revision resolution still works
- `references` + `laws` + `cases` suites green (**665 tests**), `ruff check`/`format` clean

## Scope note

This is the `citing_laws` half of the citation-endpoint slowness. The `/api/cases/<id>/?format=json` timeouts (the other endpoint family) are **not** addressed here and need separate profiling — both endpoints are already paginated (`CappedLimitOffsetPagination`, `PAGE_SIZE=50`) and `citing_cases` already resolves via Elasticsearch, so that side is already covered; the case-detail serializer cost is not.
