### PR TITLE
perf(cases): cache the citing-case id lookup for has_reference_to_law

### DIFF
--- a/oldp/apps/cases/filters.py
+++ b/oldp/apps/cases/filters.py
@@ -1,5 +1,8 @@
+import logging
+
 import django_filters
 from django.conf import settings
+from django.core.cache import cache
 from django.db import connection, models
 from django.forms import HiddenInput, TextInput
 from django.forms.widgets import NumberInput
@@ -17,6 +20,61 @@ from oldp.apps.lib.widgets import (
     CheckboxLinkWidget,
     VisibleIfSetWidget,
 )
+
+logger = logging.getLogger(__name__)
+
+
+# Bound what we're willing to hold in the cache. Past this the id list is
+# large enough that pickling it costs more than re-running the query, and the
+# API can't surface results that deep anyway (PAGINATE_UNTIL * max_limit).
+_CITING_IDS_CACHE_MAX = 50_000
+
+
+def _citing_case_ids_for_law(law_id) -> list[int]:
+    """Ids of cases citing ``law_id``, cached for ``CACHE_TTL`` seconds.
+
+    The underlying join walks ~55k rows to return ~9.7k ids for a popular
+    section, and the prod slow log clocked it at avg 3.4s / **max 10.0s** --
+    the upstream gateway timeout -- over 237 calls in a week
+    (internal-tools#5). The docstring on the caller claims ~300ms; production
+    disagrees.
+
+    Caching is safe because this id set is purely *structural*: the query
+    filters only on ``reference.law_id`` and applies no ``review_status``
+    predicate, so the result does not vary by user. Visibility is applied
+    afterwards by the caller's queryset, which is what keeps this cache
+    shareable across anonymous, owner and staff requests alike.
+
+    The set only changes when references are re-extracted (a batch job), so a
+    ``CACHE_TTL`` staleness window is well within tolerance.
+    """
+    cache_key = f"citing_case_ids:law:{law_id}"
+    try:
+        cached = cache.get(cache_key)
+        if cached is not None:
+            return cached
+    except Exception:
+        logger.warning("Citing-case id cache read failed", exc_info=True)
+
+    hint = "STRAIGHT_JOIN" if connection.vendor == "mysql" else ""
+    sql = f"""
+        SELECT {hint} DISTINCT m.referenced_by_id
+        FROM references_reference r
+        JOIN references_casereferencemarker_references mr ON mr.reference_id = r.id
+        JOIN references_casereferencemarker m ON m.id = mr.casereferencemarker_id
+        WHERE r.law_id = %s
+    """
+    with connection.cursor() as cur:
+        cur.execute(sql, (law_id,))
+        case_ids = [row[0] for row in cur.fetchall() if row[0] is not None]
+
+    if len(case_ids) <= _CITING_IDS_CACHE_MAX:
+        try:
+            cache.set(cache_key, case_ids, settings.CACHE_TTL)
+        except Exception:
+            logger.warning("Citing-case id cache write failed", exc_info=True)
+
+    return case_ids
 
 
 class BaseCaseFilter(FilterSet):
@@ -77,18 +135,10 @@ class BaseCaseFilter(FilterSet):
         20-25s on heavily cited sections such as ``§ 823 BGB`` because
         MariaDB couldn't push ``ORDER BY date DESC LIMIT N`` through the
         wide JOIN + DISTINCT; the split shape runs in ~300ms.
+
+        The id resolution is cached: see :func:`_citing_case_ids_for_law`.
         """
-        hint = "STRAIGHT_JOIN" if connection.vendor == "mysql" else ""
-        sql = f"""
-            SELECT {hint} DISTINCT m.referenced_by_id
-            FROM references_reference r
-            JOIN references_casereferencemarker_references mr ON mr.reference_id = r.id
-            JOIN references_casereferencemarker m ON m.id = mr.casereferencemarker_id
-            WHERE r.law_id = %s
-        """
-        with connection.cursor() as cur:
-            cur.execute(sql, (value,))
-            case_ids = [row[0] for row in cur.fetchall() if row[0] is not None]
+        case_ids = _citing_case_ids_for_law(value)
         if not case_ids:
             return queryset.none()
         return queryset.filter(id__in=case_ids)

--- a/oldp/apps/cases/tests/test_citing_ids_cache.py
+++ b/oldp/apps/cases/tests/test_citing_ids_cache.py
@@ -1,0 +1,157 @@
+"""Tests for the cached citing-case id resolution (internal-tools#5).
+
+``?has_reference_to_law=<id>`` resolved its case ids with a join that walked
+~55k rows for a popular section, clocking avg 3.4s / max 10.0s (the upstream
+gateway timeout) in the prod slow log. The ids are now cached.
+
+The critical property under test is that caching cannot leak visibility: the
+cached list is *structural* (it filters only on ``reference.law_id``), and
+review-status filtering happens afterwards on the caller's queryset.
+"""
+
+from datetime import date
+
+from django.contrib.auth import get_user_model
+from django.core.cache import cache
+from django.db import connection
+from django.test import TestCase, override_settings
+from django.test.utils import CaptureQueriesContext
+
+from oldp.apps.cases.filters import _citing_case_ids_for_law
+from oldp.apps.cases.models import Case
+from oldp.apps.courts.models import Court
+from oldp.apps.laws.models import Law, LawBook
+from oldp.apps.references.models import (
+    CaseReferenceMarker,
+    Reference,
+    ReferenceFromCase,
+)
+
+User = get_user_model()
+
+LOCMEM = {
+    "default": {
+        "BACKEND": "django.core.cache.backends.locmem.LocMemCache",
+        "LOCATION": "citing-ids-tests",
+    }
+}
+
+
+@override_settings(CACHES=LOCMEM)
+class CitingCaseIdsCacheTestCase(TestCase):
+    fixtures = [
+        "locations/countries.json",
+        "locations/states.json",
+        "locations/cities.json",
+        "courts/courts.json",
+    ]
+
+    @classmethod
+    def setUpTestData(cls):
+        court = Court.objects.exclude(pk=Court.DEFAULT_ID).first()
+        book = LawBook.objects.create(
+            code="BGB",
+            title="BGB",
+            slug="bgb",
+            latest=True,
+            revision_date="2024-01-01",
+            review_status="accepted",
+        )
+        cls.law = Law.objects.create(
+            book=book, section="§ 823", slug="823", review_status="accepted"
+        )
+        cls.other_law = Law.objects.create(
+            book=book, section="§ 249", slug="249", review_status="accepted"
+        )
+
+        # Two cases cite the law: one accepted, one still pending.
+        cls.accepted = cls._citing_case(court, cls.law, "ZQACC", "accepted")
+        cls.pending = cls._citing_case(court, cls.law, "ZQPEND", "pending")
+        # A case citing nothing, to prove the filter actually constrains.
+        cls.unrelated = Case.objects.create(
+            court=court,
+            file_number="ZQUNREL",
+            slug="zqunrel",
+            date=date(2024, 1, 3),
+            ecli="ECLI:DE:TEST:ZQUNREL",
+            review_status="accepted",
+        )
+
+    @classmethod
+    def _citing_case(cls, court, law, tag, review_status):
+        case = Case.objects.create(
+            court=court,
+            file_number=tag,
+            slug=tag.lower(),
+            date=date(2024, 1, 1),
+            ecli=f"ECLI:DE:TEST:{tag}",
+            review_status=review_status,
+        )
+        marker = CaseReferenceMarker.objects.create(
+            referenced_by=case, text="§ 823 BGB", start=0, end=9
+        )
+        ref = Reference.objects.create(law=law, to="§ 823 BGB")
+        ref.set_to_hash()
+        ref.save()
+        ReferenceFromCase.objects.create(marker=marker, reference=ref)
+        return case
+
+    def setUp(self):
+        cache.clear()
+
+    def test_resolves_citing_case_ids(self):
+        ids = _citing_case_ids_for_law(self.law.id)
+
+        self.assertEqual(set(ids), {self.accepted.id, self.pending.id})
+
+    def test_second_call_issues_no_sql(self):
+        _citing_case_ids_for_law(self.law.id)
+
+        with CaptureQueriesContext(connection) as ctx:
+            again = _citing_case_ids_for_law(self.law.id)
+
+        self.assertEqual(set(again), {self.accepted.id, self.pending.id})
+        self.assertEqual(
+            ctx.captured_queries, [], msg="ids should have been served from cache"
+        )
+
+    def test_distinct_laws_cache_independently(self):
+        self.assertEqual(
+            set(_citing_case_ids_for_law(self.law.id)),
+            {self.accepted.id, self.pending.id},
+        )
+        self.assertEqual(_citing_case_ids_for_law(self.other_law.id), [])
+
+    def test_law_with_no_citers_returns_empty(self):
+        self.assertEqual(_citing_case_ids_for_law(self.other_law.id), [])
+
+    def test_cache_does_not_leak_pending_cases_to_anonymous(self):
+        """The shared id cache must not bypass per-user visibility.
+
+        The cached list intentionally contains the pending case. Whether a
+        requester may *see* it is decided afterwards, by the queryset the
+        filter is applied to — so priming the cache as one user must not
+        change what another user gets.
+        """
+        # Prime the cache (contains both accepted and pending ids).
+        primed = _citing_case_ids_for_law(self.law.id)
+        self.assertIn(self.pending.id, primed)
+
+        url = f"/case/?has_reference_to_law={self.law.id}"
+
+        anon = self.client.get(url)
+        self.assertEqual(anon.status_code, 200)
+        self.assertContains(anon, "zqacc")
+        self.assertNotContains(anon, "zqpend")
+
+        staff = User.objects.create_user(username="s", password="x", is_staff=True)
+        self.client.force_login(staff)
+        as_staff = self.client.get(url)
+        self.assertEqual(as_staff.status_code, 200)
+        self.assertContains(as_staff, "zqpend")
+
+    def test_filter_excludes_non_citing_cases(self):
+        res = self.client.get(f"/case/?has_reference_to_law={self.law.id}")
+
+        self.assertEqual(res.status_code, 200)
+        self.assertNotContains(res, "zqunrel")


### PR DESCRIPTION
Refs openlegaldata/internal-tools#5 — finding ①, the single largest consumer of DB time in the sampled week.

## Problem

`?has_reference_to_law=<id>` resolves citing case ids with a reference → marker join, then filters `id__in=[...]`. For a popular section that join walks **~55k rows to return ~9.7k ids**. From the prod slow log:

| | |
|---|---|
| Calls (1 week) | 237 |
| Avg | **3.4s** |
| Max | **10.0s** |
| Total DB time | 13.5 min |

10.0s is the upstream gateway timeout — the worst of these were served to users as **errors**.

The existing docstring claims the split-query shape runs in "~300ms". Production disagrees by an order of magnitude.

## Why caching, not a rewrite

The join is already near-optimal: examined:sent is **~6:1**, so `refs_ref_law_idx` is being used and the cost is inherent join fan-out, not a bad plan. There's no index to add.

I considered routing this through Elasticsearch, as `citing_cases` already does — but rejected it. `citing_cases_queryset_via_es` filters `review_status="accepted"` internally, whereas this filter defers visibility to the caller's queryset. Swapping it in would silently hide staff/owners' own pending cases from the filter, and would make a web-UI filter hard-depend on ES availability. Caching gets most of the win with none of that risk.

## Why the cache is safe to share across users

The id set is **purely structural** — the query filters only on `reference.law_id` and applies no `review_status` predicate, so it doesn't vary by requester. Visibility is applied *afterwards*, by the queryset the filter receives.

A test pins exactly this: prime the cache (it does contain a pending case's id), then assert an anonymous request still can't see that case while staff can.

## Details

- Only changes when references are re-extracted (a batch job), so a `CACHE_TTL` staleness window is well within tolerance.
- Lists above 50k ids aren't cached, to bound what gets pickled.
- Cache read/write failures are logged and fall through to the query — a cache outage degrades to today's behaviour rather than erroring.

## Tests

Correct ids · second call issues no SQL · distinct laws cache independently · empty result for an uncited law · non-citing cases excluded · **visibility-leak pin**.

Full suite green (**1479 tests**), `ruff` clean.

> One test initially failed on `assertNotContains(res, "pend")` — that turned out to be a substring collision with "pending" in the markup, not a real leak. Slugs are now unambiguous so the assertion tests what it claims to.