### PR TITLE
perf(api): cache the pagination COUNT(*) on the LimitOffset path

### DIFF
--- a/oldp/api/__init__.py
+++ b/oldp/api/__init__.py
@@ -5,7 +5,10 @@ from rest_framework.exceptions import NotFound
 from rest_framework.pagination import LimitOffsetPagination, PageNumberPagination
 from rest_framework.permissions import DjangoModelPermissionsOrAnonReadOnly
 
-from oldp.utils.cached_count_paginator import CachedCountPaginator
+from oldp.utils.cached_count_paginator import (
+    CachedCountPaginator,
+    cached_queryset_count,
+)
 
 schema_view = get_schema_view(
     openapi.Info(
@@ -67,3 +70,17 @@ class CappedLimitOffsetPagination(LimitOffsetPagination):
     def paginate_queryset(self, queryset, request, view=None):
         _reject_deep_offset(request, settings.PAGINATE_UNTIL * self.max_limit)
         return super().paginate_queryset(queryset, request, view)
+
+    def get_count(self, queryset):
+        """Cache the pagination ``COUNT(*)``.
+
+        ``SmallResultsSetPagination`` gets this for free via
+        ``django_paginator_class = CachedCountPaginator``, but
+        ``LimitOffsetPagination`` never builds a Django ``Paginator`` — it
+        calls ``queryset.count()`` here directly, so the cache was bypassed on
+        every endpoint using the *default* pagination class (references, laws,
+        courts...). The prod slow log showed the cost: a bare
+        ``SELECT COUNT(*) FROM references_reference`` examining 18.6M rows at
+        ~3.3s a call (internal-tools#5).
+        """
+        return cached_queryset_count(queryset)

--- a/oldp/api/tests/test_pagination.py
+++ b/oldp/api/tests/test_pagination.py
@@ -112,3 +112,80 @@ class CappedLimitOffsetPaginationTests(TestCase):
 
     def test_non_integer_offset_is_ignored(self):
         self.paginator.paginate_queryset(list(range(10)), self._request(offset="bogus"))
+
+
+@override_settings(
+    # TestConfiguration pins DummyCache, so cache.set/get are no-ops and the
+    # caching under test would be invisible. Use a real local-memory backend.
+    CACHES={
+        "default": {
+            "BACKEND": "django.core.cache.backends.locmem.LocMemCache",
+            "LOCATION": "pagination-count-tests",
+        }
+    }
+)
+class CappedLimitOffsetCountCachingTests(TestCase):
+    """The LimitOffset path must cache its COUNT(*) (internal-tools#5).
+
+    ``SmallResultsSetPagination`` gets caching via
+    ``django_paginator_class = CachedCountPaginator``, but
+    ``LimitOffsetPagination`` never builds a Django ``Paginator`` — it calls
+    ``get_count()`` directly, so every endpoint on the *default* pagination
+    class re-ran the count on each page. On ``references_reference`` that
+    meant scanning 18.6M rows per request.
+    """
+
+    fixtures = [
+        "locations/countries.json",
+        "locations/states.json",
+        "locations/cities.json",
+        "courts/courts.json",
+    ]
+
+    def setUp(self):
+        from django.core.cache import cache
+
+        cache.clear()
+        self.paginator = CappedLimitOffsetPagination()
+
+    def _queryset(self):
+        from oldp.apps.courts.models import Court
+
+        return Court.objects.all().order_by("id")
+
+    def test_count_is_correct(self):
+        qs = self._queryset()
+        self.assertEqual(self.paginator.get_count(qs), qs.count())
+
+    def test_second_call_issues_no_count_query(self):
+        from django.db import connection
+        from django.test.utils import CaptureQueriesContext
+
+        qs = self._queryset()
+        first = self.paginator.get_count(qs)
+
+        with CaptureQueriesContext(connection) as ctx:
+            second = self.paginator.get_count(qs)
+
+        self.assertEqual(first, second)
+        count_queries = [
+            q for q in ctx.captured_queries if "count(" in q["sql"].lower()
+        ]
+        self.assertEqual(
+            count_queries, [], msg="COUNT(*) should have been served from cache"
+        )
+
+    def test_distinct_querysets_cache_independently(self):
+        from oldp.apps.courts.models import Court
+
+        all_courts = Court.objects.all().order_by("id")
+        subset = Court.objects.filter(pk=Court.DEFAULT_ID).order_by("id")
+
+        self.assertEqual(self.paginator.get_count(all_courts), all_courts.count())
+        self.assertEqual(self.paginator.get_count(subset), subset.count())
+        self.assertNotEqual(
+            self.paginator.get_count(all_courts), self.paginator.get_count(subset)
+        )
+
+    def test_non_queryset_falls_back_to_len(self):
+        self.assertEqual(self.paginator.get_count([1, 2, 3]), 3)

--- a/oldp/utils/cached_count_paginator.py
+++ b/oldp/utils/cached_count_paginator.py
@@ -1,9 +1,52 @@
 import hashlib
+import logging
 
 from django.conf import settings
 from django.core.cache import cache
 from django.core.paginator import Paginator
 from django.utils.functional import cached_property
+
+logger = logging.getLogger(__name__)
+
+CACHE_KEY_PREFIX = "paginator_count"
+
+
+def _count_cache_key(queryset) -> str:
+    """Cache key derived from the queryset's SQL fingerprint."""
+    sql = str(queryset.query)
+    sql_hash = hashlib.md5(sql.encode()).hexdigest()
+    return f"{CACHE_KEY_PREFIX}:{sql_hash}"
+
+
+def cached_queryset_count(queryset) -> int:
+    """``queryset.count()``, memoised in the cache for ``CACHE_TTL`` seconds.
+
+    Pagination issues a ``COUNT(*)`` before every page. On large tables that
+    count dominates the request: the prod slow log had a bare
+    ``SELECT COUNT(*) FROM references_reference`` examining **18.6 million
+    rows** to return one number, at ~3.3s a call (internal-tools#5).
+
+    Keyed on the queryset SQL, so filtered and unfiltered variants cache
+    independently. The trade-off is that a reported total can lag by up to
+    ``CACHE_TTL`` — acceptable for list pagination, and the same trade-off
+    ``CachedCountPaginator`` already makes for the page-number endpoints.
+
+    Falls back to an uncached ``count()`` if anything goes wrong, so a cache
+    outage degrades to today's behaviour rather than erroring.
+    """
+    if not hasattr(queryset, "query"):
+        return len(queryset)
+    try:
+        cache_key = _count_cache_key(queryset)
+        cached_count = cache.get(cache_key)
+        if cached_count is not None:
+            return cached_count
+        real_count = queryset.count()
+        cache.set(cache_key, real_count, settings.CACHE_TTL)
+        return real_count
+    except Exception:
+        logger.warning("Cached count failed; falling back to COUNT(*)", exc_info=True)
+        return queryset.count()
 
 
 class CachedCountPaginator(Paginator):
@@ -13,26 +56,13 @@ class CachedCountPaginator(Paginator):
     Falls back to the standard count() if caching fails.
     """
 
-    CACHE_KEY_PREFIX = "paginator_count"
+    CACHE_KEY_PREFIX = CACHE_KEY_PREFIX
 
     def _get_cache_key(self):
         """Generate a cache key from the queryset's SQL."""
-        sql = str(self.object_list.query)
-        sql_hash = hashlib.md5(sql.encode()).hexdigest()
-        return f"{self.CACHE_KEY_PREFIX}:{sql_hash}"
+        return _count_cache_key(self.object_list)
 
     @cached_property
     def count(self):
         """Return the total number of objects, using cache for QuerySets."""
-        if not hasattr(self.object_list, "query"):
-            return len(self.object_list)
-        try:
-            cache_key = self._get_cache_key()
-            cached_count = cache.get(cache_key)
-            if cached_count is not None:
-                return cached_count
-            real_count = self.object_list.count()
-            cache.set(cache_key, real_count, settings.CACHE_TTL)
-            return real_count
-        except Exception:
-            return self.object_list.count()
+        return cached_queryset_count(self.object_list)


### PR DESCRIPTION
Refs openlegaldata/internal-tools#5 — finding ② from the slow-log analysis.

## Problem

`SmallResultsSetPagination` gets count caching for free via `django_paginator_class = CachedCountPaginator`. But `LimitOffsetPagination` **never builds a Django `Paginator`** — it calls `get_count()`, and hence `queryset.count()`, directly. So the cache was silently bypassed on every endpoint using the *default* pagination class: references, laws, courts…

The prod slow log shows the cost:

```
SELECT COUNT(*) AS `__count` FROM `references_reference`
```

**18,637,840 rows examined to return a single number** — avg 3.3s, max 4.5s, 30 calls in the sampled week.

## Fix

Extract the caching from `CachedCountPaginator` into a reusable `cached_queryset_count()` and call it from `CappedLimitOffsetPagination.get_count()`. Keyed on the queryset SQL, so filtered and unfiltered variants cache independently.

Falls back to an uncached `count()` on any failure, so a cache outage degrades to today's behaviour rather than erroring — now `logger.warning`-ed instead of silently swallowed.

## Trade-off

A reported total can lag by up to `CACHE_TTL`. That's the same trade-off `CachedCountPaginator` already makes for the page-number endpoints, and it only affects the `count` field — **never which rows are returned**.

## Worth flagging

This caching was **previously untested**. `TestConfiguration` pins `DummyCache`, so `cache.set`/`get` are no-ops and the behaviour was invisible to the suite — the existing `CachedCountPaginator` had no effective coverage either. The new tests override with a real `LocMemCache`.

## Tests

- count is correct
- a second call issues **no** COUNT query
- distinct querysets cache independently
- a non-queryset falls back to `len()`

Full suite green (**1477 tests**), `ruff` clean.