### PR TITLE
perf(api): drop the apitoken JOIN from the review-status filter

### DIFF
--- a/oldp/api/mixins.py
+++ b/oldp/api/mixins.py
@@ -6,17 +6,53 @@ Provides review_status-based filtering and field visibility control.
 from django.db.models import Q
 
 
+def _own_token_ids(request, user) -> list[int]:
+    """Ids of ``user``'s API tokens, memoised on the request.
+
+    ``filter_by_review_status`` runs several times per request (DRF calls
+    ``get_queryset`` for the list, the filter backend and the paginator), so
+    resolve this once and hang it off the request.
+    """
+    cached = getattr(request, "_oldp_own_token_ids", None)
+    if cached is not None:
+        return cached
+
+    # Local import: the accounts app imports from oldp.api, so a module-level
+    # import here would close a cycle.
+    from oldp.apps.accounts.models import APIToken
+
+    token_ids = list(APIToken.objects.filter(user=user).values_list("id", flat=True))
+    try:
+        request._oldp_own_token_ids = token_ids
+    except AttributeError:  # pragma: no cover - exotic request objects
+        pass
+    return token_ids
+
+
 def filter_by_review_status(qs, request):
     """Restrict ``qs`` by ``review_status`` according to the request's user.
 
     - Staff: full queryset
     - Authenticated non-staff: accepted items plus items they created
-      (matched via ``created_by_token__user``)
     - Anonymous, no request, or request without a user: accepted only
 
     Used by :class:`ReviewStatusFilterMixin` for DRF viewsets and by the
     ``Case.get_queryset`` / ``Law.get_queryset`` / ``LawBook.get_queryset``
     static methods so all entry points share one rule.
+
+    The own-content branch matches ``created_by_token_id`` against a
+    materialised id list rather than traversing ``created_by_token__user``.
+    That traversal put a ``LEFT OUTER JOIN accounts_apitoken`` inside an
+    ``OR``, which the planner cannot trim -- and which survived into DRF's
+    pagination ``COUNT(*)``, producing
+
+        SELECT COUNT(*) FROM cases_case LEFT OUTER JOIN accounts_apitoken ...
+
+    at ~4.3s and 585k rows examined per call in the prod slow log
+    (internal-tools#5). A user has a handful of tokens, so the id list is tiny
+    and the extra lookup is an indexed hit on a small table -- the same
+    materialise-then-``IN`` shape the citation-graph helpers already use to
+    keep MariaDB on a sane plan.
     """
     if request is None or not hasattr(request, "user"):
         return qs.filter(review_status="accepted")
@@ -27,7 +63,14 @@ def filter_by_review_status(qs, request):
         return qs
 
     if user.is_authenticated:
-        return qs.filter(Q(review_status="accepted") | Q(created_by_token__user=user))
+        token_ids = _own_token_ids(request, user)
+        if not token_ids:
+            # No tokens -> the OR branch can never match. Skip it rather than
+            # emitting an empty IN ().
+            return qs.filter(review_status="accepted")
+        return qs.filter(
+            Q(review_status="accepted") | Q(created_by_token_id__in=token_ids)
+        )
 
     return qs.filter(review_status="accepted")
 

--- a/oldp/api/tests/test_mixins.py
+++ b/oldp/api/tests/test_mixins.py
@@ -116,3 +116,65 @@ class FilterByReviewStatusTestCase(TestCase):
     def test_other_user_sees_only_accepted(self):
         qs = filter_by_review_status(Case.objects.all(), self._request(self.user_b))
         self.assertEqual(self._slugs(qs), {"ACC"})
+
+    # --- Query shape (internal-tools#5) ---------------------------------
+
+    def test_owner_filter_does_not_join_apitoken(self):
+        """The own-content branch must not JOIN accounts_apitoken.
+
+        Traversing ``created_by_token__user`` inside an ``OR`` produced a
+        LEFT OUTER JOIN the planner could not trim. It survived into DRF's
+        pagination ``COUNT(*)``, which the prod slow log recorded at ~4.3s
+        and 585k rows examined per call.
+        """
+        qs = filter_by_review_status(Case.objects.all(), self._request(self.user_a))
+
+        sql = str(qs.query).lower()
+        self.assertNotIn("accounts_apitoken", sql)
+        self.assertNotIn("join", sql)
+
+    def test_owner_count_does_not_join_apitoken(self):
+        """The same must hold for the COUNT(*) the paginator issues."""
+        from django.db import connection
+        from django.test.utils import CaptureQueriesContext
+
+        qs = filter_by_review_status(Case.objects.all(), self._request(self.user_a))
+
+        with CaptureQueriesContext(connection) as ctx:
+            self.assertEqual(qs.count(), 2)
+
+        count_sql = " ".join(
+            q["sql"].lower()
+            for q in ctx.captured_queries
+            if "count(" in q["sql"].lower()
+        )
+        self.assertTrue(count_sql, "expected a COUNT query to be captured")
+        self.assertNotIn("accounts_apitoken", count_sql)
+
+    def test_token_ids_are_resolved_once_per_request(self):
+        """Repeated calls on one request must not re-query the token table."""
+        from django.db import connection
+        from django.test.utils import CaptureQueriesContext
+
+        request = self._request(self.user_a)
+
+        with CaptureQueriesContext(connection) as ctx:
+            for _ in range(3):
+                filter_by_review_status(Case.objects.all(), request)
+
+        token_queries = [
+            q for q in ctx.captured_queries if "accounts_apitoken" in q["sql"].lower()
+        ]
+        self.assertEqual(
+            len(token_queries),
+            1,
+            msg=f"token ids should be memoised on the request, got {len(token_queries)} queries",
+        )
+
+    def test_user_without_tokens_sees_accepted_only(self):
+        """No tokens must short-circuit rather than emit an empty IN ()."""
+        qs = filter_by_review_status(Case.objects.all(), self._request(self.user_b))
+
+        sql = str(qs.query).lower()
+        self.assertNotIn("in ()", sql)
+        self.assertEqual(self._slugs(qs), {"ACC"})


### PR DESCRIPTION
Refs openlegaldata/internal-tools#5 — finding ③ from the slow-log analysis.

## Problem

For authenticated non-staff users, `filter_by_review_status` applied:

```python
Q(review_status="accepted") | Q(created_by_token__user=user)
```

Traversing `created_by_token__user` **inside an `OR`** puts a `LEFT OUTER JOIN accounts_apitoken` in the query — and because it sits under an `OR`, the planner can't trim it. It survived into DRF's pagination `COUNT(*)`. From the prod slow log:

```
SELECT COUNT(*) AS `__count` FROM `cases_case` LEFT OUTER JOIN `accounts_apitoken` ...
```

**avg 4.3s · max 6.8s · 585,476 rows examined** per call, 23 calls in the sampled week.

## Fix

Match `created_by_token_id` against a materialised id list instead. A user has a handful of tokens, so the list is tiny and resolving it is an indexed hit on a small table — the same materialise-then-`IN` shape the citation-graph helpers already use to keep MariaDB on a sane plan.

The ids are memoised on the request, since DRF calls `get_queryset` several times per request (list, filter backend, paginator). Users with no tokens short-circuit to the accepted-only filter rather than emitting an empty `IN ()`.

## Behaviour

Unchanged. The existing visibility tests — staff sees all, owner sees accepted + own, other users see accepted only, anonymous / no-request / no-user — all pass **untouched**.

## Tests

New pins:
- neither the list query nor the `COUNT(*)` joins `accounts_apitoken`
- the token lookup happens exactly once per request
- a token-less user produces no empty `IN ()`

Full suite green (**1477 tests**), `ruff` clean.

## Note

This is one of five findings from a fresh analysis of five months of previously-unread slow-query data. The others are being fixed separately.