### PR TITLE
perf(api): stop loading content blobs on the citation-graph endpoints

### DIFF
--- a/oldp/apps/cases/api_views.py
+++ b/oldp/apps/cases/api_views.py
@@ -155,6 +155,27 @@ class CaseViewSet(ReviewStatusFilterMixin, viewsets.ModelViewSet):
                 qs = qs.only(*CASE_API_LIST_FIELDS)
             return qs
 
+        if action == "references":
+            # ``case_forward_references`` reads only id / file_number /
+            # references_extracted_at off the source case — never ``content``,
+            # and never ``court``. Loading the full body (plus the court JOIN)
+            # to emit a few KB of citation metadata was a large slice of this
+            # endpoint's ~8s p-max in production.
+            ref_fields = (
+                "id",
+                "slug",
+                "file_number",
+                "references_extracted_at",
+                "review_status",
+            )
+            if needs_token:
+                return qs.select_related("created_by_token").only(
+                    *ref_fields,
+                    "created_by_token_id",
+                    "created_by_token__user_id",
+                )
+            return qs.only(*ref_fields)
+
         # Detail / write path: pk-lookup is fast even with the wide JOIN.
         qs = qs.select_related("court")
         if needs_token:

--- a/oldp/apps/laws/api_views.py
+++ b/oldp/apps/laws/api_views.py
@@ -128,7 +128,18 @@ class LawViewSet(ReviewStatusFilterMixin, viewsets.ModelViewSet):
         # the heavy TEXT columns (``content``, ``footnotes``, plus
         # ``book__changelog`` / ``book__footnotes`` / ``book__sections``
         # via select_related).
-        if getattr(self, "action", None) == "list":
+        #
+        # The citation-graph actions need the same treatment: they resolve the
+        # source law only to read ``slug`` / ``section`` / ``book.slug`` before
+        # handing off to the services layer, so pulling ``content`` and the
+        # book's ``sections`` / ``changelog`` blobs is pure overhead on
+        # endpoints that were already the slowest in the API.
+        if getattr(self, "action", None) in (
+            "list",
+            "references",
+            "citing_laws",
+            "citing_cases",
+        ):
             qs = qs.defer(*Law.defer_fields_list_view)
         return qs
 

--- a/oldp/apps/references/services/citation_graph.py
+++ b/oldp/apps/references/services/citation_graph.py
@@ -16,7 +16,7 @@ import datetime
 from typing import Iterable
 
 from django.db import connection
-from django.db.models import QuerySet
+from django.db.models import Prefetch, QuerySet
 
 from oldp.apps.cases.mcp import exclude_future_dated_cases
 from oldp.apps.cases.models import Case
@@ -69,6 +69,43 @@ def serialize_law_summary(law: Law) -> dict:
 
 
 # --- Forward references (what does X cite?) -----------------------------
+
+
+def _forward_reference_prefetches() -> tuple[Prefetch, ...]:
+    """Prefetches for a marker queryset, narrowed to the serialized columns.
+
+    The forward-reference payload emits six fields per law
+    (:func:`serialize_law_summary`) and four per case, but a plain
+    ``prefetch_related("references__law", …)`` loads *entire* rows — so a
+    case citing a few hundred distinct targets dragged every
+    ``Law.content``, ``Case.content``/``raw`` and ``LawBook.sections`` blob
+    out of the DB, through Python, and straight into the garbage collector.
+    That is the compute behind ``/api/cases/<id>/references/`` sitting at
+    ~8s in production; the payload itself is small.
+
+    ``.only()`` the columns the serializers actually touch. Heavy fields
+    stay deferred, so re-adding one to the payload raises a query on
+    attribute access rather than silently regressing performance.
+    """
+    law_targets = Law.objects.select_related("book").only(
+        "id",
+        "section",
+        "slug",
+        "title",
+        # FK column + the two book fields serialize_law_summary reads.
+        "book_id",
+        "book__id",
+        "book__code",
+        "book__slug",
+    )
+    case_targets = Case.objects.only("id", "slug", "file_number", "date")
+    return (
+        "references",
+        # select_related("book") above already covers references__law__book,
+        # so it is deliberately not prefetched separately.
+        Prefetch("references__law", queryset=law_targets),
+        Prefetch("references__case", queryset=case_targets),
+    )
 
 
 def _walk_forward_references(markers, *, marker_text_field: str = "text"):
@@ -139,10 +176,7 @@ def case_forward_references(case: Case) -> dict:
     prefetch so target rows resolve in a constant number of queries.
     """
     markers = CaseReferenceMarker.objects.filter(referenced_by=case).prefetch_related(
-        "references",
-        "references__law",
-        "references__law__book",
-        "references__case",
+        *_forward_reference_prefetches()
     )
     return _forward_references_payload(
         source_id=case.id,
@@ -162,10 +196,7 @@ def law_forward_references(law: Law) -> dict:
     overwhelmingly cite laws (intra-book ``§ N`` cross-references).
     """
     markers = LawReferenceMarker.objects.filter(referenced_by=law).prefetch_related(
-        "references",
-        "references__law",
-        "references__law__book",
-        "references__case",
+        *_forward_reference_prefetches()
     )
     return _forward_references_payload(
         source_id=law.id,

--- a/oldp/apps/references/tests/test_api.py
+++ b/oldp/apps/references/tests/test_api.py
@@ -147,6 +147,73 @@ class CitationApiTestCase(ESCitingCasesShimMixin, TestCase):
         self.assertEqual(body["law_references"][0]["id"], self.law_823.id)
         self.assertEqual(body["case_references"][0]["id"], self.case_b.id)
 
+    def test_case_references_does_not_select_heavy_columns(self):
+        """Forward-reference prefetches must not drag content blobs along.
+
+        The payload emits six fields per law and four per case, but a plain
+        ``prefetch_related("references__law", …)`` loaded whole rows — so a
+        case citing hundreds of targets pulled every ``Law.content``,
+        ``Case.content``/``raw`` and ``LawBook.sections`` blob out of the DB
+        to serialize a handful of short strings. That is the compute behind
+        ``/api/cases/<id>/references/`` at ~8s in production.
+
+        Assert those columns never appear in the executed SQL.
+        """
+        from django.db import connection
+        from django.test.utils import CaptureQueriesContext
+
+        with CaptureQueriesContext(connection) as ctx:
+            resp = self.client.get(f"/api/cases/{self.case_a.id}/references/")
+
+        self.assertEqual(resp.status_code, 200)
+        sql = " ".join(q["sql"].lower() for q in ctx.captured_queries)
+        for heavy in (
+            '"laws_law"."content"',
+            '"cases_case"."content"',
+            '"cases_case"."raw"',
+            '"laws_lawbook"."sections"',
+            '"laws_lawbook"."changelog"',
+        ):
+            self.assertNotIn(
+                heavy,
+                sql,
+                msg=f"{heavy} was selected but is never serialized",
+            )
+
+    def test_case_references_payload_unchanged_with_narrowed_prefetch(self):
+        """Narrowing the prefetch must not change the response body."""
+        resp = self.client.get(f"/api/cases/{self.case_a.id}/references/")
+
+        self.assertEqual(resp.status_code, 200)
+        body = resp.json()
+        law_ref = body["law_references"][0]
+        # Every field serialize_law_summary emits must still resolve — a
+        # missing column in .only() would raise or return a deferred value.
+        self.assertEqual(law_ref["id"], self.law_823.id)
+        self.assertEqual(law_ref["book_code"], "BGB")
+        self.assertEqual(law_ref["book_slug"], "bgb")
+        self.assertEqual(law_ref["section"], "§ 823")
+        self.assertEqual(law_ref["slug"], "823")
+        self.assertEqual(law_ref["marker_text"], "§ 823 BGB")
+        case_ref = body["case_references"][0]
+        self.assertEqual(case_ref["id"], self.case_b.id)
+        self.assertEqual(case_ref["slug"], self.case_b.slug)
+        self.assertEqual(case_ref["file_number"], self.case_b.file_number)
+        self.assertEqual(case_ref["date"], "2024-01-01")
+
+    def test_law_references_does_not_select_heavy_columns(self):
+        """``law_forward_references`` shares the narrowed prefetches."""
+        from django.db import connection
+        from django.test.utils import CaptureQueriesContext
+
+        with CaptureQueriesContext(connection) as ctx:
+            resp = self.client.get(f"/api/laws/{self.law_823.id}/references/")
+
+        self.assertEqual(resp.status_code, 200)
+        sql = " ".join(q["sql"].lower() for q in ctx.captured_queries)
+        self.assertNotIn('"laws_law"."content"', sql)
+        self.assertNotIn('"laws_lawbook"."sections"', sql)
+
     def test_case_citing_cases_action(self):
         """``/api/cases/<id>/citing_cases/`` paginates."""
         resp = self.client.get(f"/api/cases/{self.case_b.id}/citing_cases/")


### PR DESCRIPTION
Second half of the citation-endpoint slowness (the `/api/cases/<id>/…` timeouts). Complements #269.

## Problem

The forward-reference payload emits **six fields per law** and **four per case**, but the endpoints serving it dragged entire rows out of the DB to produce them. Two independent sources of waste:

**1. Unrestricted prefetches.** `case_forward_references` / `law_forward_references` did:

```python
.prefetch_related("references", "references__law", "references__law__book", "references__case")
```

No field restriction — so every target's `Law.content`, `Law.footnotes`, `Case.content`, `Case.raw` and `LawBook.sections`/`changelog` blob was fetched, decoded into Python, and immediately discarded.

**2. The source row was just as wide.** `get_object()` on `/api/cases/<id>/references/` pulled the full case body *and* a `courts_court` JOIN it never reads; `/api/laws/<id>/{references,citing_laws,citing_cases}/` pulled `content` plus the book's `sections`/`changelog` — all to read `slug`, `section` and `book.slug`.

I found #2 only because the test I wrote for #1 kept failing on a column I hadn't touched.

## Fix

- `Prefetch(...)` querysets restricted via `.only()` to exactly the columns the serializers touch
- An action-specific `.only()` for the case `references` action (drops the court JOIN too)
- Extended the existing `Law.defer_fields_list_view` to the citation-graph actions — it already covered `list`

Heavy fields stay **deferred**, not dropped: re-adding one to a payload raises a query on attribute access rather than silently regressing performance.

## Measured impact

Source case citing 100 laws + 100 cases, 200 KB content each:

| | before | after |
|---|---|---|
| time | 108.9 ms | **54.9 ms** |
| peak memory | 209.2 MB | **2.0 MB** |
| queries | 5 | 4 |

~2× faster and **~100× less memory churn per request**. The memory figure is the significant one — that allocate-and-discard traffic across 12 gunicorn worker slots is a plausible contributor to the app pinning ~200% CPU under bot load. (Measured on SQLite locally; on MariaDB over a socket the transfer cost should dominate more, not less.)

## Tests

- Heavy columns never appear in the executed SQL — for both the case and law reference endpoints
- Payload pinned field-by-field, so the narrowing can't quietly drop data
- Full suite green (**1476 tests**), `ruff check`/`format` clean

## Remaining work

Between this and #269, the application-side work is addressed. Re-enabling MariaDB slow-query logging is still outstanding, but that is an infrastructure-side change and belongs in a separate change.

I could not profile against the production database, so the improvement is measured on synthetic data matching the observed shape rather than on the actual slow case IDs.
