### PR TITLE
chore: drop references to private repositories from source comments

### DIFF
--- a/oldp/api/tests/test_write_authz.py
+++ b/oldp/api/tests/test_write_authz.py
@@ -1,13 +1,14 @@
 """End-to-end authorization tests for content write endpoints.
 
-Regression tests for the API write-authz hardening (internal-tools #14 & #15):
+Regression tests for the API write-authz hardening, covering two linked
+authorization gaps:
 
-* #14 — a website **session**-authenticated user (no API token) must not be able
-  to perform token-gated writes; ``HasTokenPermission`` previously allowed any
-  non-token authenticated request.
-* #15 — mutating a law / law book / court (including flipping ``review_status``
-  to publish) is a moderation action and must be **staff-only**, mirroring the
-  guard already present on ``CaseViewSet``.
+* **Session bypass** — a website **session**-authenticated user (no API token)
+  must not be able to perform token-gated writes; ``HasTokenPermission``
+  previously allowed any non-token authenticated request.
+* **Missing staff guard** — mutating a law / law book / court (including
+  flipping ``review_status`` to publish) is a moderation action and must be
+  **staff-only**, mirroring the guard already present on ``CaseViewSet``.
 """
 
 from datetime import date

--- a/oldp/apps/accounts/management/commands/purge_unverified_users.py
+++ b/oldp/apps/accounts/management/commands/purge_unverified_users.py
@@ -6,7 +6,7 @@ never confirmed). This is separate from the inactive-account lifecycle
 (``warn_inactive_users`` / ``purge_inactive_users``), which only ever touches
 *verified* accounts.
 
-Scriptable by design (see internal-tools ``purge_unverified_users.sh``):
+Scriptable by design:
 
     python manage.py purge_unverified_users --dry-run        # list, delete nothing
     python manage.py purge_unverified_users --limit 100 --yes  # delete a batch

--- a/oldp/apps/accounts/permissions.py
+++ b/oldp/apps/accounts/permissions.py
@@ -51,8 +51,7 @@ class HasTokenPermission(permissions.BasePermission):
         # require staff for writes so session auth cannot bypass the
         # deny-by-default write gating the token model enforces. Previously this
         # branch returned True unconditionally, which let any logged-in user
-        # perform token-gated writes via the browsable API / session (see
-        # internal-tools #14).
+        # perform token-gated writes via the browsable API / session.
         from oldp.apps.accounts.models import APIToken
 
         if not isinstance(getattr(request, "auth", None), APIToken):

--- a/oldp/apps/accounts/tests/test_permissions.py
+++ b/oldp/apps/accounts/tests/test_permissions.py
@@ -332,7 +332,7 @@ class HasTokenPermissionTestCase(TestCase):
         self.assertEqual(permission._get_action("PATCH"), "write")
         self.assertEqual(permission._get_action("DELETE"), "delete")
 
-    # --- Session / non-token auth is deny-by-default for writes (internal-tools #14) ---
+    # --- Session / non-token auth is deny-by-default for writes ---
 
     def test_session_auth_read_allowed(self):
         """Session-authenticated (non-token) GET is allowed."""

--- a/oldp/apps/search/search_backend.py
+++ b/oldp/apps/search/search_backend.py
@@ -113,9 +113,7 @@ class SearchBackend(Elasticsearch7SearchBackend):
             found in the index settings), and because ``SILENTLY_FAIL`` is
             False the live search path raises on the first query. Run
             ``manage.py rebuild_index`` (recreates the index with the new
-            settings) as part of the same rollout window. See
-            ``internal-tools/docs/search/improvements-overview.md`` →
-            "Analyzer rollout".
+            settings) as part of the same rollout window.
         """
         content_field_name, mapping = super().build_schema(fields)
         for field_name in self.GERMAN_TEXT_FIELDS:


### PR DESCRIPTION
## Why

This repository is public. The org's ops and deployment repositories are private, but several docstrings and comments pointed at them by name — issue numbers, a script filename, and a docs path. Those are dead links for anyone outside the org, and they surface internal repo names in a public codebase for no benefit.

## What

Comment/docstring rewrites that keep the same information without the pointer:

| File | Change |
|---|---|
| `api/tests/test_write_authz.py` | Describe the two authorization gaps by what they *are* — "session bypass", "missing staff guard" — instead of by private issue number |
| `accounts/permissions.py` | Keep the explanation of why non-token auth is read-only; drop the trailing issue reference |
| `accounts/tests/test_permissions.py` | Same, in a section header |
| `accounts/management/commands/purge_unverified_users.py` | Drop the pointer to the external wrapper script — the usage examples immediately below already show how to script it |
| `search/search_backend.py` | Keep the analyzer-rollout warning and the `rebuild_index` instruction; drop the internal docs path |

Nothing of engineering value was removed — in a couple of places the prose is now more useful, since it says what the problem was rather than referring to a ticket the reader can't open.

## Scope

- **Comments only.** No behaviour change, no logic touched.
- **Git history is deliberately left alone.** This only changes what a reader of the current source sees.
- A repo-wide grep for the private repo names now returns nothing.

Suites for the touched apps green (**406 tests**), `ruff` clean.